### PR TITLE
Add connection status sensor

### DIFF
--- a/custom_components/f1_sensor/binary_sensor.py
+++ b/custom_components/f1_sensor/binary_sensor.py
@@ -7,7 +7,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import datetime
 
-from .const import DOMAIN, SIGNAL_FLAG_UPDATE, SIGNAL_SC_UPDATE
+from .const import (
+    DOMAIN,
+    SIGNAL_FLAG_UPDATE,
+    SIGNAL_SC_UPDATE,
+    SIGNAL_CONNECTED,
+    SIGNAL_DISCONNECTED,
+)
 from .entity import F1BaseEntity
 from .signalr_client import F1SignalRClient
 
@@ -41,6 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     client = getattr(rc_coord, "_client", None) if rc_coord else None
     if client:
         sensors.append(F1SignalRBinary(client))
+    sensors.append(F1SignalRStatus(hass))
     async_add_entities(sensors, True)
 
 
@@ -153,3 +160,21 @@ class F1SignalRBinary(BinarySensorEntity):
 
     async def async_update(self):
         return
+
+
+class F1SignalRStatus(BinarySensorEntity):
+    _attr_name = "F1 SignalR connected"
+    _attr_icon = "mdi:web"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._attr_is_on = False
+        async_dispatcher_connect(hass, SIGNAL_CONNECTED, self._set_on)
+        async_dispatcher_connect(hass, SIGNAL_DISCONNECTED, self._set_off)
+
+    def _set_on(self) -> None:
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    def _set_off(self) -> None:
+        self._attr_is_on = False
+        self.async_write_ha_state()

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -4,6 +4,8 @@ PLATFORMS = ["sensor", "binary_sensor"]
 # Dispatcher signals for real-time updates
 SIGNAL_FLAG_UPDATE = "f1sensor_flag_update"
 SIGNAL_SC_UPDATE = "f1sensor_safety_car_update"
+SIGNAL_CONNECTED = "f1_signalr_connected"
+SIGNAL_DISCONNECTED = "f1_signalr_disconnected"
 
 SUBSCRIBE_FEEDS = [
     "TrackStatus",

--- a/custom_components/f1_sensor/signalr_client.py
+++ b/custom_components/f1_sensor/signalr_client.py
@@ -19,6 +19,8 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from .const import (
     SIGNAL_FLAG_UPDATE,
     SIGNAL_SC_UPDATE,
+    SIGNAL_CONNECTED,
+    SIGNAL_DISCONNECTED,
     SUBSCRIBE_FEEDS,
     NEGOTIATE_URL,
 )
@@ -168,6 +170,7 @@ class F1SignalRClient:
             try:
                 self._ws = await self._connect_once()
                 self.failed = False
+                async_dispatcher_send(self.hass, SIGNAL_CONNECTED)
                 self._set_connected(True)
                 await self._handshake_and_subscribe()
 
@@ -199,6 +202,7 @@ class F1SignalRClient:
                         await hb_task
                 if self._ws:
                     await self._ws.close()
+                    async_dispatcher_send(self.hass, SIGNAL_DISCONNECTED)
                     self._ws = None
                 await asyncio.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, 300)


### PR DESCRIPTION
## Summary
- add `SIGNAL_CONNECTED` and `SIGNAL_DISCONNECTED`
- dispatch signals on websocket connect/disconnect
- add `F1SignalRStatus` binary sensor and register it

## Testing
- `python3 -m py_compile custom_components/f1_sensor/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685ed815f6f483229b947960c77aee8e