### PR TITLE
Fix naive datetime handling in race control

### DIFF
--- a/custom_components/f1_sensor/flag_state.py
+++ b/custom_components/f1_sensor/flag_state.py
@@ -43,6 +43,8 @@ class FlagState:
         utc_raw = rc.get("Utc") or rc.get("utc")
         if utc_raw:
             rc_time = datetime.fromisoformat(str(utc_raw).replace("Z", "+00:00"))
+            if rc_time.tzinfo is None:
+                rc_time = rc_time.replace(tzinfo=timezone.utc)
         else:
             rc_time = datetime.now(timezone.utc)
 

--- a/custom_components/f1_sensor/rc_transform.py
+++ b/custom_components/f1_sensor/rc_transform.py
@@ -48,10 +48,16 @@ SCOPE_MAP = {
 
 
 def _parse_date(raw, t0: dt.datetime) -> str:
-    """Return ISO-8601 oavsett om raw är ms eller ISO-sträng."""
+    """Return ISO-8601 timestamp in UTC regardless of input."""
     if isinstance(raw, (int, float)):
-        return (t0 + dt.timedelta(milliseconds=raw)).isoformat() + "Z"
-    return dparse.parse(raw).isoformat()
+        dt_obj = t0 + dt.timedelta(milliseconds=raw)
+    else:
+        dt_obj = dparse.parse(raw)
+
+    if dt_obj.tzinfo is None:
+        dt_obj = dt_obj.replace(tzinfo=dt.timezone.utc)
+
+    return dt_obj.astimezone(dt.timezone.utc).isoformat()
 
 
 def clean_rc(data, t0: dt.datetime):

--- a/custom_components/f1_sensor/signalr.py
+++ b/custom_components/f1_sensor/signalr.py
@@ -30,7 +30,7 @@ class SignalRClient:
         self._hass = hass
         self._session = session
         self._ws = None
-        self._t0 = dt.datetime.utcnow()
+        self._t0 = dt.datetime.now(dt.timezone.utc)
         self._startup_cutoff = None
 
     async def connect(self) -> None:
@@ -59,7 +59,7 @@ class SignalRClient:
             CONNECT_URL, params=params, headers=headers
         )
         await self._ws.send_json(SUBSCRIBE_MSG)
-        self._t0 = dt.datetime.utcnow()
+        self._t0 = dt.datetime.now(dt.timezone.utc)
         self._startup_cutoff = self._t0 - dt.timedelta(seconds=30)
         _LOGGER.debug("SignalR connection established")
         _LOGGER.debug("Subscribed to RaceControlMessages")
@@ -143,6 +143,8 @@ class SignalRClient:
 
             if self._startup_cutoff:
                 rc_time = dt.datetime.fromisoformat(clean["utc"].replace("Z", "+00:00"))
+                if rc_time.tzinfo is None:
+                    rc_time = rc_time.replace(tzinfo=dt.timezone.utc)
                 if rc_time < self._startup_cutoff:
                     return
 


### PR DESCRIPTION
## Summary
- set startup timestamps to timezone-aware UTC datetime objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688631918c248322b2cd184e31a2a331