### PR TITLE
fix: **Keep current session synchronized with live session statu…

### DIFF
--- a/custom_components/f1_sensor/translations/sv.json
+++ b/custom_components/f1_sensor/translations/sv.json
@@ -145,7 +145,6 @@
                     "low_grip": "Lågt grepp",
                     "disabled": "Inaktiverat"
                 }
- 
             },
             "track_status": {
                 "name": "Banstatus"


### PR DESCRIPTION
…s during temporary interruptions**

Current session now remains in sync with live session status when timing briefly reports interruption-like states before the session is truly over. This prevents the session label from dropping to unknown while live status still indicates active running conditions. The fix makes dashboards and automations more reliable around session start and short control interruptions without changing end-of-session behavior.

Fixes #292