### PR TITLE
Handle race control sensors better

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -79,7 +79,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         data = hass.data[DOMAIN].pop(entry.entry_id)
         for coordinator in data.values():
-            await coordinator.async_close()
+            if coordinator is not None:
+                await coordinator.async_close()
         hass.data.pop(FLAG_MACHINE, None)
     return unload_ok
 

--- a/custom_components/f1_sensor/binary_sensor.py
+++ b/custom_components/f1_sensor/binary_sensor.py
@@ -29,10 +29,11 @@ async def async_setup_entry(
                 base,
             )
         )
-    if "safety_car" in enabled:
+    coord = data.get("race_control_coordinator")
+    if "safety_car" in enabled and coord:
         sensors.append(
             F1SafetyCarBinarySensor(
-                data.get("race_control_coordinator"),
+                coord,
                 f"{base}_safety_car",
                 f"{entry.entry_id}_safety_car",
                 entry.entry_id,

--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -12,6 +12,12 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
+            if not user_input.get("enable_race_control", True):
+                user_input["enabled_sensors"] = [
+                    s
+                    for s in user_input["enabled_sensors"]
+                    if s not in {"race_control", "flag", "safety_car"}
+                ]
             return self.async_create_entry(
                 title=user_input["sensor_name"], data=user_input
             )
@@ -63,6 +69,12 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
+            if not user_input.get("enable_race_control", True):
+                user_input["enabled_sensors"] = [
+                    s
+                    for s in user_input["enabled_sensors"]
+                    if s not in {"race_control", "flag", "safety_car"}
+                ]
             entry = self._get_reconfigure_entry()
             return self.async_update_reload_and_abort(
                 entry,


### PR DESCRIPTION
## Summary
- prevent calling async_close on None coordinators during unload
- only create the Safety Car sensor when race control is active
- drop race control related sensors when race control is disabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a21b07ac08322bb2a572818641d02