### PR TITLE
Update race control handling

### DIFF
--- a/custom_components/f1_sensor/rc_transform.py
+++ b/custom_components/f1_sensor/rc_transform.py
@@ -2,6 +2,7 @@
 import gzip
 import json
 import datetime as dt
+import dateutil.parser as dparse
 
 FLAG_MAP = {
     0: None,
@@ -20,13 +21,24 @@ CATEGORY_MAP = {
     2: "Flag",
     3: "Session",
     4: "Message",
+    5: "Other",
 }
 SCOPE_MAP = {0: "Track", 1: "Sector", 2: "Driver"}
 
 
-def clean_rc(raw_bytes: bytes, t0: dt.datetime) -> dict:
-    """Return a readable dict from compressed RaceControl payload."""
-    data = json.loads(gzip.decompress(raw_bytes))
+def _parse_date(raw, t0: dt.datetime) -> str:
+    """Return ISO timestamp from UTC ms offset or ISO string."""
+    if isinstance(raw, (int, float)):
+        return (t0 + dt.timedelta(milliseconds=raw)).isoformat() + "Z"
+    return dparse.parse(str(raw)).isoformat()
+
+
+def clean_rc(data_or_bytes, t0: dt.datetime) -> dict:
+    """Return a readable dict from RaceControl payload."""
+    if isinstance(data_or_bytes, (bytes, bytearray)):
+        data = json.loads(gzip.decompress(data_or_bytes))
+    else:
+        data = data_or_bytes
     return {
         "category": CATEGORY_MAP.get(data["m"]),
         "flag": FLAG_MAP.get(data.get("f")),
@@ -35,5 +47,5 @@ def clean_rc(raw_bytes: bytes, t0: dt.datetime) -> dict:
         "lap_number": data.get("lap"),
         "driver_number": data.get("drv"),
         "message": data.get("mes"),
-        "date": (t0 + dt.timedelta(milliseconds=data["utc"])).isoformat() + "Z",
+        "date": _parse_date(data["utc"], t0),
     }


### PR DESCRIPTION
## Summary
- normalize race control timestamps
- parse result frames from SignalR
- handle compressed & JSON messages the same way

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686924a257888322ab8c03b0cbfc8136