### PR TITLE
Add F1 race control sensors

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import timedelta
+from datetime import timedelta, datetime, timezone
 import async_timeout
 
 from homeassistant.config_entries import ConfigEntry
@@ -15,7 +15,10 @@ from .const import (
     CONSTRUCTOR_STANDINGS_URL,
     LAST_RACE_RESULTS_URL,
     SEASON_RESULTS_URL,
+    LIVETIMING_INDEX_URL,
+    RACE_CONTROL_URL,
 )
+from .helpers import find_next_session, to_utc, parse_racecontrol
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,12 +29,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     constructor_coordinator = F1DataCoordinator(hass, CONSTRUCTOR_STANDINGS_URL, "F1 Constructor Standings Coordinator")
     last_race_coordinator = F1DataCoordinator(hass, LAST_RACE_RESULTS_URL, "F1 Last Race Results Coordinator")
     season_results_coordinator = F1DataCoordinator(hass, SEASON_RESULTS_URL, "F1 Season Results Coordinator")
+    year = datetime.utcnow().year
+    session_coordinator = LiveSessionCoordinator(hass, year)
+    enable_rc = entry.data.get("enable_race_control", True)
+    fast_seconds = entry.data.get("fast_poll_seconds", 5)
+    race_control_coordinator = None
+    if enable_rc:
+        race_control_coordinator = RaceControlCoordinator(hass, session_coordinator, fast_seconds)
 
     await race_coordinator.async_config_entry_first_refresh()
     await driver_coordinator.async_config_entry_first_refresh()
     await constructor_coordinator.async_config_entry_first_refresh()
     await last_race_coordinator.async_config_entry_first_refresh()
     await season_results_coordinator.async_config_entry_first_refresh()
+    await session_coordinator.async_config_entry_first_refresh()
+    if race_control_coordinator:
+        await race_control_coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "race_coordinator": race_coordinator,
@@ -39,6 +52,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "constructor_coordinator": constructor_coordinator,
         "last_race_coordinator": last_race_coordinator,
         "season_results_coordinator": season_results_coordinator,
+        "session_coordinator": session_coordinator,
+        "race_control_coordinator": race_control_coordinator,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -79,4 +94,102 @@ class F1DataCoordinator(DataUpdateCoordinator):
                     return await response.json()
         except Exception as err:
             raise UpdateFailed(f"Error fetching data: {err}") from err
