### PR TITLE
Fix Safety Car parsing and flag handling

### DIFF
--- a/tests/fixtures/race_dump_2025_07_06.json
+++ b/tests/fixtures/race_dump_2025_07_06.json
@@ -1,0 +1,8 @@
+[
+  {"category": "Flag", "flag": "YELLOW", "scope": "Sector", "sector": 1},
+  {"category": "Flag", "flag": "CLEAR", "scope": "Sector", "sector": 2},
+  {"category": "SafetyCar", "Mode": "VIRTUAL SAFETY CAR", "Status": "DEPLOYED"},
+  {"category": "SafetyCar", "Mode": "VIRTUAL SAFETY CAR", "Status": "ENDING"},
+  {"category": "Flag", "flag": "GREEN", "scope": "Track"},
+  {"category": "Flag", "flag": "CHEQUERED", "scope": "Track"}
+]


### PR DESCRIPTION
## Summary
- handle list/dict RC payloads when streaming race control
- overhaul flag state logic
- update safety car binary sensor
- add regression tests for flag state and safety car handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767681d2ac8322af99981a04d9f6f8