### PR TITLE
Stabilize flag state handling

### DIFF
--- a/custom_components/f1_sensor/binary_sensor.py
+++ b/custom_components/f1_sensor/binary_sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DOMAIN, FLAG_MACHINE
 from .entity import F1BaseEntity
 
 
@@ -133,30 +133,23 @@ class F1SafetyCarBinarySensor(F1BaseEntity, BinarySensorEntity):
             self._attr_device_class = None
         self._attr_is_on = False
         self._attr_extra_state_attributes = {}
+        self._flag_state = None
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
+        self._flag_state = self.hass.data.get(FLAG_MACHINE)
         self.coordinator.async_add_listener(self._handle_coordinator_update)
-        if self.coordinator.data:
-            self._handle_message(self.coordinator.data)
+        self._update_from_flag_state()
+
+    def _update_from_flag_state(self) -> None:
+        if not self._flag_state:
+            return
+        self._attr_is_on = self._flag_state.vsc_mode is not None
+        self._attr_extra_state_attributes = {"mode": self._flag_state.vsc_mode}
 
     def _handle_coordinator_update(self) -> None:
-        if self.coordinator.data:
-            self._handle_message(self.coordinator.data)
+        self._update_from_flag_state()
         self.async_write_ha_state()
-
-    def _handle_message(self, message: dict) -> None:
-        if message.get("Category") != "SafetyCar" and message.get("category") != "SafetyCar":
-            return
-        status = message.get("Status", "").upper()
-        if "DEPLOYED" in status:
-            self._attr_is_on = True
-            mode = message.get("Mode", "")
-            self._attr_extra_state_attributes["mode"] = (
-                "vsc" if "VIRTUAL" in mode.upper() else "sc"
-            )
-        elif status in ("ENDING", "IN THIS LAP"):
-            self._attr_is_on = False
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/f1_sensor/flag_state.py
+++ b/custom_components/f1_sensor/flag_state.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import asyncio
 
 
 class FlagState:
-    """State machine tracking track flags and safety car status."""
+    """Tracks global flag state with proper priority."""
 
-    def __init__(self) -> None:
-        self.track_flag: str | None = None
-        self.vsc_mode: str | None = None
-        self.active_yellows: set[int] = set()
+    # --- init -------------------------------------------------------
+    def __init__(self):
+        self.track_flag: str | None = None  # green / red / chequered
+        self.vsc_mode: str | None = None  # "VSC" / "SC" / None
+        self.active_yellows: set[int] = set()  # sector-IDs
         self.state = "green"
+        self.last_change: datetime = datetime.now(timezone.utc)
 
-    # --------------------------------------------------
+    # --- private helpers -------------------------------------------
     def _recalculate(self) -> str:
+        """Priority: RED > CHEQUERED > SC/VSC > YELLOW > GREEN"""
         if self.track_flag == "red":
             return "red"
         if self.track_flag == "chequered":
@@ -24,41 +28,59 @@ class FlagState:
             return "yellow"
         return "green"
 
-    # --------------------------------------------------
-    async def apply(self, rc: dict) -> str | None:
+    # --- public API -------------------------------------------------
+    async def apply(self, rc: dict) -> tuple[str | None, dict]:
+        """
+        Update internal status. Return (new_state | None, attributes).
+        Attributes are always returned for convenience.
+        """
         cat = rc["category"]
         scope = rc.get("scope")
         flag = rc.get("flag")
 
-        # SAFETY CAR / VSC -----------------------------------------
+        # SAFETY CAR / VSC ------------------------------------------
         if cat == "SafetyCar":
             status = rc.get("Status", "").upper()
             if "DEPLOYED" in status:
-                self.vsc_mode = rc.get("Mode")
+                self.vsc_mode = rc["Mode"]
             elif status in ("ENDING", "IN THIS LAP"):
                 self.vsc_mode = None
 
-        # TRACK-OMFATTANDE FLAGGOR ---------------------------------
+        # TRACK-WIDE FLAGGORS ---------------------------------------
         elif cat == "Flag" and scope == "Track":
             if flag in ("GREEN", "RED", "CHEQUERED"):
+                # GREEN låser upp chequered och rensar red
                 self.track_flag = flag.lower()
