### PR TITLE
Add debug logging for Race Control messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ recorder:
       - sensor.f1_season_results
 ```
 
+##### Debug logging
+Enable debug logging to view each Race Control message in the Home Assistant log:
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.f1_sensor: debug
+```
+
+
 
 
 

--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -189,6 +189,7 @@ class RaceControlCoordinator(DataUpdateCoordinator):
                 async for payload in self._client.messages():
                     msg = self._parse_message(payload)
                     if msg:
+                        _LOGGER.debug("Race control message: %s", msg)
                         self.available = True
                         self._last_message = msg
                         self.async_set_updated_data(msg)


### PR DESCRIPTION
## Summary
- log parsed Race Control messages when debug logging is enabled
- document how to enable debug logging in Home Assistant

## Testing
- `pip install -r requirements_dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868ed6b3070832287efb693120537d4