### PR TITLE
Enable SignalR live updates with polling fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Resolve race control stream URL from official index files for improved reliability.
 - Poll using HTTP range requests, reducing bandwidth usage by about 90%.
 - Session detection now uses real-time status across all meetings and includes TrackStatus feed for accurate flags.
+- SignalR live-feed + fallback.

--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -2,6 +2,8 @@ import logging
 from datetime import timedelta
 import async_timeout
 
+__version__ = "1.2.0"
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -50,6 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         from .race_control_coordinator import RaceControlCoordinator
 
         race_control_coordinator = RaceControlCoordinator(hass, race_coordinator)
+        await race_control_coordinator.async_setup_entry()
         await race_control_coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {

--- a/custom_components/f1_sensor/manifest.json
+++ b/custom_components/f1_sensor/manifest.json
@@ -7,7 +7,8 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Nicxe/f1_sensor/issues",
     "requirements": [
-        "timezonefinder==5.2.0"
+        "timezonefinder==5.2.0",
+        "signalrcore-async==0.11.0"
     ],
-    "version": "1.1.1"
+    "version": "1.2.0"
 }

--- a/custom_components/f1_sensor/signalr_client.py
+++ b/custom_components/f1_sensor/signalr_client.py
@@ -1,0 +1,111 @@
+import asyncio
+import json
+import logging
+from typing import Awaitable, Callable, Dict
+from urllib.parse import urlencode, quote_plus
+
+import aiohttp
+from signalrcore.async_signalr_core import HubConnectionBuilder
+
+LOGGER = logging.getLogger(__name__)
+
+
+class F1SignalRClient:
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        callback: Callable[[str, Dict], Awaitable[None]],
+    ) -> None:
+        self._session = session
+        self._callback = callback
+        self._hub = None
+        self.connected = False
+        self.failed = False
+        self._stopped = False
+        self._attempts = 0
+        self.on_open: Callable[[], Awaitable[None]] | None = None
+        self.on_close: Callable[[], Awaitable[None]] | None = None
+
+    async def start(self) -> None:
+        self._stopped = False
+        self.failed = False
+        self._attempts = 0
+        await self._connect()
+
+    async def stop(self) -> None:
+        self._stopped = True
+        if self._hub:
+            await self._hub.stop()
+            self._hub = None
+        self.connected = False
+
+    async def _connect(self) -> None:
+        while not self._stopped:
+            try:
+                await self._start_once()
+                return
+            except Exception as err:  # pragma: no cover - network errors
+                LOGGER.warning("SignalR connect failed: %s", err)
+                self._attempts += 1
+                if self._attempts >= 3:
+                    self.failed = True
+                    if self.on_close:
+                        await self.on_close()
+                    return
+                await asyncio.sleep(min(2**self._attempts, 30))
+
+    async def _start_once(self) -> None:
+        url = "https://livetiming.formula1.com/signalr/negotiate?clientProtocol=1.5"
+        async with self._session.get(url) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+            token = data.get("ConnectionToken")
+            cookie = resp.headers.get("Set-Cookie", "")
+        params = {
+            "transport": "webSockets",
+            "clientProtocol": "1.5",
+            "connectionToken": token,
+            "connectionData": json.dumps([{"name": "streaming"}]),
+        }
+        ws_url = "wss://livetiming.formula1.com/signalr/connect?" + urlencode(
+            params, quote_via=quote_plus
+        )
+        builder = HubConnectionBuilder()
+        self._hub = builder.with_url(
+            ws_url, options={"headers": {"Cookie": cookie}}
+        ).build()
+        self._hub.on_open(lambda: asyncio.create_task(self._on_open()))
+        self._hub.on_close(lambda: asyncio.create_task(self._on_close()))
+        for topic in [
+            "TrackStatus",
+            "RaceControlMessages",
+            "SessionStatus",
+            "Heartbeat",
+        ]:
+            self._hub.on(
+                topic,
+                lambda args, t=topic: asyncio.create_task(
+                    self._callback(t, args[0] if args else {})
+                ),
+            )
+        await self._hub.start()
+
+    async def _on_open(self) -> None:
+        self.connected = True
+        self._attempts = 0
+        if self.on_open:
+            await self.on_open()
+        if self._hub:
+            self._hub.send(
+                "Streaming",
+                "Subscribe",
+                [["TrackStatus", "RaceControlMessages", "SessionStatus", "Heartbeat"]],
+            )
+
+    async def _on_close(self) -> None:
+        if self.connected:
+            self.connected = False
+            if self.on_close:
+                await self.on_close()
+        if not self._stopped:
+            await self._connect()


### PR DESCRIPTION
## Summary
- add SignalR async client
- integrate SignalR live feed with fallback in race control coordinator
- bump component version and requirements
- document new SignalR support

## Testing
- `black custom_components/f1_sensor/*.py`
- `mypy --strict custom_components/f1_sensor` *(fails: Cannot find Home Assistant stubs)*

------
https://chatgpt.com/codex/tasks/task_e_68590ae177cc8322ba27211a974cd02a