-                self.active_yellows.clear()
-            elif flag == "CLEAR":
-                self.track_flag = None
-                self.active_yellows.clear()
+                # nollställ gulor endast om GREEN eller RED -> GREEN
+                if flag.lower() in ("green", "red"):
+                    self.active_yellows.clear()
 
         # SEKTORFLAGGOR --------------------------------------------
         elif cat == "Flag" and scope == "Sector":
-            sector = rc.get("sector")
-            if flag in ("YELLOW", "DOUBLE YELLOW") and sector is not None:
-                self.active_yellows.add(int(sector))
-            elif flag == "CLEAR" and sector is not None:
-                self.active_yellows.discard(int(sector))
+            sector = rc["sector"]
+            if flag in ("YELLOW", "DOUBLE YELLOW"):
+                self.active_yellows.add(sector)
+            elif flag == "CLEAR":
+                self.active_yellows.discard(sector)
 
+        # --- compute new state ------------------------------------
         new_state = self._recalculate()
+        changed = None
         if new_state != self.state:
-            if {self.state, new_state} == {"green", "yellow"}:
+            # debounce: avoid green<->yellow flip-flop within 0.5 s
+            if {self.state, new_state} <= {"green", "yellow"}:
                 await asyncio.sleep(0.5)
+                new_state2 = self._recalculate()
+                if new_state2 != new_state:
+                    new_state = new_state2
             self.state = new_state
-            return new_state
-        return None
+            self.last_change = datetime.now(timezone.utc)
+            changed = new_state
+
+        attrs = {
+            "active_sectors": sorted(self.active_yellows),
+            "track_flag": self.track_flag,
+            "sc_mode": self.vsc_mode,
+            "last_state_change": self.last_change.isoformat(),
+        }
+        return changed, attrs

--- a/tests/test_flag_safety.py
+++ b/tests/test_flag_safety.py
@@ -215,9 +215,13 @@ async def test_flag_state_apply_sequence():
         },
     ]
     fs = FlagState()
-    assert await fs.apply(msgs[0]) == "red"
+    changed, _ = await fs.apply(msgs[0])
+    assert changed == "red"
     await fs.apply(msgs[1])
-    assert await fs.apply(msgs[2]) == "vsc"
+    changed, _ = await fs.apply(msgs[2])
+    assert changed == "vsc"
     await fs.apply(msgs[3])
-    assert await fs.apply(msgs[4]) == "yellow"
-    assert await fs.apply(msgs[5]) == "green"
+    changed, _ = await fs.apply(msgs[4])
+    assert changed == "yellow"
+    changed, _ = await fs.apply(msgs[5])
+    assert changed == "green"

--- a/tests/test_flag_state.py
+++ b/tests/test_flag_state.py
@@ -34,20 +34,26 @@ async def test_flag_state_sequence(rc_dump):
     fs = FlagState()
 
     # First yellow sector
-    assert await fs.apply(rc_dump[0]) == "yellow"
+    changed, _ = await fs.apply(rc_dump[0])
+    assert changed == "yellow"
 
     # Clear another sector should keep yellow
-    assert await fs.apply(rc_dump[1]) is None
+    changed, _ = await fs.apply(rc_dump[1])
+    assert changed is None
     assert fs.state == "yellow"
 
     # VSC deployment
-    assert await fs.apply(rc_dump[2]) == "vsc"
+    changed, _ = await fs.apply(rc_dump[2])
+    assert changed == "vsc"
 
     # VSC ending - still yellow because sector 1 active
-    assert await fs.apply(rc_dump[3]) == "yellow"
+    changed, _ = await fs.apply(rc_dump[3])
+    assert changed == "yellow"
 
     # Track clear after SC with no yellows -> green
-    assert await fs.apply(rc_dump[4]) == "green"
+    changed, _ = await fs.apply(rc_dump[4])
+    assert changed == "green"
 
     # Chequered flag
-    assert await fs.apply(rc_dump[5]) == "chequered"
+    changed, _ = await fs.apply(rc_dump[5])
+    assert changed == "chequered"


### PR DESCRIPTION
## Summary
- overhaul `FlagState` priority and provide attributes
- ignore startup RC messages older than 30s
- update SignalR client to feed new attributes
- connect Safety Car binary sensor to shared flag state
- adjust tests for new return signature

## Testing
- `pip install -q -r requirements_dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885c6d353b48322a2aae041e3496a7d