+
+
+class LiveSessionCoordinator(DataUpdateCoordinator):
+    """Fetch current or next session from the LiveTiming index."""
+
+    def __init__(self, hass: HomeAssistant, year: int):
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="F1 Live Session Coordinator",
+            update_interval=timedelta(hours=1),
+        )
+        self._session = async_get_clientsession(hass)
+        self.year = year
+
+    async def async_close(self, *_):
+        return
+
+    async def _async_update_data(self):
+        url = LIVETIMING_INDEX_URL.format(year=self.year)
+        try:
+            async with async_timeout.timeout(10):
+                async with self._session.get(url) as response:
+                    if response.status in (403, 404):
+                        _LOGGER.warning("Index unavailable: %s", response.status)
+                        return self.data
+                    if response.status != 200:
+                        raise UpdateFailed(f"Error fetching data: {response.status}")
+                    return await response.json()
+        except Exception as err:
+            _LOGGER.warning("Error fetching index: %s", err)
+            return self.data
+
+
+class RaceControlCoordinator(DataUpdateCoordinator):
+    """Coordinator for race control messages."""
+
+    def __init__(self, hass: HomeAssistant, session_coord: LiveSessionCoordinator, fast_seconds: int = 5):
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="F1 Race Control Coordinator",
+            update_interval=timedelta(hours=1),
+        )
+        self._session = async_get_clientsession(hass)
+        self._session_coord = session_coord
+        self._fast = timedelta(seconds=fast_seconds)
+        self.available = True
+        self._last_message = None
+
+    async def async_close(self, *_):
+        return
+
+    def _adjust_interval(self, session):
+        start = to_utc(session.get("StartDate"), session.get("GmtOffset"))
+        end = to_utc(session.get("EndDate"), session.get("GmtOffset"))
+        now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        if start and end and start - timedelta(hours=1) <= now <= end + timedelta(hours=2):
+            if self.update_interval != self._fast:
+                self.update_interval = self._fast
+        elif self._last_message:
+            try:
+                msg_dt = to_utc(self._last_message.get("Utc"), "+00:00")
+            except Exception:
+                msg_dt = None
+            if msg_dt and end and msg_dt > end + timedelta(hours=2):
+                if self.update_interval != timedelta(hours=1):
+                    self.update_interval = timedelta(hours=1)
+
+    async def _async_update_data(self):
+        if not self._session_coord.data:
+            return self._last_message
+        meeting, session = find_next_session(self._session_coord.data)
+        if not session:
+            return self._last_message
+
+        self._adjust_interval(session)
+
+        url = RACE_CONTROL_URL.format(path=session.get("Path"))
+        try:
+            async with async_timeout.timeout(10):
+                async with self._session.get(url) as response:
+                    if response.status in (403, 404):
+                        self.available = False
+                        _LOGGER.warning("Race control unavailable: %s", response.status)
+                        return self._last_message
+                    if response.status != 200:
+                        raise UpdateFailed(f"Error fetching data: {response.status}")
+                    text = await response.text()
+        except Exception as err:
+            _LOGGER.warning("Error fetching race control: %s", err)
+            return self._last_message
+
+        self.available = True
+        msg = parse_racecontrol(text)
+        if msg:
+            self._last_message = msg
+        return self._last_message
 

--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -29,6 +29,8 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     "last_race_results",
                     "season_results",
                     "race_week",
+                    "next_session",
+                    "race_control",
                 ]
             ): cv.multi_select({
                 "next_race": "Next race",
@@ -39,7 +41,11 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 "last_race_results": "Last race results",
                 "season_results": "Season results",
                 "race_week": "Race week",
+                "next_session": "Next session",
+                "race_control": "Race control",
             }),
+            vol.Optional("enable_race_control", default=True): cv.boolean,
+            vol.Optional("fast_poll_seconds", default=5): cv.positive_int,
         })
 
         return self.async_show_form(
@@ -73,6 +79,8 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     "last_race_results",
                     "season_results",
                     "race_week",
+                    "next_session",
+                    "race_control",
                 ])
             ): cv.multi_select({
                 "next_race": "Next race",
@@ -83,7 +91,11 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 "last_race_results": "Last race results",
                 "season_results": "Season results",
                 "race_week": "Race week",
+                "next_session": "Next session",
+                "race_control": "Race control",
             }),
