### PR TITLE
Improve flag handling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ logger:
     custom_components.f1_sensor: debug
 ```
 
+#### Race Control message flow
+
+```mermaid
+sequenceDiagram
+    participant RC as SignalR
+    participant T as rc_transform
+    participant F as FlagState
+    participant S as sensor.f1_flag
+    RC->>T: raw message
+    T->>F: normalized dict
+    F->>S: new state
+```
+
+Example payload from the F1 API:
+
+```json
+{
+  "Category": "Flag",
+  "Flag": "RED",
+  "Scope": "Track",
+  "Message": "SESSION STOPPED",
+  "Utc": 123456789
+}
+```
+
 
 
 

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -1,6 +1,9 @@
 DOMAIN = "f1_sensor"
 PLATFORMS = ["sensor", "binary_sensor"]
 
+# Global key for the shared flag state machine
+FLAG_MACHINE = "f1_flag_state"
+
 API_URL = "https://api.jolpi.ca/ergast/f1/current.json"
 DRIVER_STANDINGS_URL = "https://api.jolpi.ca/ergast/f1/current/driverstandings.json"
 CONSTRUCTOR_STANDINGS_URL = (

--- a/custom_components/f1_sensor/flag_state.py
+++ b/custom_components/f1_sensor/flag_state.py
@@ -37,7 +37,6 @@ class FlagState:
                 if scope == "Sector":
                     self.active_yellows.discard(rc["sector"])
                 elif scope == "Track":
-                    self.active_yellows.clear()
                     self.track_red = False
 
             elif flag == "GREEN" and scope == "Track":

--- a/custom_components/f1_sensor/rc_transform.py
+++ b/custom_components/f1_sensor/rc_transform.py
@@ -65,13 +65,22 @@ def clean_rc(data, t0: dt.datetime):
     flag_val = data.get("f", data.get("Flag"))
     scope_val = data.get("s", data.get("Scope"))
 
+    category = CATEGORY_MAP.get(category_val, category_val)
+    flag_raw = FLAG_MAP.get(flag_val, flag_val)
+    if isinstance(flag_raw, str):
+        flag = flag_raw.upper()
+    else:
+        flag = flag_raw
+    scope = SCOPE_MAP.get(scope_val, scope_val)
+    sector = data.get("sc", data.get("Sector"))
+    message = data.get("mes", data.get("Message"))
+    utc = _parse_date(data.get("utc", data.get("Utc")), t0)
+
     return {
-        "category": CATEGORY_MAP.get(category_val, category_val),
-        "flag": FLAG_MAP.get(flag_val, flag_val),
-        "scope": SCOPE_MAP.get(scope_val, scope_val),
-        "sector": data.get("sc", data.get("Sector")),
-        "lap_number": data.get("lap", data.get("Lap")),
-        "driver_number": data.get("drv", data.get("RacingNumber")),
-        "message": data.get("mes", data.get("Message")),
-        "date": _parse_date(data.get("utc", data.get("Utc")), t0),
+        "category": category,
+        "flag": flag,
+        "scope": scope,
+        "sector": sector,
+        "message": message,
+        "utc": utc,
     }

--- a/tests/test_flag_state.py
+++ b/tests/test_flag_state.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+homeassistant = types.ModuleType("homeassistant")
+homeassistant.core = types.ModuleType("homeassistant.core")
+homeassistant.core.HomeAssistant = type("HomeAssistant", (), {})
+sys.modules.setdefault("homeassistant", homeassistant)
+sys.modules.setdefault("homeassistant.core", homeassistant.core)
+
+spec = importlib.util.spec_from_file_location(
+    "custom_components.f1_sensor.flag_state",
+    Path("custom_components/f1_sensor/flag_state.py"),
+)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+sys.modules["custom_components.f1_sensor.flag_state"] = module
+spec.loader.exec_module(module)
+FlagState = module.FlagState
+
+
+def test_track_red_overrides_all():
+    fs = FlagState()
+    fs.apply({"category": "Flag", "flag": "YELLOW", "scope": "Sector", "sector": 1})
+    assert fs.state == "yellow"
+    fs.apply({"category": "Flag", "flag": "RED", "scope": "Track"})
+    assert fs.state == "red"
+    fs.apply({"category": "SafetyCar", "Status": "VSC DEPLOYED", "scope": "Track"})
+    assert fs.state == "red"
+
+
+def test_sector_clear_does_not_cancel_track_red():
+    fs = FlagState()
+    fs.apply({"category": "Flag", "flag": "RED", "scope": "Track"})
+    fs.apply({"category": "Flag", "flag": "CLEAR", "scope": "Sector", "sector": 1})
+    assert fs.track_red
+    assert fs.state == "red"
+
+
+def test_track_clear_requires_no_yellows_for_green():
+    fs = FlagState()
+    fs.apply({"category": "Flag", "flag": "RED", "scope": "Track"})
+    fs.apply({"category": "Flag", "flag": "YELLOW", "scope": "Sector", "sector": 2})
+    fs.apply({"category": "Flag", "flag": "CLEAR", "scope": "Track"})
+    assert fs.state == "yellow"
+    fs.apply({"category": "Flag", "flag": "CLEAR", "scope": "Sector", "sector": 2})
+    assert fs.state == "green"
+


### PR DESCRIPTION
## Summary
- fix iteration over race control message dicts in SignalR client
- refactor `_handle_rc` to use global flag state machine
- ensure `clean_rc` outputs flat dict and normalizes flags
- expose new data list from race control coordinator
- push updates correctly from `F1FlagSensor`
- add tests for `FlagState`
- document race control workflow

## Testing
- `ruff check --fix .`
- `mypy --strict custom_components/f1_sensor` *(fails: missing stubs)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686946e3a1f48322adee1266fd8c78ba