### PR TITLE
Update timezonefinder requirement to 5.2.0

### DIFF
--- a/custom_components/f1_sensor/manifest.json
+++ b/custom_components/f1_sensor/manifest.json
@@ -7,7 +7,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Nicxe/f1_sensor/issues",
     "requirements": [
-        "timezonefinder==6.5.9"
+        "timezonefinder==5.2.0"
     ],
     "version": "1.1.0"
 }


### PR DESCRIPTION
## Summary
- use `timezonefinder==5.2.0` to avoid CMake-dependent `h3`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff8aa9fe8832290b8f0c8e3af6924