+            vol.Optional("enable_race_control", default=current.get("enable_race_control", True)): cv.boolean,
+            vol.Optional("fast_poll_seconds", default=current.get("fast_poll_seconds", 5)): cv.positive_int,
         })
 
         return self.async_show_form(

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -6,3 +6,6 @@ DRIVER_STANDINGS_URL = "https://api.jolpi.ca/ergast/f1/current/driverstandings.j
 CONSTRUCTOR_STANDINGS_URL = "https://api.jolpi.ca/ergast/f1/current/constructorstandings.json"
 LAST_RACE_RESULTS_URL = "https://api.jolpi.ca/ergast/f1/current/last/results.json"
 SEASON_RESULTS_URL = "https://api.jolpi.ca/ergast/f1/current/results.json?limit=100"
+
+LIVETIMING_INDEX_URL = "https://livetiming.formula1.com/static/{year}/Index.json"
+RACE_CONTROL_URL = "https://livetiming.formula1.com/static/{path}RaceControlMessages.jsonStream"

--- a/custom_components/f1_sensor/helpers.py
+++ b/custom_components/f1_sensor/helpers.py
@@ -1,0 +1,56 @@
+import json
+from datetime import datetime, timedelta, timezone
+from json import JSONDecodeError
+
+
+def parse_offset(offset_str: str) -> timedelta:
+    sign = -1 if offset_str.startswith('-') else 1
+    h, m, s = [int(x) for x in offset_str.lstrip('+-').split(':')]
+    return sign * timedelta(hours=h, minutes=m, seconds=s)
+
+
+def to_utc(date_str: str, offset_str: str) -> datetime | None:
+    if not date_str:
+        return None
+    dt = datetime.fromisoformat(date_str)
+    if offset_str:
+        dt -= parse_offset(offset_str)
+    return dt.replace(tzinfo=timezone.utc)
+
+
+def find_next_session(data: dict):
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    meetings = data.get('Meetings', []) if data else []
+    upcoming = []
+    for meeting in meetings:
+        for session in meeting.get('Sessions', []):
+            start = to_utc(session.get('StartDate'), session.get('GmtOffset'))
+            end = to_utc(session.get('EndDate'), session.get('GmtOffset'))
+            session['start_utc'] = start.isoformat() if start else None
+            session['end_utc'] = end.isoformat() if end else None
+            if end and end >= now:
+                upcoming.append((start, meeting, session))
+    if not upcoming:
+        return None, None
+    upcoming.sort(key=lambda x: x[0])
+    _, meeting, session = upcoming[0]
+    return meeting, session
+
+
+def parse_racecontrol(text: str):
+    last = None
+    for line in text.splitlines():
+        if '{' not in line:
+            continue
+        _, json_part = line.split('{', 1)
+        try:
+            obj = json.loads('{' + json_part)
+        except JSONDecodeError:
+            continue
+        msgs = obj.get('Messages')
+        if isinstance(msgs, list) and msgs:
+            last = msgs[-1]
+        elif isinstance(msgs, dict) and msgs:
+            key = max(msgs.keys(), key=lambda x: int(x))
+            last = msgs[key]
+    return last

--- a/custom_components/f1_sensor/manifest.json
+++ b/custom_components/f1_sensor/manifest.json
@@ -7,7 +7,8 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Nicxe/f1_sensor/issues",
     "requirements": [
-        "timezonefinder==5.2.0"
+        "timezonefinder==5.2.0",
+        "python-dateutil>=2.8"
     ],
-    "version": "1.1.1"
+    "version": "1.2.0"
 }

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -6,11 +6,15 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .entity import F1BaseEntity
 import async_timeout
 import datetime
+import json
+from dateutil import parser as dtparser
+from homeassistant.util import dt as dt_util
 from timezonefinder import TimezoneFinder
 from zoneinfo import ZoneInfo
 
 
 from .const import DOMAIN
+from .helpers import find_next_session, parse_racecontrol
 
 
 SYMBOL_CODE_TO_MDI = {
@@ -70,6 +74,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         "weather": (F1WeatherSensor, data["race_coordinator"]),
         "last_race_results": (F1LastRaceSensor, data["last_race_coordinator"]),
         "season_results": (F1SeasonResultsSensor, data["season_results_coordinator"]),
+        "next_session": (F1NextSessionSensor, data.get("session_coordinator")),
+        "race_control": (F1RaceControlSensor, data.get("race_control_coordinator")),
     }
 
     sensors = []
@@ -513,6 +519,86 @@ class F1SeasonResultsSensor(F1BaseEntity, SensorEntity):
                 "results": results
             })
         return {"races": cleaned}
