### PR TITLE
Remove deprecated last qualifying sensor reference

### DIFF
--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -68,7 +68,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         "weather": (F1WeatherSensor, data["race_coordinator"]),
         "last_race_results": (F1LastRaceSensor, data["last_race_coordinator"]),
         "season_results": (F1SeasonResultsSensor, data["season_results_coordinator"]),
-        # "last_qualifying": (F1LastQualifyingSensor, data["last_qualifying_coordinator"]),
         "race_week": (F1RaceWeekSensor, data["race_coordinator"]),
     }
 


### PR DESCRIPTION
## Summary
- remove leftover comment for the old `last_qualifying` sensor

## Testing
- `python -m py_compile custom_components/f1_sensor/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6845648c3c308322a2f375a1598c7aab