### PR TITLE
Add race control sensors

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -1,5 +1,7 @@
 import logging
-from datetime import timedelta
+from datetime import timedelta, datetime, timezone
+import json
+import urllib.parse
 import async_timeout
 
 from homeassistant.config_entries import ConfigEntry
@@ -33,12 +35,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await last_race_coordinator.async_config_entry_first_refresh()
     await season_results_coordinator.async_config_entry_first_refresh()
 
+    enabled = entry.data.get("enabled_sensors", [])
+    race_control_coordinator = None
+    if "flag_status" in enabled or "safety_car" in enabled:
+        race_control_coordinator = RaceControlCoordinator(hass, race_coordinator)
+        await race_control_coordinator.async_config_entry_first_refresh()
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "race_coordinator": race_coordinator,
         "driver_coordinator": driver_coordinator,
         "constructor_coordinator": constructor_coordinator,
         "last_race_coordinator": last_race_coordinator,
         "season_results_coordinator": season_results_coordinator,
+        "race_control_coordinator": race_control_coordinator,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -49,7 +58,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         data = hass.data[DOMAIN].pop(entry.entry_id)
         for coordinator in data.values():
-            await coordinator.async_close()
+            if coordinator:
+                await coordinator.async_close()
     return unload_ok
 
 class F1DataCoordinator(DataUpdateCoordinator):
@@ -79,4 +89,154 @@ class F1DataCoordinator(DataUpdateCoordinator):
                     return await response.json()
         except Exception as err:
             raise UpdateFailed(f"Error fetching data: {err}") from err
+
+
+class RaceControlCoordinator(DataUpdateCoordinator):
+    """Coordinator for F1 race control messages."""
+
+    def __init__(self, hass: HomeAssistant, race_coordinator: F1DataCoordinator):
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="F1 Race Control Coordinator",
+            update_interval=timedelta(seconds=5),
+        )
+        self._session = async_get_clientsession(hass)
+        self._race_coordinator = race_coordinator
+        self._yellow_sectors: set[str] = set()
+        self._sc_active = False
+        self._vsc_active = False
+        self._red_flag = False
+        self._finished = False
+        self._last = {"flag_status": None, "sc_active": False}
+
+    async def async_close(self, *_):
+        return
+
+    def _combine_dt(self, date: str | None, time: str | None) -> datetime | None:
+        if not date:
+            return None
+        if not time:
+            time = "00:00:00Z"
+        try:
+            return datetime.fromisoformat(f"{date}T{time}".replace("Z", "+00:00"))
+        except ValueError:
+            return None
+
+    def _current_session(self):
+        data = self._race_coordinator.data or {}
+        races = data.get("MRData", {}).get("RaceTable", {}).get("Races", [])
+        now = datetime.now(timezone.utc)
+        for race in races:
+            race_dt = self._combine_dt(race.get("date"), race.get("time"))
+            qual = race.get("Qualifying", {})
+            qual_dt = self._combine_dt(qual.get("date"), qual.get("time"))
+            if race_dt and race_dt - timedelta(minutes=30) <= now <= race_dt + timedelta(hours=3):
+                return race, "Race", race_dt
+            if qual_dt and qual_dt - timedelta(minutes=30) <= now <= qual_dt + timedelta(hours=2):
+                return race, "Qualifying", qual_dt
+        return None, None, None
+
+    def _build_url(self, race: dict, session_name: str) -> str:
+        year = race.get("season")
+        event = urllib.parse.quote(race.get("raceName", "").replace(" ", "_"))
+        event_path = f"{race.get('date')}_{event}"
+        if session_name == "Race":
+            session_date = race.get("date")
+        else:
+            session_date = race.get("Qualifying", {}).get("date")
+        session_path = f"{session_date}_{session_name}"
+        return (
+            f"https://livetiming.formula1.com/static/{year}/{event_path}/{session_path}/RaceControlMessages.jsonStream"
+        )
+
+    def _handle_message(self, msg: dict):
+        flag = str(msg.get("Flag", "")).upper()
+        status = str(msg.get("Status", "")).upper()
+        text = str(msg.get("Message", "")).upper()
+        scope = msg.get("Scope")
+        sector = msg.get("Sector")
+
+        if flag in ("YELLOW", "DOUBLE YELLOW"):
+            if scope == "Sector" and sector is not None:
+                self._yellow_sectors.add(str(sector))
+            else:
+                self._yellow_sectors.add("track")
+        elif flag in ("GREEN", "CLEAR"):
+            if scope == "Sector" and sector is not None:
+                self._yellow_sectors.discard(str(sector))
+            else:
+                self._yellow_sectors.clear()
+                self._red_flag = False
+        if flag == "RED":
+            self._red_flag = True
+
+        if "VIRTUAL SAFETY CAR" in text or status.startswith("VSC"):
+            if "END" in text or "ENDING" in text or status.endswith("ENDING") or status.endswith("WITHDRAWN"):
+                self._vsc_active = False
+            elif "DEPLOYED" in text or "DEPLOYED" in status:
+                self._vsc_active = True
+
+        if "SAFETY CAR" in text and "VIRTUAL" not in text:
+            if "END" in text or "IN THIS LAP" in text or "ENDING" in text or status.endswith("ENDING"):
+                self._sc_active = False
+            elif "DEPLOYED" in text or status.endswith("DEPLOYED"):
+                self._sc_active = True
+
+        if "CHEQUERED" in text or "SESSION FINISHED" in text:
+            self._finished = True
+
+    def _derive(self):
+        if self._red_flag:
+            return "RED"
+        if self._sc_active:
+            return "SC"
+        if self._vsc_active:
+            return "VSC"
+        if self._yellow_sectors:
+            return "YELLOW"
+        return "GREEN"
+
+    async def _async_update_data(self):
+        race, session_name, _ = self._current_session()
+        if not race or not session_name or self._finished:
+            return self._last
+
+        url = self._build_url(race, session_name)
+        try:
+            async with async_timeout.timeout(10):
+                resp = await self._session.get(url)
+                if resp.status == 404:
+                    return self._last
+                if resp.status != 200:
+                    raise UpdateFailed(f"Race control fetch failed: {resp.status}")
+                text = await resp.text()
+        except Exception as err:
+            raise UpdateFailed(f"Error fetching race control data: {err}") from err
+
+        for line in text.splitlines():
+            if not line:
+                continue
+            line = line.lstrip("\ufeff")
+            json_start = line.find("{")
+            if json_start == -1:
+                continue
+            try:
+                data = json.loads(line[json_start:])
+            except Exception:
+                continue
+            msgs = data.get("Messages")
+            if isinstance(msgs, dict):
+                iterable = msgs.values()
+            else:
+                iterable = msgs or []
+            for msg in iterable:
+                self._handle_message(msg)
+
+        self._last = {
+            "flag_status": self._derive(),
+            "sc_active": self._sc_active or self._vsc_active,
+        }
+        return self._last
+
 

