### PR TITLE
Handle missing keys in RaceControl messages

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -80,3 +80,12 @@ class F1DataCoordinator(DataUpdateCoordinator):
         except Exception as err:
             raise UpdateFailed(f"Error fetching data: {err}") from err
 
+
+def _safe_category(data: dict):
+    """Return category value from a race control payload."""
+    try:
+        return data.get("m", data.get("Category"))
+    except Exception as exc:  # pragma: no cover - defensive
+        _LOGGER.warning("Race control websocket error: %s", exc)
+        return None
+

--- a/custom_components/f1_sensor/manifest.json
+++ b/custom_components/f1_sensor/manifest.json
@@ -7,7 +7,8 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Nicxe/f1_sensor/issues",
     "requirements": [
-        "timezonefinder==5.2.0"
+        "timezonefinder==5.2.0",
+        "python-dateutil>=2.8.2"
     ],
     "version": "1.1.1"
 }

--- a/custom_components/f1_sensor/rc_transform.py
+++ b/custom_components/f1_sensor/rc_transform.py
@@ -1,0 +1,60 @@
+import gzip
+import json
+import datetime as dt
+from dateutil import parser as dparse
+
+CATEGORY_MAP = {
+    0: "CarEvent",
+    1: "SafetyCar",
+    2: "Flag",
+    3: "Session",
+    4: "Message",
+    5: "Other",
+}
+FLAG_MAP = {
+    0: None,
+    1: "GREEN",
+    2: "YELLOW",
+    3: "DOUBLE YELLOW",
+    4: "RED",
+    5: "BLUE",
+    6: "WHITE",
+    7: "BLACK",
+    8: "CHEQUERED",
+    "CLEAR": "CLEAR",
+}
+SCOPE_MAP = {
+    0: "Track",
+    1: "Sector",
+    2: "Driver",
+    "Track": "Track",
+    "Sector": "Sector",
+    "Driver": "Driver",
+}
+
+def _parse_date(raw, t0):
+    """Return ISO-8601 regardless if raw is milliseconds or ISO string."""
+    if isinstance(raw, (int, float)):
+        return (t0 + dt.timedelta(milliseconds=raw)).isoformat() + "Z"
+    return dparse.parse(raw).isoformat()
+
+
+def clean_rc(data: dict, t0: dt.datetime) -> dict:
+    """Normalize RaceControl row regardless of key type."""
+    if isinstance(data, (bytes, bytearray)):
+        data = json.loads(gzip.decompress(data))
+
+    category_val = data.get("m", data.get("Category"))
+    flag_val = data.get("f", data.get("Flag"))
+    scope_val = data.get("s", data.get("Scope"))
+
+    return {
+        "category": CATEGORY_MAP.get(category_val, category_val),
+        "flag": FLAG_MAP.get(flag_val, flag_val),
+        "scope": SCOPE_MAP.get(scope_val, scope_val),
+        "sector": data.get("sc", data.get("Sector")),
+        "lap_number": data.get("lap", data.get("Lap")),
+        "driver_number": data.get("drv", data.get("RacingNumber")),
+        "message": data.get("mes", data.get("Message")),
+        "date": _parse_date(data.get("utc", data.get("Utc")), t0),
+    }

--- a/custom_components/f1_sensor/signalr.py
+++ b/custom_components/f1_sensor/signalr.py
@@ -1,0 +1,42 @@
+import json
+import logging
+
+from . import rc_transform
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SignalRClient:
+    """Minimal SignalR client to handle F1 Race Control messages."""
+
+    def __init__(self, hass, ws, t0):
+        self._hass = hass
+        self._ws = ws
+        self._t0 = t0
+
+    async def listen(self):
+        """Listen for incoming websocket messages."""
+        async for raw in self._ws:
+            payload = json.loads(raw)
+
+            # A. Push frames containing compressed packages
+            if "M" in payload:
+                for hub_msg in payload["M"]:
+                    if hub_msg.get("A"):
+                        await self._handle_rc(hub_msg["A"][0])
+
+            # B. Result frames (history/bulk), already JSON
+            elif "R" in payload and "RaceControlMessages" in payload["R"]:
+                for msg in payload["R"]["RaceControlMessages"]["Messages"]:
+                    await self._handle_rc(msg)
+
+    async def _handle_rc(self, rc_raw):
+        try:
+            clean = rc_transform.clean_rc(rc_raw, self._t0)
+            await self._hass.states.async_set(
+                "sensor.f1_flag", clean.get("flag", "UNKNOWN"), clean
+            )
+        except Exception as exc:
+            _LOGGER.warning(
+                "Race control transform failed: %s", exc, exc_info=True
+            )


### PR DESCRIPTION
## Summary
- add rc_transform helper with flexible timestamp parsing
- add minimal SignalR client with robust RaceControl frame handling
- fallback when extracting RaceControl category
- include python-dateutil requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68692be8c10483228bfc5a96f368d686