### PR TITLE
Implement shared session and binary_sensor platform

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -1,12 +1,11 @@
 import logging
 from datetime import timedelta
-import aiohttp
 import async_timeout
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     DOMAIN,
@@ -63,18 +62,12 @@ class F1DataCoordinator(DataUpdateCoordinator):
             name=name,
             update_interval=timedelta(hours=1),
         )
-        self._session = aiohttp.ClientSession()
+        self._session = async_get_clientsession(hass)
         self._url = url
-        self._unsub_close = hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_CLOSE, self.async_close
-        )
 
     async def async_close(self, *_):
-        """Close the aiohttp session."""
-        if self._unsub_close:
-            self._unsub_close()
-            self._unsub_close = None
-        await self._session.close()
+        """Placeholder for future cleanup."""
+        return
 
     async def _async_update_data(self):
         """Fetch data from the F1 API."""
@@ -86,3 +79,4 @@ class F1DataCoordinator(DataUpdateCoordinator):
                     return await response.json()
         except Exception as err:
             raise UpdateFailed(f"Error fetching data: {err}") from err
+

--- a/custom_components/f1_sensor/binary_sensor.py
+++ b/custom_components/f1_sensor/binary_sensor.py
@@ -1,0 +1,83 @@
+from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+import datetime
+
+from .const import DOMAIN
+from .entity import F1BaseEntity
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    data = hass.data[DOMAIN][entry.entry_id]
+    base = entry.data.get("sensor_name", "F1")
+    enabled = entry.data.get("enabled_sensors", [])
+
+    sensors = []
+    if "race_week" in enabled:
+        sensors.append(
+            F1RaceWeekSensor(
+                data["race_coordinator"],
+                f"{base}_race_week",
+                f"{entry.entry_id}_race_week",
+                entry.entry_id,
+                base,
+            )
+        )
+    async_add_entities(sensors, True)
+
+
+class F1RaceWeekSensor(F1BaseEntity, BinarySensorEntity):
+    """Binary sensor indicating if it's currently race week."""
+
+    def __init__(self, coordinator, name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, name, unique_id, entry_id, device_name)
+        self._attr_icon = "mdi:calendar-range"
+        self._attr_device_class = BinarySensorDeviceClass.OCCUPANCY
+
+    def _get_next_race(self):
+        data = self.coordinator.data
+        if not data:
+            return None, None
+
+        races = data.get("MRData", {}).get("RaceTable", {}).get("Races", [])
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        for race in races:
+            date = race.get("date")
+            time = race.get("time") or "00:00:00Z"
+            dt_str = f"{date}T{time}".replace("Z", "+00:00")
+            try:
+                dt = datetime.datetime.fromisoformat(dt_str)
+            except ValueError:
+                continue
+            if dt > now:
+                return dt, race
+        return None, None
+
+    @property
+    def is_on(self):
+        next_race_dt, _ = self._get_next_race()
+        if not next_race_dt:
+            return False
+        now = datetime.datetime.now(datetime.timezone.utc)
+        start_of_week = now - datetime.timedelta(days=now.weekday())
+        end_of_week = start_of_week + datetime.timedelta(days=6, hours=23, minutes=59, seconds=59)
+        return start_of_week.date() <= next_race_dt.date() <= end_of_week.date()
+
+    @property
+    def state(self):
+        return self.is_on
+
+    @property
+    def extra_state_attributes(self):
+        next_race_dt, race = self._get_next_race()
+        now = datetime.datetime.now(datetime.timezone.utc)
+        days = None
+        race_name = None
+        if next_race_dt:
+            delta = next_race_dt.date() - now.date()
+            days = delta.days
+            race_name = race.get("raceName") if race else None
+        return {
+            "days_until_next_race": days,
+            "next_race_name": race_name,
+        }

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -1,5 +1,5 @@
 DOMAIN = "f1_sensor"
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "binary_sensor"]
 
 API_URL = "https://api.jolpi.ca/ergast/f1/current.json"
 DRIVER_STANDINGS_URL = "https://api.jolpi.ca/ergast/f1/current/driverstandings.json"

--- a/custom_components/f1_sensor/entity.py
+++ b/custom_components/f1_sensor/entity.py
@@ -1,0 +1,23 @@
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+class F1BaseEntity(CoordinatorEntity):
+    """Common base entity for F1 sensors."""
+
+    def __init__(self, coordinator, name, unique_id, entry_id, device_name):
+        super().__init__(coordinator)
+        self._attr_name = name
+        self._attr_unique_id = unique_id
+        self._entry_id = entry_id
+        self._device_name = device_name
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._entry_id)},
+            "name": self._device_name,
+            "manufacturer": "Jolpica",
+            "model": "F1 Sensor",
+        }
+

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -1,9 +1,9 @@
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
-from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from .entity import F1BaseEntity
 import async_timeout
 import datetime
 
@@ -68,24 +68,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         "weather": (F1WeatherSensor, data["race_coordinator"]),
         "last_race_results": (F1LastRaceSensor, data["last_race_coordinator"]),
         "season_results": (F1SeasonResultsSensor, data["season_results_coordinator"]),
