### PR TITLE
Revert "Change image paths to static directory"

### DIFF
--- a/docs/example/custom-card-by.md
+++ b/docs/example/custom-card-by.md
@@ -48,7 +48,7 @@ In the same folder, I created another file, myfont.css, with the following conte
 I went to **Settings \-\> Dashboards \-\> Resources** (located in the More menu of Dashboards, the 3 vertical dots) and added a new resource of type **Stylesheet**, pointing to (URL) **/local/fonts/myfont.css**
 
 
-![Resources fonts](/static/img/dashboard_resources_fonts.png)
+![Resources fonts](/img/dashboard_resources_fonts.png)
 
 At this point, an **Empty Cache and Hard reload** might be required (as I said, I had many trials and errors, involving even restarts of HA, so try the Empty Cache and Hard reload, as it does not hurt).
 
@@ -125,7 +125,7 @@ Here are the codes.
 
 ### Drivers Standings card
 
-![Drivers standings](/static/img/Drivers_standings_card.png)
+![Drivers standings](/img/Drivers_standings_card.png)
 
 ```yaml
 type: custom:button-card
@@ -393,7 +393,7 @@ custom_fields:
 
 ### Constructors Standings card
 
-![Constructors standings](/static/img/constructors_standings_card.png)
+![Constructors standings](/img/constructors_standings_card.png)
 
 ```yaml
 type: custom:button-card


### PR DESCRIPTION
Reverts Nicxe/f1_sensor#197


```
Error:  Client bundle compiled with errors therefore further build is impossible.
Error: MDX compilation failed for file "/home/runner/work/f1_sensor/f1_sensor/docs/example/custom-card-by.md"
Cause: Markdown image with URL `/static/img/dashboard_resources_fonts.png` in source file "docs/example/custom-card-by.md" (51:1) couldn't be resolved to an existing local image file.
To ignore this error, use the `siteConfig.markdown.hooks.onBrokenMarkdownImages` option, or apply the `pathname://` protocol to the broken image URLs.
Details:
Error: Markdown image with URL `/static/img/dashboard_resources_fonts.png` in source file "docs/example/custom-card-by.md" (51:1) couldn't be resolved to an existing local image file.
To ignore this error, use the `siteConfig.markdown.hooks.onBrokenMarkdownImages` option, or apply the `pathname://` protocol to the broken image URLs.
    at async Promise.all (index 0)
Error: Process completed with exit code 1.
```