### PR TITLE
Improve race control sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This integration **does not provide any UI components**. Instead, it creates:
 - `sensor.f1_last_race_results`: Results from the most recent Formula 1 race.
 - `sensor.f1_season_results`: All race results for the ongoing season.
 - `binary_sensor.f1_race_week`: A native binary sensor that returns `on` if it's currently race week.
+- `sensor.f1_flag_status`: Current track flag. Attributes include `yellow_sectors` and `vsc_active`.
+- `binary_sensor.f1_safety_car`: Indicates if the safety car or virtual safety car is active.
 
 Each timestamp attribute (e.g. `race_start`) is still provided in UTC. In addition, a `_local` variant such as `race_start_local` is available. These values use the circuit's timezone so you can easily create automations at the correct local time.
 

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -527,5 +527,15 @@ class F1FlagStatusSensor(F1BaseEntity, SensorEntity):
     def state(self):
         return (self.coordinator.data or {}).get("flag_status")
 
+    @property
+    def extra_state_attributes(self):
+        data = self.coordinator.data or {}
+        attrs = {
+            "vsc_active": data.get("vsc_active"),
+        }
+        if data.get("yellow_sectors"):
+            attrs["yellow_sectors"] = data.get("yellow_sectors")
+        return attrs
+
 
 


### PR DESCRIPTION
## Summary
- reuse shared aiohttp session in race control helpers
- expose detailed flag info
- reset state when session ends
- document new sensors in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858f4e543ac832297603263c6d5c918