### PR TITLE
Add timezone conversion to next race sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a custom integration for Home Assistant that creates sensors using data 
 > If your goal is to visually display upcoming race information, current standings, and more in your Home Assistant dashboard, the [FormulaOne Card](https://github.com/marcokreeft87/formulaone-card) is the better choice for that purpose.
 
 This integration **does not provide any UI components**. Instead, it creates:
-- `sensor.f1_next_race` — Attributes include detailed information about the next race, such as when and where it takes place.
+- `sensor.f1_next_race` — Attributes include detailed information about the next race, such as when and where it takes place. All start times are provided both in UTC and converted to the circuit's local timezone.
 - `sensor.f1_season_calendar` — A list of all races in the current F1 season.
 - `sensor.f1_driver_standings` — Current driver championship standings.
 - `sensor.f1_constructor_standings` — Current constructor championship standings.
@@ -22,6 +22,8 @@ This integration **does not provide any UI components**. Instead, it creates:
 - `sensor.f1_last_race_results`: Results from the most recent Formula 1 race.
 - `sensor.f1_season_results`: All race results for the ongoing season.
 - `binary_sensor.f1_race_week`: A native binary sensor that returns `on` if it's currently race week.
+
+Each timestamp attribute (e.g. `race_start`) is still provided in UTC. In addition, a `_local` variant such as `race_start_local` is available. These values use the circuit's timezone so you can easily create automations at the correct local time.
 
 
 During installation, you can choose exactly which sensors you want to include in your setup.  
@@ -135,7 +137,7 @@ data:
   entity_id: media_player.living_room_speaker
   message: >
     {% set next_race = state_attr('sensor.f1_next_race', 'race_name') %}
-    {% set race_date = as_datetime(state_attr('sensor.f1_next_race', 'race_start')) %}
+    {% set race_date = as_datetime(state_attr('sensor.f1_next_race', 'race_start_local')) %}
     {% set race_location = state_attr('sensor.f1_next_race', 'circuit_locality') %}
     {% set race_country = state_attr('sensor.f1_next_race', 'circuit_country') %}
     {% set days_left = (race_date.date() - now().date()).days %}
@@ -164,7 +166,7 @@ data:
     {% set race = state_attr('sensor.f1_next_race', 'race_name') %}
     {% set city = state_attr('sensor.f1_next_race', 'circuit_locality') %}
     {% set country = state_attr('sensor.f1_next_race', 'circuit_country') %}
-    {% set race_time = as_datetime(state_attr('sensor.f1_next_race', 'race_start')) %}
+    {% set race_time = as_datetime(state_attr('sensor.f1_next_race', 'race_start_local')) %}
     {% set days = (race_time.date() - now().date()).days %}
     {% set drivers = state_attr('sensor.f1_driver_standings', 'driver_standings') %}
     {% set constructors = state_attr('sensor.f1_constructor_standings', 'constructor_standings') %}

--- a/custom_components/f1_sensor/manifest.json
+++ b/custom_components/f1_sensor/manifest.json
@@ -6,5 +6,8 @@
     "documentation": "https://github.com/Nicxe/f1_sensor",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Nicxe/f1_sensor/issues",
+    "requirements": [
+        "timezonefinder==6.5.9"
+    ],
     "version": "1.0.0"
-  }
+}

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -6,6 +6,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .entity import F1BaseEntity
 import async_timeout
 import datetime
+from timezonefinder import TimezoneFinder
+from zoneinfo import ZoneInfo
 
 
 from .const import DOMAIN
@@ -93,6 +95,13 @@ class F1NextRaceSensor(F1BaseEntity, SensorEntity):
         super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
         self._attr_icon = "mdi:flag-checkered"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._tf = None
+
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        # TimezoneFinder loads binary data from disk which blocks, so load it
+        # in the executor thread to avoid blocking the event loop.
+        self._tf = await self.hass.async_add_executor_job(TimezoneFinder)
 
     def _get_next_race(self):
         data = self.coordinator.data
@@ -126,6 +135,23 @@ class F1NextRaceSensor(F1BaseEntity, SensorEntity):
         except ValueError:
             return None
 
