### PR TITLE
Fix missing signalrcore import

### DIFF
--- a/custom_components/f1_sensor/signalr_client.py
+++ b/custom_components/f1_sensor/signalr_client.py
@@ -5,7 +5,7 @@ from typing import Awaitable, Callable, Dict
 from urllib.parse import urlencode, quote_plus
 
 import aiohttp
-from signalrcore.async_signalr_core import HubConnectionBuilder
+from signalrcore_async.hub_connection_builder import HubConnectionBuilder
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- fix import path for HubConnectionBuilder

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685914be2bd08322a4c406f281bb9176