### PR TITLE
fix: **Keep live timing active when the primary session index is outd…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ custom_components/f1_sensor/AGENTS.md
 custom_components/f1_sensor/CLAUDE.md
 /custom_components/f1_sensor/skills
 /custom_components/f1_sensor/tests
+/scripts
+pytest.ini


### PR DESCRIPTION
…ated**

When the primary live schedule index is behind and does not include a newly started session, the integration now checks a secondary schedule source instead of staying idle. This allows live timing to connect during active sessions even when index updates are delayed. Session status parsing was also hardened for streamed responses, reducing false negatives that could otherwise stop live detection.