### PR TITLE
Fix websocket error on non-numeric race control keys

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -215,8 +215,10 @@ class RaceControlCoordinator(DataUpdateCoordinator):
                 if isinstance(content, list) and content:
                     return content[-1]
                 if isinstance(content, dict) and content:
-                    key = max(content.keys(), key=lambda x: int(x))
-                    return content[key]
+                    numeric_keys = [k for k in content.keys() if str(k).isdigit()]
+                    if numeric_keys:
+                        key = max(numeric_keys, key=lambda x: int(x))
+                        return content[key]
         return None
 
     async def async_config_entry_first_refresh(self):

--- a/custom_components/f1_sensor/helpers.py
+++ b/custom_components/f1_sensor/helpers.py
@@ -51,6 +51,8 @@ def parse_racecontrol(text: str):
         if isinstance(msgs, list) and msgs:
             last = msgs[-1]
         elif isinstance(msgs, dict) and msgs:
-            key = max(msgs.keys(), key=lambda x: int(x))
-            last = msgs[key]
+            numeric_keys = [k for k in msgs.keys() if str(k).isdigit()]
+            if numeric_keys:
+                key = max(numeric_keys, key=lambda x: int(x))
+                last = msgs[key]
     return last

--- a/tests/fixtures/racecontrol_mixed_keys.jsonstream
+++ b/tests/fixtures/racecontrol_mixed_keys.jsonstream
@@ -1,0 +1,1 @@
+00: 00: 01{"Messages": {"Messages": {"abc": 1}, "3": {"Message": "FIRST"}, "5": {"Message": "SECOND"}}}

--- a/tests/test_race_control.py
+++ b/tests/test_race_control.py
@@ -13,3 +13,9 @@ def test_parse_racecontrol_returns_last_message():
     text = Path("tests/fixtures/racecontrol.jsonstream").read_text()
     msg = parse_racecontrol(text)
     assert msg["Message"] == "CLEAR IN TRACK SECTOR 3"
+
+
+def test_parse_racecontrol_ignores_string_keys():
+    text = Path("tests/fixtures/racecontrol_mixed_keys.jsonstream").read_text()
+    msg = parse_racecontrol(text)
+    assert msg["Message"] == "SECOND"


### PR DESCRIPTION
## Summary
- guard against non-numeric keys when parsing Race Control messages
- adjust helper to ignore string keys
- add regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686907bcb71c8322a8107fd70313aef5