### PR TITLE
Add RaceControl log sensor and debug logging

### DIFF
--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -9,6 +9,7 @@ import async_timeout
 import datetime
 from timezonefinder import TimezoneFinder
 from zoneinfo import ZoneInfo
+import json
 
 
 from .const import (
@@ -93,6 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     base,
                 )
             )
+    sensors.append(RaceControlLogSensor(hass))
     async_add_entities(sensors, True)
 
 
@@ -577,6 +579,27 @@ class F1FlagStatusSensor(F1BaseEntity, SensorEntity):
         if data.get("yellow_sectors"):
             attrs["yellow_sectors"] = data.get("yellow_sectors")
         return attrs
+
+
+class RaceControlLogSensor(SensorEntity):
+    """Visar det råa RaceControlMessages-meddelandet."""
+
+    _attr_name = "F1 Race Control Last"
+    _attr_icon = "mdi:alert-circle-outline"
+    _attr_unique_id = "f1_race_control_last"
+
+    def __init__(self, hass):
+        self._state = ""
+        async_dispatcher_connect(hass, SIGNAL_SC_UPDATE, self._handle_payload)
+
+    def _handle_payload(self, payload: dict):
+        # Spara hela payload som JSON-sträng
+        self._state = json.dumps(payload, ensure_ascii=False)
+        self.async_write_ha_state()
+
+    @property
+    def state(self):
+        return self._state
 
 
 

--- a/custom_components/f1_sensor/signalr_client.py
+++ b/custom_components/f1_sensor/signalr_client.py
@@ -243,6 +243,7 @@ class F1SignalRClient:
             if topic == "TrackStatus":
                 async_dispatcher_send(self.hass, SIGNAL_FLAG_UPDATE, payload)
             elif topic == "RaceControlMessages":
+                _LOGGER.debug("RaceControlMessages raw payload: %s", payload)
                 async_dispatcher_send(self.hass, SIGNAL_SC_UPDATE, payload)
 
     async def _heartbeat(self, ws: ClientWebSocketResponse) -> None:


### PR DESCRIPTION
## Summary
- add debug logging for RaceControlMessages
- provide a `RaceControlLogSensor` to show raw race control messages

## Testing
- `python -m py_compile custom_components/f1_sensor/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685efa1031488322a9856eaf5c1b441d