### PR TITLE
Implement RestoreEntity and backoff

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -44,12 +44,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     year = datetime.utcnow().year
     session_coordinator = LiveSessionCoordinator(hass, year)
     enable_rc = entry.data.get("enable_race_control", True)
-    fast_seconds = entry.data.get("fast_poll_seconds", 5)
     race_control_coordinator = None
     hass.data[FLAG_MACHINE] = FlagState()
     if enable_rc:
         race_control_coordinator = RaceControlCoordinator(
-            hass, session_coordinator, fast_seconds
+            hass, session_coordinator
         )
 
     await race_coordinator.async_config_entry_first_refresh()
@@ -155,7 +154,6 @@ class RaceControlCoordinator(DataUpdateCoordinator):
         self,
         hass: HomeAssistant,
         session_coord: LiveSessionCoordinator,
-        fast_seconds: int = 5,
     ):
         super().__init__(
             hass,
@@ -165,7 +163,6 @@ class RaceControlCoordinator(DataUpdateCoordinator):
         )
         self._session = async_get_clientsession(hass)
         self._session_coord = session_coord
-        self._fast = fast_seconds
         self.available = True
         self._last_message = None
         self.data_list: list[dict] = []
@@ -186,10 +183,14 @@ class RaceControlCoordinator(DataUpdateCoordinator):
     async def _listen(self):
         from .signalr import SignalRClient
 
+        from .const import BACK_OFF_FACTOR, FAST_RETRY_SEC, MAX_RETRY_SEC
+
         self._client = SignalRClient(self.hass, self._session)
+        delay = FAST_RETRY_SEC
         while True:
             try:
                 await self._client.connect()
+                delay = FAST_RETRY_SEC
                 async for payload in self._client.messages():
                     msg = self._parse_message(payload)
                     if msg:
@@ -200,8 +201,13 @@ class RaceControlCoordinator(DataUpdateCoordinator):
                         self.async_set_updated_data(msg)
             except Exception as err:  # pragma: no cover - network errors
                 self.available = False
-                _LOGGER.warning("Race control websocket error: %s", err)
-                await asyncio.sleep(self._fast)
+                _LOGGER.warning(
+                    "Race control websocket error: %s. Retrying in %s s …",
+                    err,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * BACK_OFF_FACTOR, MAX_RETRY_SEC)
             finally:
                 if self._client:
                     await self._client.close()

--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -52,7 +52,6 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     }
                 ),
                 vol.Optional("enable_race_control", default=True): cv.boolean,
-                vol.Optional("fast_poll_seconds", default=5): cv.positive_int,
             }
         )
 
@@ -116,9 +115,6 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     "enable_race_control",
                     default=current.get("enable_race_control", True),
                 ): cv.boolean,
-                vol.Optional(
-                    "fast_poll_seconds", default=current.get("fast_poll_seconds", 5)
-                ): cv.positive_int,
             }
         )
 

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -13,3 +13,8 @@ LAST_RACE_RESULTS_URL = "https://api.jolpi.ca/ergast/f1/current/last/results.jso
 SEASON_RESULTS_URL = "https://api.jolpi.ca/ergast/f1/current/results.json?limit=100"
 
 LIVETIMING_INDEX_URL = "https://livetiming.formula1.com/static/{year}/Index.json"
+
+# SignalR reconnect settings
+FAST_RETRY_SEC = 5
+MAX_RETRY_SEC = 60
+BACK_OFF_FACTOR = 2

