### PR TITLE
Add SignalR race control transform and logging

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -182,7 +182,7 @@ class RaceControlCoordinator(DataUpdateCoordinator):
     async def _listen(self):
         from .signalr import SignalRClient
 
-        self._client = SignalRClient(self._session)
+        self._client = SignalRClient(self.hass, self._session)
         while True:
             try:
                 await self._client.connect()

--- a/custom_components/f1_sensor/rc_transform.py
+++ b/custom_components/f1_sensor/rc_transform.py
@@ -1,0 +1,39 @@
+"""Helpers to clean raw RaceControlMessages."""
+import gzip
+import json
+import datetime as dt
+
+FLAG_MAP = {
+    0: None,
+    1: "GREEN",
+    2: "YELLOW",
+    3: "DOUBLE YELLOW",
+    4: "RED",
+    5: "BLUE",
+    6: "WHITE",
+    7: "BLACK",
+    8: "CHEQUERED",
+}
+CATEGORY_MAP = {
+    0: "CarEvent",
+    1: "SafetyCar",
+    2: "Flag",
+    3: "Session",
+    4: "Message",
+}
+SCOPE_MAP = {0: "Track", 1: "Sector", 2: "Driver"}
+
+
+def clean_rc(raw_bytes: bytes, t0: dt.datetime) -> dict:
+    """Return a readable dict from compressed RaceControl payload."""
+    data = json.loads(gzip.decompress(raw_bytes))
+    return {
+        "category": CATEGORY_MAP.get(data["m"]),
+        "flag": FLAG_MAP.get(data.get("f")),
+        "scope": SCOPE_MAP.get(data["s"]),
+        "sector": data.get("sc"),
+        "lap_number": data.get("lap"),
+        "driver_number": data.get("drv"),
+        "message": data.get("mes"),
+        "date": (t0 + dt.timedelta(milliseconds=data["utc"])).isoformat() + "Z",
+    }

--- a/custom_components/f1_sensor/signalr.py
+++ b/custom_components/f1_sensor/signalr.py
@@ -1,8 +1,13 @@
+import base64
 import json
 import logging
+import datetime as dt
 from typing import AsyncGenerator, Optional
 
 from aiohttp import ClientSession, WSMsgType
+from homeassistant.core import HomeAssistant
+
+from . import rc_transform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,11 +25,14 @@ SUBSCRIBE_MSG = {
 class SignalRClient:
     """Minimal SignalR client for Formula 1 live timing."""
 
-    def __init__(self, session: ClientSession) -> None:
+    def __init__(self, hass: HomeAssistant, session: ClientSession) -> None:
+        self._hass = hass
         self._session = session
         self._ws = None
+        self._t0 = dt.datetime.utcnow()
 
     async def connect(self) -> None:
+        _LOGGER.debug("Connecting to F1 SignalR service")
         params = {"clientProtocol": "1.5", "connectionData": HUB_DATA}
         async with self._session.get(NEGOTIATE_URL, params=params) as resp:
             resp.raise_for_status()
@@ -49,6 +57,9 @@ class SignalRClient:
             CONNECT_URL, params=params, headers=headers
         )
         await self._ws.send_json(SUBSCRIBE_MSG)
+        self._t0 = dt.datetime.utcnow()
+        _LOGGER.debug("SignalR connection established")
+        _LOGGER.debug("Subscribed to RaceControlMessages")
 
     async def messages(self) -> AsyncGenerator[dict, None]:
         if not self._ws:
@@ -59,6 +70,13 @@ class SignalRClient:
                     payload = json.loads(msg.data)
                 except json.JSONDecodeError:
                     continue
+                _LOGGER.debug("Stream payload: %s", payload)
+                messages = payload.get("M") if isinstance(payload, dict) else None
+                if messages:
+                    for update in messages:
+                        args = update.get("A", [])
+                        if len(args) >= 2 and args[0] == "RaceControlMessages":
+                            await self._on_rc(base64.b64decode(args[1]))
                 yield payload
             elif msg.type in (WSMsgType.CLOSED, WSMsgType.ERROR):
                 break
@@ -67,3 +85,9 @@ class SignalRClient:
         if self._ws is not None:
             await self._ws.close()
             self._ws = None
+
+    async def _on_rc(self, payload: bytes) -> None:
+        """Handle RaceControlMessages by updating sensor state."""
+        clean = rc_transform.clean_rc(payload, self._t0)
+        _LOGGER.debug("Race control message: %s", clean)
+        self._hass.states.async_set("sensor.f1_flag", clean["flag"], clean)


### PR DESCRIPTION
## Summary
- add helper to normalize RaceControl messages
- update SignalR client to decode and log race control data
- pass Home Assistant instance when starting SignalR client

## Testing
- `pytest -q`
- `python3 -m script.hassfest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6869195b4d908322a66318f5daa27a17