-        "race_week": (F1RaceWeekSensor, data["race_coordinator"]),
     }
 
     sensors = []
     for key in enabled:
         cls, coord = mapping.get(key, (None, None))
         if cls and coord:
-            sensors.append(cls(coord, f"{base}_{key}"))
+            sensors.append(
+                cls(
+                    coord,
+                    f"{base}_{key}",
+                    f"{entry.entry_id}_{key}",
+                    entry.entry_id,
+                    base,
+                )
+            )
     async_add_entities(sensors, True)
 
 
-class F1NextRaceSensor(CoordinatorEntity, SensorEntity):
+class F1NextRaceSensor(F1BaseEntity, SensorEntity):
     """Sensor that returns date/time (ISO8601) for the next race in 'state'."""
 
-    def __init__(self, coordinator, sensor_name):
-        super().__init__(coordinator)
-        self._attr_name = sensor_name
-        self._attr_unique_id = f"{sensor_name}_unique"
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
         self._attr_icon = "mdi:flag-checkered"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
 
@@ -168,13 +173,11 @@ class F1NextRaceSensor(CoordinatorEntity, SensorEntity):
         }
 
 
-class F1CurrentSeasonSensor(CoordinatorEntity, SensorEntity):
+class F1CurrentSeasonSensor(F1BaseEntity, SensorEntity):
     """Sensor showing number of races this season."""
 
-    def __init__(self, coordinator, sensor_name):
-        super().__init__(coordinator)
-        self._attr_name = sensor_name
-        self._attr_unique_id = f"{sensor_name}_unique"
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
         self._attr_icon = "mdi:calendar-month"
 
     @property
@@ -192,13 +195,11 @@ class F1CurrentSeasonSensor(CoordinatorEntity, SensorEntity):
         }
 
 
-class F1DriverStandingsSensor(CoordinatorEntity, SensorEntity):
+class F1DriverStandingsSensor(F1BaseEntity, SensorEntity):
     """Sensor for driver standings."""
 
-    def __init__(self, coordinator, sensor_name):
-        super().__init__(coordinator)
-        self._attr_name = sensor_name
-        self._attr_unique_id = f"{sensor_name}_unique"
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
         self._attr_icon = "mdi:account-multiple-check"
 
     @property
@@ -219,13 +220,11 @@ class F1DriverStandingsSensor(CoordinatorEntity, SensorEntity):
         }
 
 
-class F1ConstructorStandingsSensor(CoordinatorEntity, SensorEntity):
+class F1ConstructorStandingsSensor(F1BaseEntity, SensorEntity):
     """Sensor for constructor standings."""
 
-    def __init__(self, coordinator, sensor_name):
-        super().__init__(coordinator)
-        self._attr_name = sensor_name
-        self._attr_unique_id = f"{sensor_name}_unique"
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
         self._attr_icon = "mdi:factory"
 
     @property
@@ -246,13 +245,11 @@ class F1ConstructorStandingsSensor(CoordinatorEntity, SensorEntity):
         }
 
 
-class F1WeatherSensor(CoordinatorEntity, SensorEntity):
+class F1WeatherSensor(F1BaseEntity, SensorEntity):
     """Sensor for current and race-start weather."""
 
-    def __init__(self, coordinator, sensor_name):
-        super().__init__(coordinator)
-        self._attr_name = sensor_name
-        self._attr_unique_id = f"{sensor_name}_unique"
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
         self._attr_icon = "mdi:weather-partly-cloudy"
         self._current = {}
         self._race = {}
@@ -263,8 +260,40 @@ class F1WeatherSensor(CoordinatorEntity, SensorEntity):
         self.async_on_remove(removal)
         await self._update_weather()
 
+    def _get_next_race(self):
+        data = self.coordinator.data
+        if not data:
+            return None
+
+        races = data.get("MRData", {}).get("RaceTable", {}).get("Races", [])
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        for race in races:
+            date = race.get("date")
+            time = race.get("time") or "00:00:00Z"
+            dt_str = f"{date}T{time}".replace("Z", "+00:00")
+            try:
+                dt = datetime.datetime.fromisoformat(dt_str)
+            except ValueError:
+                continue
+            if dt > now:
+                return race
+        return None
+
+    def _combine_date_time(self, date_str, time_str):
+        if not date_str:
+            return None
+        if not time_str:
+            time_str = "00:00:00Z"
+        dt_str = f"{date_str}T{time_str}".replace("Z", "+00:00")
+        try:
+            dt = datetime.datetime.fromisoformat(dt_str)
+            return dt.isoformat()
+        except ValueError:
+            return None
+
     async def _update_weather(self):
-        race = F1NextRaceSensor(self.coordinator, "")._get_next_race()
+        race = self._get_next_race()
         loc = race.get("Circuit", {}).get("Location", {}) if race else {}
         lat, lon = loc.get("lat"), loc.get("long")
         if lat is None or lon is None:
@@ -290,7 +319,7 @@ class F1WeatherSensor(CoordinatorEntity, SensorEntity):
             .get("symbol_code")
         current_icon = SYMBOL_CODE_TO_MDI.get(current_symbol, self._attr_icon)
         self._attr_icon = current_icon
