### PR TITLE
Implement three-state flag sensor

### DIFF
--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -4,6 +4,8 @@ PLATFORMS = ["sensor", "binary_sensor"]
 # Dispatcher signals for real-time updates
 SIGNAL_FLAG_UPDATE = "f1sensor_flag_update"
 SIGNAL_SC_UPDATE = "f1sensor_safety_car_update"
+SIGNAL_CONNECTED = "f1sensor_connected"
+SIGNAL_DISCONNECTED = "f1sensor_disconnected"
 
 SUBSCRIBE_FEEDS = [
     "TrackStatus",

--- a/custom_components/f1_sensor/signalr_client.py
+++ b/custom_components/f1_sensor/signalr_client.py
@@ -21,6 +21,8 @@ from .const import (
     SIGNAL_SC_UPDATE,
     SUBSCRIBE_FEEDS,
     NEGOTIATE_URL,
+    SIGNAL_CONNECTED,
+    SIGNAL_DISCONNECTED,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,6 +69,10 @@ class F1SignalRClient:
         if self.connected != value:
             self.connected = value
             async_dispatcher_send(self.hass, "f1_signalr_state")
+            if value:
+                async_dispatcher_send(self.hass, SIGNAL_CONNECTED)
+            else:
+                async_dispatcher_send(self.hass, SIGNAL_DISCONNECTED)
 
     async def _handle_ha_stop(self, _event):
         await self.stop()


### PR DESCRIPTION
## Summary
- add `SIGNAL_CONNECTED` and `SIGNAL_DISCONNECTED` constants
- dispatch these signals from `F1SignalRClient`
- enhance `F1FlagStatusSensor` to track idle and unavailable states

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edc85d1308322a27bb7005309715a