### PR TITLE
chore: Add ruff checks, auto-labeler, conflict detection, and improved PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,70 @@
 <!--
-  IMPORTANT: Make sure your PR targets the `dev` branch.
+  IMPORTANT: Your PR must target the `dev` branch.
   PRs targeting `main` or `beta` are closed automatically.
-  See CONTRIBUTING.md for the branch model.
+  If you are unsure whether your change fits the project direction, open an issue first.
 -->
 
 ## What does this PR do?
 
-<!-- A short description of the change and the motivation behind it. -->
+<!-- Describe what this PR changes and why. Be specific — what behavior changes, what was broken, what is new. -->
+
+## Type of change
+
+<!-- Check all that apply -->
+
+- [ ] Bug fix (corrects existing behavior without breaking anything)
+- [ ] New feature (adds functionality to the integration)
+- [ ] Breaking change (existing automations, entities, or config options will stop working or behave differently)
+- [ ] Blueprint (new or updated blueprint)
+- [ ] Documentation only (no code changes)
+- [ ] Refactoring or internal cleanup (no user-visible changes)
+- [ ] Dependency update
+
+## What area does this affect?
+
+<!-- Check all that apply -->
+
+- [ ] Integration core (data fetching, coordinator, SignalR, API)
+- [ ] Sensor entities
+- [ ] Binary sensors, buttons, selects, switches, or other platforms
+- [ ] Configuration flow or options
+- [ ] Live delay / calibration
+- [ ] Replay mode
+- [ ] Blueprint
+- [ ] Documentation
+- [ ] Tests
+- [ ] CI / release pipeline
+
+## Have you tested this?
+
+<!-- Describe how you tested the change. Be specific. -->
+
+- [ ] Tested locally with a real Home Assistant instance
+- [ ] Tested with replay mode (if applicable)
+- [ ] Verified that existing automations or dashboards still work as expected after the change
 
 ## Checklist
 
 - [ ] My PR targets the `dev` branch
-- [ ] I have tested the changes locally
 - [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] The code has no commented-out blocks left behind
+- [ ] Code is formatted with Ruff (`ruff format custom_components`)
+- [ ] Code passes Ruff lint check (`ruff check custom_components`)
+- [ ] Tests have been added or updated to cover the change
+- [ ] All tests pass locally (`pytest custom_components/f1_sensor/tests`)
+- [ ] Hassfest validation passes (`python3 -m script.hassfest`)
+- [ ] Translations updated if new config options or UI strings were added
+- [ ] This PR has no merge conflicts with `dev`
+
+If this PR changes user-facing behavior, entities, or configuration:
+
+- [ ] I have noted what users need to update or be aware of in the PR description above
+
+If this PR adds or changes a blueprint:
+
+- [ ] The blueprint has been imported and tested in Home Assistant
+- [ ] Triggers and conditions work as expected in a live environment
+
+If this is a breaking change:
+
+- [ ] I have clearly described in the PR description what will break and what users need to do to adapt

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,38 @@
+integration:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "custom_components/f1_sensor/*.py"
+          - "custom_components/f1_sensor/translations/**"
+          - "custom_components/f1_sensor/manifest.json"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "custom_components/f1_sensor/tests/**"
+
+blueprint:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "blueprints/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "*.md"
+          - ".github/*.md"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "custom_components/f1_sensor/manifest.json"
+          - "package.json"
+          - "package-lock.json"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/dependabot.yml"
+          - "pyproject.toml"
+          - "pytest.ini"

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -1,0 +1,27 @@
+name: Conflict check
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  conflict:
+    name: Check for merge conflicts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "has-conflicts"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          commentOnDirty: |
+            This PR has merge conflicts with the `dev` branch and cannot be merged until they are resolved.
+
+            Please rebase or merge `dev` into your branch and resolve the conflicts locally, then push the updated branch.
+          commentOnClean: |
+            Merge conflicts have been resolved. Thank you!

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  labeler:
+    name: Apply labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,31 @@
+name: Ruff
+
+on:
+  pull_request:
+    paths:
+      - "custom_components/**/*.py"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    name: Lint & format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ruff lint
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check custom_components"
+
+      - name: Ruff format check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check custom_components"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "C4"]
+ignore = [
+  "E501",  # line too long — handled by formatter
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+combine-as-imports = true


### PR DESCRIPTION
## Summary

- Adds `ruff.yml` workflow that runs `ruff check` and `ruff format --check` automatically on every PR push targeting Python files
- Adds `pyproject.toml` with shared ruff configuration (Python 3.13, line length 88) so contributors and CI use identical settings
- Adds `labeler.yml` config and workflow to auto-label PRs based on changed file paths (`integration`, `tests`, `blueprint`, `documentation`, `dependencies`, `ci`)
- Adds `conflict-check.yml` workflow that detects merge conflicts, labels the PR with `has-conflicts`, posts a comment with resolution instructions, and removes the label once resolved
- Updates PR template with ruff format/lint checkboxes and a merge conflict confirmation item

## Notes

The following labels must exist in the repository for the auto-labeler to work:
`integration`, `tests`, `blueprint`, `documentation`, `dependencies`, `ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)