### PR TITLE
Fix blocking call in signalr client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Session detection now uses real-time status across all meetings and includes TrackStatus feed for accurate flags.
 - SignalR live-feed + fallback.
 - Fix incorrect signalrcore-async version in manifest.
+- Avoid blocking call in SignalR client by skipping negotiation.

--- a/custom_components/f1_sensor/signalr_client.py
+++ b/custom_components/f1_sensor/signalr_client.py
@@ -71,9 +71,13 @@ class F1SignalRClient:
             params, quote_via=quote_plus
         )
         builder = HubConnectionBuilder()
-        self._hub = builder.with_url(
-            ws_url, options={"headers": {"Cookie": cookie}}
-        ).build()
+        self._hub = (
+            builder.with_url(
+                ws_url,
+                options={"headers": {"Cookie": cookie}, "skip_negotiation": True},
+            )
+            .build()
+        )
         self._hub.on_open(lambda: asyncio.create_task(self._on_open()))
         self._hub.on_close(lambda: asyncio.create_task(self._on_close()))
         for topic in [


### PR DESCRIPTION
## Summary
- skip negotiation when creating SignalR connection to avoid blocking call
- document fix in changelog

## Testing
- `pip install signalrcore-async`
- `python -m hassfest` *(fails: No module named hassfest)*

------
https://chatgpt.com/codex/tasks/task_e_685916fe62a083229cd2ff603bbb5a01