### PR TITLE
Minor changes

### DIFF
--- a/examples/blueprint.yaml
+++ b/examples/blueprint.yaml
@@ -22,11 +22,6 @@ blueprint:
 
     After that you can change the status off the `Track state` sensor under [developer tools](https://my.home-assistant.io/redirect/developer_states/).
 
-    ## Blueprint settings
-
-    You can create a optional [helper](https://my.home-assistant.io/redirect/helpers/) that can be switched on or off. This is usefull when you want to enable of disable the blueprint really quick.
-    Yes, it's possible to enable or disable the automation itself but that could be harder to implement on a other automation.
-
     ## Track sensors
 
     This section needs to be filled in to communicate between the lights and the data provided by the add-on. 


### PR DESCRIPTION
Please see:
[Fix for the default session state](https://github.com/Nicxe/f1_sensor/discussions/110#discussioncomment-14590755)
[Fix for the media_player](https://github.com/Nicxe/f1_sensor/discussions/110#discussioncomment-14590689)

The media_player is only checking if it's on, please be sure you're device is showing that kind of state. In a upcoming release i will make it possible to add you're own state as well

Also removed the option to select a helper thats stops the automation from running. Instead use [this](https://www.home-assistant.io/docs/automation/services/) to turn on or off the automation itself