-        start_iso = F1NextRaceSensor(self.coordinator, "").combine_date_time(race.get("date"), race.get("time")) if race else None
+        start_iso = self._combine_date_time(race.get("date"), race.get("time")) if race else None
         self._race = {k: None for k in self._current}
         if start_iso:
             start_dt = datetime.datetime.fromisoformat(start_iso)
@@ -351,13 +380,11 @@ class F1WeatherSensor(CoordinatorEntity, SensorEntity):
         return attrs
 
 
-class F1LastRaceSensor(CoordinatorEntity, SensorEntity):
+class F1LastRaceSensor(F1BaseEntity, SensorEntity):
     """Sensor for results of the latest race."""
 
-    def __init__(self, coordinator, sensor_name):
-        super().__init__(coordinator)
-        self._attr_name = sensor_name
-        self._attr_unique_id = f"{sensor_name}_unique"
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
         self._attr_icon = "mdi:trophy"
 
     @property
@@ -402,13 +429,11 @@ class F1LastRaceSensor(CoordinatorEntity, SensorEntity):
         }
 
 
-class F1SeasonResultsSensor(CoordinatorEntity, SensorEntity):
+class F1SeasonResultsSensor(F1BaseEntity, SensorEntity):
     """Sensor for entire season's results."""
 
-    def __init__(self, coordinator, sensor_name):
-        super().__init__(coordinator)
-        self._attr_name = sensor_name
-        self._attr_unique_id = f"{sensor_name}_unique"
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
         self._attr_icon = "mdi:podium"
 
     @property
@@ -449,63 +474,4 @@ class F1SeasonResultsSensor(CoordinatorEntity, SensorEntity):
         return {"races": cleaned}
 
 
-class F1RaceWeekSensor(CoordinatorEntity, BinarySensorEntity):
-    """Binary sensor that returns True if it's race week, else False. Extra attribute: days until next race."""
-
-    def __init__(self, coordinator, sensor_name):
-        super().__init__(coordinator)
-        self._attr_name = sensor_name
-        self._attr_unique_id = f"{sensor_name}_unique"
-        self._attr_icon = "mdi:calendar-range"
-        self._attr_device_class = BinarySensorDeviceClass.OCCUPANCY
-
-    def _get_next_race(self):
-        data = self.coordinator.data
-        if not data:
-            return None, None
-
-        races = data.get("MRData", {}).get("RaceTable", {}).get("Races", [])
-        now = datetime.datetime.now(datetime.timezone.utc)
-
-        for race in races:
-            date = race.get("date")
-            time = race.get("time") or "00:00:00Z"
-            dt_str = f"{date}T{time}".replace("Z", "+00:00")
-            try:
-                dt = datetime.datetime.fromisoformat(dt_str)
-            except ValueError:
-                continue
-            if dt > now:
-                return dt, race
-        return None, None
-
-    @property
-    def is_on(self):
-        next_race_dt, _ = self._get_next_race()
-        if not next_race_dt:
-            return False
-        now = datetime.datetime.now(datetime.timezone.utc)
-        start_of_week = now - datetime.timedelta(days=now.weekday())
-        end_of_week = start_of_week + datetime.timedelta(days=6, hours=23, minutes=59, seconds=59)
-        return start_of_week.date() <= next_race_dt.date() <= end_of_week.date()
-
-    @property
-    def state(self):
-        # For compatibility, state returns True/False (not "on"/"off")
-        return self.is_on
-
-    @property
-    def extra_state_attributes(self):
-        next_race_dt, race = self._get_next_race()
-        now = datetime.datetime.now(datetime.timezone.utc)
-        days = None
-        race_name = None
-        if next_race_dt:
-            delta = next_race_dt.date() - now.date()
-            days = delta.days
-            race_name = race.get("raceName") if race else None
-        return {
-            "days_until_next_race": days,
-            "next_race_name": race_name
-        }
 

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -1,0 +1,51 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "F1 Sensor setup",
+        "data": {
+          "sensor_name": "Device name",
+          "enabled_sensors": "Enabled sensors"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure F1 Sensor",
+        "data": {
+          "sensor_name": "Device name",
+          "enabled_sensors": "Enabled sensors"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "next_race": {
+        "name": "Next race"
+      },
+      "current_season": {
+        "name": "Current season"
+      },
+      "driver_standings": {
+        "name": "Driver standings"
+      },
+      "constructor_standings": {
+        "name": "Constructor standings"
+      },
+      "weather": {
+        "name": "Weather"
+      },
+      "last_race_results": {
+        "name": "Last race results"
+      },
+      "season_results": {
+        "name": "Season results"
+      }
+    },
+    "binary_sensor": {
+      "race_week": {
+        "name": "Race week"
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- use `async_get_clientsession` for HTTP requests
- expose `binary_sensor` platform and move race week sensor
- provide stable unique_id and device info via new base entity
- add translations scaffolding

## Testing
- `python -m py_compile custom_components/f1_sensor/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684593e334588322b1357b68c6b1541a