--- a/custom_components/f1_sensor/binary_sensor.py
+++ b/custom_components/f1_sensor/binary_sensor.py
@@ -22,6 +22,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 base,
             )
         )
+    if "safety_car" in enabled and data.get("race_control_coordinator"):
+        sensors.append(
+            F1SafetyCarSensor(
+                data["race_control_coordinator"],
+                f"{base}_safety_car",
+                f"{entry.entry_id}_safety_car",
+                entry.entry_id,
+                base,
+            )
+        )
     async_add_entities(sensors, True)
 
 
@@ -81,3 +91,20 @@ class F1RaceWeekSensor(F1BaseEntity, BinarySensorEntity):
             "days_until_next_race": days,
             "next_race_name": race_name,
         }
+
+
+class F1SafetyCarSensor(F1BaseEntity, BinarySensorEntity):
+    """Binary sensor indicating if Safety Car or VSC is active."""
+
+    def __init__(self, coordinator, name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, name, unique_id, entry_id, device_name)
+        self._attr_icon = "mdi:car"
+        self._attr_device_class = BinarySensorDeviceClass.SAFETY
+
+    @property
+    def is_on(self):
+        return (self.coordinator.data or {}).get("sc_active")
+
+    @property
+    def state(self):
+        return self.is_on

--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -29,6 +29,8 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     "last_race_results",
                     "season_results",
                     "race_week",
+                    "flag_status",
+                    "safety_car",
                 ]
             ): cv.multi_select({
                 "next_race": "Next race",
@@ -39,6 +41,8 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 "last_race_results": "Last race results",
                 "season_results": "Season results",
                 "race_week": "Race week",
+                "flag_status": "Flag status",
+                "safety_car": "Safety car",
             }),
         })
 
@@ -73,6 +77,8 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     "last_race_results",
                     "season_results",
                     "race_week",
+                    "flag_status",
+                    "safety_car",
                 ])
             ): cv.multi_select({
                 "next_race": "Next race",
@@ -83,6 +89,8 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 "last_race_results": "Last race results",
                 "season_results": "Season results",
                 "race_week": "Race week",
+                "flag_status": "Flag status",
+                "safety_car": "Safety car",
             }),
         })
 

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -70,6 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         "weather": (F1WeatherSensor, data["race_coordinator"]),
         "last_race_results": (F1LastRaceSensor, data["last_race_coordinator"]),
         "season_results": (F1SeasonResultsSensor, data["season_results_coordinator"]),
+        "flag_status": (F1FlagStatusSensor, data.get("race_control_coordinator")),
     }
 
     sensors = []
@@ -513,6 +514,18 @@ class F1SeasonResultsSensor(F1BaseEntity, SensorEntity):
                 "results": results
             })
         return {"races": cleaned}
+
+
+class F1FlagStatusSensor(F1BaseEntity, SensorEntity):
+    """Sensor showing current track flag status."""
+
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
+        self._attr_icon = "mdi:flag"
+
+    @property
+    def state(self):
+        return (self.coordinator.data or {}).get("flag_status")
 
 
 

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -39,11 +39,17 @@
       },
       "season_results": {
         "name": "Season results"
+      },
+      "flag_status": {
+        "name": "Flag status"
       }
     },
     "binary_sensor": {
       "race_week": {
         "name": "Race week"
+      },
+      "safety_car": {
+        "name": "Safety car"
       }
     }
   }


### PR DESCRIPTION
## Summary
- add RaceControlCoordinator for live flag and safety car state
- add new Flag Status sensor and Safety Car binary sensor
- wire up coordinator and sensors in setup and config flow
- update translations for new entities

## Testing
- `python -m py_compile custom_components/f1_sensor/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68583c7cfd208322bc9122c8f516dde5