+
+
+class F1NextSessionSensor(F1BaseEntity, SensorEntity):
+    """Sensor providing information about the next session."""
+
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
+        self._attr_icon = "mdi:clock-outline"
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def _get_session(self):
+        meeting, session = find_next_session(self.coordinator.data or {})
+        return meeting, session
+
+    @property
+    def unique_id(self):
+        meeting, session = self._get_session()
+        if meeting and session:
+            return f"f1_next_session_{meeting.get('Key')}_{session.get('Key')}"
+        return self._attr_unique_id
+
+    @property
+    def state(self):
+        _, session = self._get_session()
+        if session:
+            return session.get("start_utc")
+        return None
+
+    @property
+    def extra_state_attributes(self):
+        meeting, session = self._get_session()
+        if not session:
+            return {}
+        attrs = {
+            "session_name": session.get("Name"),
+            "session_type": session.get("Type"),
+            "session_number": session.get("Number"),
+            "session_start": session.get("start_utc"),
+            "session_end": session.get("end_utc"),
+            "path": session.get("Path"),
+        }
+        if meeting:
+            attrs["meeting_name"] = meeting.get("Name")
+            attrs["meeting_key"] = meeting.get("Key")
+        attrs["session_key"] = session.get("Key")
+        return attrs
+
+
+class F1RaceControlSensor(F1BaseEntity, SensorEntity):
+    """Sensor that shows latest race control message."""
+
+    def __init__(self, coordinator, sensor_name, unique_id, entry_id, device_name):
+        super().__init__(coordinator, sensor_name, unique_id, entry_id, device_name)
+        self._attr_icon = "mdi:flag"
+
+    @property
+    def available(self):
+        return getattr(self.coordinator, "available", True)
+
+    def _get_session_keys(self):
+        meeting, session = find_next_session(self.hass.data[DOMAIN][self._entry_id]["session_coordinator"].data or {})
+        if meeting and session:
+            return meeting.get("Key"), session.get("Key")
+        return None, None
+
+    @property
+    def unique_id(self):
+        mk, sk = self._get_session_keys()
+        if mk and sk:
+            return f"f1_race_control_{mk}_{sk}"
+        return self._attr_unique_id
+
+    @property
+    def state(self):
+        data = self.coordinator.data or {}
+        return data.get("Message") if isinstance(data, dict) else None
+
+    @property
+    def extra_state_attributes(self):
+        return self.coordinator.data or {}
 
 
 

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -40,6 +40,13 @@
       "season_results": {
         "name": "Season results"
       }
+      ,
+      "next_session": {
+        "name": "Next session"
+      },
+      "race_control": {
+        "name": "Race control"
+      }
     },
     "binary_sensor": {
       "race_week": {

--- a/tests/fixtures/racecontrol.jsonstream
+++ b/tests/fixtures/racecontrol.jsonstream
@@ -1,0 +1,2 @@
+00: 13: 07.973{"Messages": [{"Utc": "2025-06-29T12:20:01", "Lap": 1, "Category": "Flag", "Flag": "GREEN", "Scope": "Track", "Message": "GREEN LIGHT - PIT EXIT OPEN"}]}
+00: 13: 42.880{"Messages": {"3": {"Utc": "2025-06-29T12:20:36", "Lap": 1, "Category": "Flag", "Flag": "CLEAR", "Scope": "Sector", "Sector": 3, "Message": "CLEAR IN TRACK SECTOR 3"}}}

--- a/tests/test_race_control.py
+++ b/tests/test_race_control.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "helpers", Path("custom_components/f1_sensor/helpers.py")
+)
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+parse_racecontrol = helpers.parse_racecontrol
+
+
+def test_parse_racecontrol_returns_last_message():
+    text = Path('tests/fixtures/racecontrol.jsonstream').read_text()
+    msg = parse_racecontrol(text)
+    assert msg['Message'] == 'CLEAR IN TRACK SECTOR 3'


### PR DESCRIPTION
## Summary
- implement LiveSession and RaceControl coordinators
- provide `sensor.f1_next_session` and `sensor.f1_race_control`
- add helper utilities and translations
- support options for race control in config flow
- include tests for parsing RaceControl messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619f7e53448322a38d5bf9c73b8477