### PR TITLE
Handle async SSL and dispatcher updates

### DIFF
--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -1,6 +1,10 @@
 DOMAIN = "f1_sensor"
 PLATFORMS = ["sensor", "binary_sensor"]
 
+# Dispatcher signals for real-time updates
+SIGNAL_FLAG_UPDATE = "f1sensor_flag_update"
+SIGNAL_SC_UPDATE = "f1sensor_safety_car_update"
+
 API_URL = "https://api.jolpi.ca/ergast/f1/current.json"
 DRIVER_STANDINGS_URL = "https://api.jolpi.ca/ergast/f1/current/driverstandings.json"
 CONSTRUCTOR_STANDINGS_URL = "https://api.jolpi.ca/ergast/f1/current/constructorstandings.json"


### PR DESCRIPTION
## Summary
- avoid blocking load_default_certs by awaiting `get_ssl_context`
- add dispatcher signals for flag and safety car updates
- fire dispatcher events from RaceControlCoordinator
- listen for dispatcher in Flag Status and Safety Car sensors

## Testing
- `python -m py_compile custom_components/f1_sensor/*.py`
- `find custom_components -name "*.py" | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68593a121b908322a94855c39cc70d44