+    def _timezone_from_location(self, lat, lon):
+        if lat is None or lon is None or self._tf is None:
+            return None
+        try:
+            return self._tf.timezone_at(lat=float(lat), lng=float(lon))
+        except Exception:
+            return None
+
+    def _to_local(self, iso_ts, timezone):
+        if not iso_ts or not timezone:
+            return None
+        try:
+            dt = datetime.datetime.fromisoformat(iso_ts)
+            return dt.astimezone(ZoneInfo(timezone)).isoformat()
+        except Exception:
+            return None
+
     @property
     def state(self):
         next_race = self._get_next_race()
@@ -141,6 +167,7 @@ class F1NextRaceSensor(F1BaseEntity, SensorEntity):
 
         circuit = race.get("Circuit", {})
         loc = circuit.get("Location", {})
+        timezone = self._timezone_from_location(loc.get("lat"), loc.get("long"))
 
         first_practice = race.get("FirstPractice", {})
         second_practice = race.get("SecondPractice", {})
@@ -148,6 +175,14 @@ class F1NextRaceSensor(F1BaseEntity, SensorEntity):
         qualifying = race.get("Qualifying", {})
         sprint_qualifying = race.get("SprintQualifying", {})
         sprint = race.get("Sprint", {})
+
+        race_start = self.combine_date_time(race.get("date"), race.get("time"))
+        first_start = self.combine_date_time(first_practice.get("date"), first_practice.get("time"))
+        second_start = self.combine_date_time(second_practice.get("date"), second_practice.get("time"))
+        third_start = self.combine_date_time(third_practice.get("date"), third_practice.get("time"))
+        qual_start = self.combine_date_time(qualifying.get("date"), qualifying.get("time"))
+        sprint_quali_start = self.combine_date_time(sprint_qualifying.get("date"), sprint_qualifying.get("time"))
+        sprint_start = self.combine_date_time(sprint.get("date"), sprint.get("time"))
 
         return {
             "season": race.get("season"),
@@ -162,14 +197,22 @@ class F1NextRaceSensor(F1BaseEntity, SensorEntity):
             "circuit_long": loc.get("long"),
             "circuit_locality": loc.get("locality"),
             "circuit_country": loc.get("country"),
+            "circuit_timezone": timezone,
 
-            "race_start": self.combine_date_time(race.get("date"), race.get("time")),
-            "first_practice_start": self.combine_date_time(first_practice.get("date"), first_practice.get("time")),
-            "second_practice_start": self.combine_date_time(second_practice.get("date"), second_practice.get("time")),
-            "third_practice_start": self.combine_date_time(third_practice.get("date"), third_practice.get("time")),
-            "qualifying_start": self.combine_date_time(qualifying.get("date"), qualifying.get("time")),
-            "sprint_qualifying_start": self.combine_date_time(sprint_qualifying.get("date"), sprint_qualifying.get("time")),
-            "sprint_start": self.combine_date_time(sprint.get("date"), sprint.get("time")),
+            "race_start": race_start,
+            "race_start_local": self._to_local(race_start, timezone),
+            "first_practice_start": first_start,
+            "first_practice_start_local": self._to_local(first_start, timezone),
+            "second_practice_start": second_start,
+            "second_practice_start_local": self._to_local(second_start, timezone),
+            "third_practice_start": third_start,
+            "third_practice_start_local": self._to_local(third_start, timezone),
+            "qualifying_start": qual_start,
+            "qualifying_start_local": self._to_local(qual_start, timezone),
+            "sprint_qualifying_start": sprint_quali_start,
+            "sprint_qualifying_start_local": self._to_local(sprint_quali_start, timezone),
+            "sprint_start": sprint_start,
+            "sprint_start_local": self._to_local(sprint_start, timezone),
         }
 
 


### PR DESCRIPTION
## Summary
- require `timezonefinder`
- add helper for timezone detection in `F1NextRaceSensor`
- expose local time attributes for race sessions
- document the new attributes and example usage
- clarify that UTC attributes remain alongside local ones
- fix manifest key ordering
- load `TimezoneFinder` asynchronously to avoid blocking

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install timezonefinder==6.5.9`
- `pip install async_timeout`
- `python custom_components/f1_sensor/sensor.py` *(failed: `No module named 'homeassistant'`)*

------
https://chatgpt.com/codex/tasks/task_e_684d96609e448322b2f83cbed825cd9f