### PR TITLE
Enable message ID for race control sensor

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -218,12 +218,16 @@ class RaceControlCoordinator(DataUpdateCoordinator):
             if args[0] == "RaceControlMessages":
                 content = args[1]
                 if isinstance(content, list) and content:
-                    return content[-1]
+                    msg = content[-1]
+                    return msg
                 if isinstance(content, dict) and content:
                     numeric_keys = [k for k in content.keys() if str(k).isdigit()]
                     if numeric_keys:
                         key = max(numeric_keys, key=lambda x: int(x))
-                        return content[key]
+                        msg = content[key]
+                        if isinstance(msg, dict):
+                            msg.setdefault("id", int(key))
+                        return msg
                     try:
                         content.get("m", content.get("Category"))
                     except KeyError as exc:

--- a/custom_components/f1_sensor/helpers.py
+++ b/custom_components/f1_sensor/helpers.py
@@ -55,4 +55,6 @@ def parse_racecontrol(text: str):
             if numeric_keys:
                 key = max(numeric_keys, key=lambda x: int(x))
                 last = msgs[key]
+                if isinstance(last, dict):
+                    last.setdefault("id", int(key))
     return last

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -684,7 +684,11 @@ class F1RaceControlSensor(F1BaseEntity, SensorEntity):
     @property
     def state(self):
         data = self.coordinator.data or {}
-        return data.get("Message") if isinstance(data, dict) else None
+        if isinstance(data, dict):
+            if "id" in data:
+                return data["id"]
+            return data.get("Message")
+        return None
 
     @property
     def extra_state_attributes(self):

--- a/tests/test_race_control.py
+++ b/tests/test_race_control.py
@@ -13,9 +13,11 @@ def test_parse_racecontrol_returns_last_message():
     text = Path("tests/fixtures/racecontrol.jsonstream").read_text()
     msg = parse_racecontrol(text)
     assert msg["Message"] == "CLEAR IN TRACK SECTOR 3"
+    assert msg["id"] == 3
 
 
 def test_parse_racecontrol_ignores_string_keys():
     text = Path("tests/fixtures/racecontrol_mixed_keys.jsonstream").read_text()
     msg = parse_racecontrol(text)
     assert msg["Message"] == "SECOND"
+    assert msg["id"] == 5


### PR DESCRIPTION
## Summary
- track message ID when parsing race control data
- surface message ID in RaceControl coordinator
- return ID as state for `sensor.f1_race_control`
- test parse_racecontrol returns message ID

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686966fe9c64832295e86050f29ab204