--- a/tests/test_restore_state.py
+++ b/tests/test_restore_state.py
@@ -1,0 +1,173 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Reuse environment setup from test_flag_safety but add RestoreEntity stub
+async_timeout_mod = types.ModuleType("async_timeout")
+
+class _Dummy:
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+def timeout(_):
+    return _Dummy()
+
+async_timeout_mod.timeout = timeout
+sys.modules.setdefault("async_timeout", async_timeout_mod)
+
+# timezonefinder stub
+tf = types.ModuleType("timezonefinder")
+tf.TimezoneFinder = object
+sys.modules.setdefault("timezonefinder", tf)
+
+# homeassistant stubs
+homeassistant = types.ModuleType("homeassistant")
+components = types.ModuleType("homeassistant.components")
+sensor_mod = types.ModuleType("homeassistant.components.sensor")
+binary_mod = types.ModuleType("homeassistant.components.binary_sensor")
+
+sensor_mod.SensorEntity = type("SensorEntity", (), {})
+sensor_mod.SensorDeviceClass = type("SensorDeviceClass", (), {})
+binary_mod.BinarySensorEntity = type("BinarySensorEntity", (), {})
+binary_mod.BinarySensorDeviceClass = type("BinarySensorDeviceClass", (), {})
+components.sensor = sensor_mod
+components.binary_sensor = binary_mod
+homeassistant.components = components
+
+helpers = types.ModuleType("homeassistant.helpers")
+aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+
+def async_get_clientsession(hass):
+    return None
+
+aiohttp_client.async_get_clientsession = async_get_clientsession
+update = types.ModuleType("homeassistant.helpers.update_coordinator")
+update.DataUpdateCoordinator = object
+update.UpdateFailed = Exception
+
+class CoordinatorEntity:
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+update.CoordinatorEntity = CoordinatorEntity
+helpers.aiohttp_client = aiohttp_client
+helpers.update_coordinator = update
+
+# restore_state stub
+restore_state = types.ModuleType("homeassistant.helpers.restore_state")
+
+class FakeState:
+    def __init__(self, state, attributes):
+        self.state = state
+        self.attributes = attributes
+
+restore_state.LAST_STATE = None
+
+class RestoreEntity:
+    async def async_get_last_state(self):
+        return restore_state.LAST_STATE
+
+    async def async_added_to_hass(self):
+        return None
+
+    async def async_will_remove_from_hass(self):
+        return None
+
+restore_state.RestoreEntity = RestoreEntity
+helpers.restore_state = restore_state
+
+homeassistant.helpers = helpers
+
+config_entries = types.ModuleType("homeassistant.config_entries")
+config_entries.ConfigEntry = type("ConfigEntry", (), {})
+homeassistant.config_entries = config_entries
+core = types.ModuleType("homeassistant.core")
+core.HomeAssistant = type("HomeAssistant", (), {})
+homeassistant.core = core
+
+sys.modules.setdefault("homeassistant", homeassistant)
+sys.modules.setdefault("homeassistant.components", components)
+sys.modules.setdefault("homeassistant.components.sensor", sensor_mod)
+sys.modules.setdefault("homeassistant.components.binary_sensor", binary_mod)
+sys.modules.setdefault("homeassistant.helpers", helpers)
+sys.modules.setdefault("homeassistant.helpers.aiohttp_client", aiohttp_client)
+sys.modules.setdefault("homeassistant.helpers.update_coordinator", update)
+sys.modules.setdefault("homeassistant.helpers.restore_state", restore_state)
+sys.modules.setdefault("homeassistant.config_entries", config_entries)
+sys.modules.setdefault("homeassistant.core", core)
+
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+cc_f1 = types.ModuleType("custom_components.f1_sensor")
+cc_f1.__path__ = []  # type: ignore[attr-defined]
+sys.modules.setdefault("custom_components.f1_sensor", cc_f1)
+
+# load modules
+spec_const = importlib.util.spec_from_file_location(
+    "custom_components.f1_sensor.const",
+    Path("custom_components/f1_sensor/const.py"),
+)
+const_mod = importlib.util.module_from_spec(spec_const)
+sys.modules["custom_components.f1_sensor.const"] = const_mod
+spec_const.loader.exec_module(const_mod)
+
+spec_entity = importlib.util.spec_from_file_location(
+    "custom_components.f1_sensor.entity",
+    Path("custom_components/f1_sensor/entity.py"),
+)
+entity_mod = importlib.util.module_from_spec(spec_entity)
+sys.modules["custom_components.f1_sensor.entity"] = entity_mod
+spec_entity.loader.exec_module(entity_mod)
+
+spec_helpers = importlib.util.spec_from_file_location(
+    "custom_components.f1_sensor.helpers",
+    Path("custom_components/f1_sensor/helpers.py"),
+)
+helpers_mod = importlib.util.module_from_spec(spec_helpers)
+sys.modules["custom_components.f1_sensor.helpers"] = helpers_mod
+spec_helpers.loader.exec_module(helpers_mod)
+
+spec_sensor = importlib.util.spec_from_file_location(
+    "custom_components.f1_sensor.sensor",
+    Path("custom_components/f1_sensor/sensor.py"),
+)
+sensor = importlib.util.module_from_spec(spec_sensor)
+sys.modules["custom_components.f1_sensor.sensor"] = sensor
+spec_sensor.loader.exec_module(sensor)
+
+F1RaceControlSensor = sensor.F1RaceControlSensor
+F1FlagSensor = sensor.F1FlagSensor
+
+class DummyCoordinator:
+    def __init__(self):
+        self.data = None
+        self.data_list = []
+
+    def async_add_listener(self, cb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_racecontrol_restore_state():
+    restore_state.LAST_STATE = FakeState("15", {"Message": "OK"})
+    coord = DummyCoordinator()
+    ent = F1RaceControlSensor(coord, "rc", "uid", "entry", "F1")
+    await ent.async_added_to_hass()
+    assert ent.state == "15"
+
+
+@pytest.mark.asyncio
+async def test_flag_restore_state():
+    restore_state.LAST_STATE = FakeState(
+        "yellow",
+        {"track_red": False, "vsc_active": False, "active_yellow_sectors": [2]},
+    )
+    coord = DummyCoordinator()
+    ent = F1FlagSensor(coord, "flag", "uid", "entry", "F1")
+    await ent.async_added_to_hass()
+    assert ent.state == "yellow"
+    assert ent.extra_state_attributes["active_yellow_sectors"] == [2]


### PR DESCRIPTION
## Summary
- restore state for race control and flag sensors
- remove fast polling option and implement exponential back-off
- add reconnect constants
- test restored state logic

## Testing
- `pytest -q tests/test_restore_state.py`

------
https://chatgpt.com/codex/tasks/task_e_68697ae8dca883228758802f1501dced