### PR TITLE
fix: prevent semantic-release success step from failing

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,7 +1,16 @@
-module.exports = require("@nicxe/semantic-release-config")({
+const config = require("@nicxe/semantic-release-config")({
   componentDir: "custom_components/f1_sensor",
   manifestPath: "custom_components/f1_sensor/manifest.json",
   projectName: "F1 Sensor",
   repoSlug: "Nicxe/f1_sensor"
 });
 
+const githubPlugin = config.plugins.find(
+  (plugin) => Array.isArray(plugin) && plugin[0] === "@semantic-release/github"
+);
+
+if (githubPlugin?.[1]) {
+  githubPlugin[1].successCommentCondition = false;
+}
+
+module.exports = config;


### PR DESCRIPTION
This updates the release configuration to disable GitHub success-comment processing that can fail on stale pull request associations. The change keeps release publishing behavior intact while avoiding the 404 crash in the success step.