### PR TITLE
Remove fast_poll_seconds & add reconnect backoff

### DIFF
--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -52,7 +52,6 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     }
                 ),
                 vol.Optional("enable_race_control", default=True): cv.boolean,
-                vol.Optional("fast_poll_seconds", default=5): cv.positive_int,
             }
         )
 
@@ -116,9 +115,6 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     "enable_race_control",
                     default=current.get("enable_race_control", True),
                 ): cv.boolean,
-                vol.Optional(
-                    "fast_poll_seconds", default=current.get("fast_poll_seconds", 5)
-                ): cv.positive_int,
             }
         )
 

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -13,3 +13,8 @@ LAST_RACE_RESULTS_URL = "https://api.jolpi.ca/ergast/f1/current/last/results.jso
 SEASON_RESULTS_URL = "https://api.jolpi.ca/ergast/f1/current/results.json?limit=100"
 
 LIVETIMING_INDEX_URL = "https://livetiming.formula1.com/static/{year}/Index.json"
+
+# Reconnection back-off settings for the SignalR client
+FAST_RETRY_SEC = 5
+MAX_RETRY_SEC = 60
+BACK_OFF_FACTOR = 2


### PR DESCRIPTION
## Summary
- remove user option `fast_poll_seconds`
- add reconnect backoff constants
- implement `_ensure_connection` with exponential backoff for SignalR
- update race control coordinator to use new reconnect logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686983689380832281823ac2ed6574be