### PR TITLE
Replace SignalR client with aiohttp websocket

### DIFF
--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -5,8 +5,19 @@ PLATFORMS = ["sensor", "binary_sensor"]
 SIGNAL_FLAG_UPDATE = "f1sensor_flag_update"
 SIGNAL_SC_UPDATE = "f1sensor_safety_car_update"
 
+SUBSCRIBE_FEEDS = [
+    "TrackStatus",
+    "RaceControlMessages",
+    "SessionStatus",
+    "Heartbeat",
+]
+
+NEGOTIATE_URL = "https://livetiming.formula1.com/signalr/negotiate"
+
 API_URL = "https://api.jolpi.ca/ergast/f1/current.json"
 DRIVER_STANDINGS_URL = "https://api.jolpi.ca/ergast/f1/current/driverstandings.json"
-CONSTRUCTOR_STANDINGS_URL = "https://api.jolpi.ca/ergast/f1/current/constructorstandings.json"
+CONSTRUCTOR_STANDINGS_URL = (
+    "https://api.jolpi.ca/ergast/f1/current/constructorstandings.json"
+)
 LAST_RACE_RESULTS_URL = "https://api.jolpi.ca/ergast/f1/current/last/results.json"
 SEASON_RESULTS_URL = "https://api.jolpi.ca/ergast/f1/current/results.json?limit=100"

--- a/custom_components/f1_sensor/entity.py
+++ b/custom_components/f1_sensor/entity.py
@@ -2,6 +2,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 
+
 class F1BaseEntity(CoordinatorEntity):
     """Common base entity for F1 sensors."""
 
@@ -11,6 +12,7 @@ class F1BaseEntity(CoordinatorEntity):
         self._attr_unique_id = unique_id
         self._entry_id = entry_id
         self._device_name = device_name
+        self._attr_should_poll = False
 
     @property
     def device_info(self):
@@ -20,4 +22,3 @@ class F1BaseEntity(CoordinatorEntity):
             "manufacturer": "Nicxe",
             "model": "F1 Sensor",
         }
-

--- a/custom_components/f1_sensor/manifest.json
+++ b/custom_components/f1_sensor/manifest.json
@@ -6,10 +6,6 @@
     "documentation": "https://github.com/Nicxe/f1_sensor",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Nicxe/f1_sensor/issues",
-    "requirements": [
-        "timezonefinder==5.2.0",
-        "signalrcore-async==0.5.4",
-        "rx==1.6.1"
-    ],
-    "version": "1.3.0"
+    "requirements": ["timezonefinder==5.2.0"],
+    "version": "1.3.0",
 }

--- a/custom_components/f1_sensor/manifest.json
+++ b/custom_components/f1_sensor/manifest.json
@@ -7,5 +7,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Nicxe/f1_sensor/issues",
     "requirements": ["timezonefinder==5.2.0"],
-    "version": "1.3.0",
+    "version": "1.3.0"
 }


### PR DESCRIPTION
## Summary
- drop signalrcore_async and rx dependencies
- add new websocket client using aiohttp
- expose dispatcher constants for track status feeds
- update RaceControlCoordinator to use dispatcher-based client
- ensure entities do not poll Home Assistant

## Testing
- `python -m compileall -q custom_components/f1_sensor`

------
https://chatgpt.com/codex/tasks/task_e_68595c7d06f083229a8fceea082c48a9