### PR TITLE
docs: Update for 4.0 fix entities names

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -90,8 +90,8 @@ action:
     data:
       title: "Formula 1"
       message: >
-        Race week is here! Next up: {{ state_attr('sensor.f1_race_next_race', 'race_name') }}
-        at {{ state_attr('sensor.f1_race_next_race', 'circuit_name') }}.
+        Race week is here! Next up: {{ state_attr('sensor.f1_next_race', 'race_name') }}
+        at {{ state_attr('sensor.f1_next_race', 'circuit_name') }}.
 mode: single
 ```
 
@@ -107,7 +107,7 @@ description: Send a reminder 30 minutes before any F1 session
 trigger:
   - platform: calendar
     event: start
-    entity_id: calendar.f1_season
+    entity_id: calendar.f1_race_season_calendar
     offset: "-0:30:0"
 condition: []
 action:
@@ -133,7 +133,7 @@ alias: F1 - Session is live
 description: Trigger when a session goes live
 trigger:
   - platform: state
-    entity_id: sensor.f1_session_session_status
+    entity_id: sensor.f1_session_status
     to: "live"
 condition: []
 action:
@@ -141,8 +141,8 @@ action:
     data:
       title: "F1 is live"
       message: >
-        {{ state_attr('sensor.f1_session_session_status', 'session_name') }} at
-        {{ state_attr('sensor.f1_session_session_status', 'meeting_name') }} has started.
+        {{ state_attr('sensor.f1_session_status', 'session_name') }} at
+        {{ state_attr('sensor.f1_session_status', 'meeting_name') }} has started.
 mode: single
 ```
 
@@ -157,7 +157,7 @@ alias: F1 - Formation lap started
 description: Notify when the formation lap begins
 trigger:
   - platform: state
-    entity_id: binary_sensor.f1_session_formation_start
+    entity_id: binary_sensor.f1_formation_start
     to: "on"
 condition: []
 action:

--- a/docs/cards/overview.md
+++ b/docs/cards/overview.md
@@ -104,7 +104,7 @@ Displays an at-a-glance overview of the current session: session name and status
 
 ![Placeholder — F1 Live Session card screenshot](/img/placeholder_card_live_session.png)
 
-**Required entities:** `sensor.f1_session_current_session`, `sensor.f1_session_session_status`, `binary_sensor.f1_session_formation_start`, `sensor.f1_session_race_lap_count`, `sensor.f1_session_track_status`, `sensor.f1_session_track_weather`, `sensor.f1_race_next_race`
+**Required entities:** `sensor.f1_current_session`, `sensor.f1_session_status`, `binary_sensor.f1_formation_start`, `sensor.f1_race_lap_count`, `sensor.f1_track_status`, `sensor.f1_track_weather`, `sensor.f1_next_race`
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -123,7 +123,7 @@ Shows the latest race control message with flag type and category. Automatically
 
 ![Placeholder — F1 Race Control card screenshot](/img/placeholder_card_race_control.png)
 
-**Required entity:** `sensor.f1_officials_race_control`
+**Required entity:** `sensor.f1_race_control`
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -140,7 +140,7 @@ Displays the current tyre compound for each driver along with stint history and 
 
 ![Placeholder — F1 Tyre Statistics card screenshot](/img/placeholder_card_tyres.png)
 
-**Required entities:** `sensor.f1_drivers_tyre_statistics`, `sensor.f1_drivers_driver_list`
+**Required entities:** `sensor.f1_tyre_statistics`, `sensor.f1_driver_list`
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -163,7 +163,7 @@ Shows a full pit stop history for all drivers: stop number, tyre fitted, pit tim
 
 ![Placeholder — F1 Pit Stop Overview card screenshot](/img/placeholder_card_pitstops.png)
 
-**Required entities:** `sensor.f1_drivers_pit_stops`, `sensor.f1_drivers_current_tyres`, `sensor.f1_drivers_driver_positions`, `sensor.f1_drivers_driver_list`
+**Required entities:** `sensor.f1_pitstops`, `sensor.f1_current_tyres`, `sensor.f1_driver_positions`, `sensor.f1_driver_list`
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -188,7 +188,7 @@ Displays the current race order with each driver's last lap time, current status
 
 ![Placeholder — F1 Driver Lap Times card screenshot](/img/placeholder_card_lap_times.png)
 
-**Required entities:** `sensor.f1_drivers_driver_positions`, `sensor.f1_drivers_driver_list`
+**Required entities:** `sensor.f1_driver_positions`, `sensor.f1_driver_list`
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -209,7 +209,7 @@ Lists all steward investigations and their outcomes for the current session. Sho
 
 ![Placeholder — F1 Investigations card screenshot](/img/placeholder_card_investigations.png)
 
-**Required entities:** `sensor.f1_officials_investigations_penalties`, `sensor.f1_drivers_driver_list`, `sensor.f1_drivers_driver_positions`
+**Required entities:** `sensor.f1_investigations`, `sensor.f1_driver_list`, `sensor.f1_driver_positions`
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -227,7 +227,7 @@ Shows how many track limit violations each driver has accumulated during the ses
 
 ![Placeholder — F1 Track Limits card screenshot](/img/placeholder_card_track_limits.png)
 
-**Required entities:** `sensor.f1_officials_track_limits`, `sensor.f1_drivers_driver_list`, `sensor.f1_drivers_driver_positions`
+**Required entities:** `sensor.f1_track_limits`, `sensor.f1_driver_list`, `sensor.f1_driver_positions`
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -245,7 +245,7 @@ Displays the driver championship standings with predicted final points alongside
 
 ![Placeholder — F1 Championship Prediction Drivers card screenshot](/img/placeholder_card_prediction_drivers.png)
 
-**Required entities:** `sensor.f1_championship_championship_prediction_drivers`, `sensor.f1_drivers_driver_list`
+**Required entities:** `sensor.f1_championship_prediction_drivers`, `sensor.f1_driver_list`
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -268,7 +268,7 @@ Displays the constructor championship standings with predicted final points and 
 
 ![Placeholder — F1 Championship Prediction Teams card screenshot](/img/placeholder_card_prediction_teams.png)
 
-**Required entity:** `sensor.f1_championship_championship_prediction_teams`
+**Required entity:** `sensor.f1_championship_prediction_teams`
 
 | Option | Default | Description |
 | --- | --- | --- |

--- a/docs/entities/live_data.md
+++ b/docs/entities/live_data.md
@@ -115,27 +115,27 @@ Use this section to understand the possible values for enum-type states and attr
 
 | Entity                                                | Info                                                                                                                 |  
 | --------                                              | --------                                                                                                              |  
-| [sensor.f1_session_session_status](#session-status)           | Current session phase|
-| [sensor.f1_session_current_session](#current-session)         | Current ongoing session, like Practice 1, Qualification, Race|
-| [sensor.f1_session_session_time_elapsed](#session-time-elapsed) | Time elapsed in the current session `(beta)` |
-| [sensor.f1_session_session_time_remaining](#session-time-remaining) | Time remaining in the current session `(beta)` |
-| [sensor.f1_session_track_status](#track-status)               | Current track status |
+| [sensor.f1_session_status](#session-status)           | Current session phase|
+| [sensor.f1_current_session](#current-session)         | Current ongoing session, like Practice 1, Qualification, Race|
+| [sensor.f1_session_time_elapsed](#session-time-elapsed) | Time elapsed in the current session `(beta)` |
+| [sensor.f1_session_time_remaining](#session-time-remaining) | Time remaining in the current session `(beta)` |
+| [sensor.f1_track_status](#track-status)               | Current track status |
 | [binary_sensor.f1_safety_car](#safety-car)            | Safety Car (SC) or Virtual Safety Car (VSC) is active|  
-| [sensor.f1_session_race_lap_count](#race-lap)                 | Current race lap number|
-| [sensor.f1_session_track_weather](#track-weather)             | Current on-track weather (air temp, track temp, rainfall, wind speed, etc.)|
-| [sensor.f1_drivers_driver_list](#driver-list)                 | Show list and details on all drivers, including team color, headshot URL etc| 
-| [sensor.f1_drivers_pit_stops](#pit-stops)                      | Live pit stop events and aggregated pit stop series per car |
+| [sensor.f1_race_lap_count](#race-lap)                 | Current race lap number|
+| [sensor.f1_track_weather](#track-weather)             | Current on-track weather (air temp, track temp, rainfall, wind speed, etc.)|
+| [sensor.f1_driver_list](#driver-list)                 | Show list and details on all drivers, including team color, headshot URL etc| 
+| [sensor.f1_pitstops](#pit-stops)                      | Live pit stop events and aggregated pit stop series per car |
 | [sensor.f1_team_radio](#team-radio)                   | Latest team radio message and rolling history |
-| [sensor.f1_drivers_current_tyres](#current-tyres)             | Current tyre compound per driver |
-| [sensor.f1_drivers_tyre_statistics](#tyre-statistics)         | Aggregated tyre statistics per compound |
-| [sensor.f1_drivers_driver_positions](#driver-positions)       | Driver positions and lap times |
+| [sensor.f1_current_tyres](#current-tyres)             | Current tyre compound per driver |
+| [sensor.f1_tyre_statistics](#tyre-statistics)         | Aggregated tyre statistics per compound |
+| [sensor.f1_driver_positions](#driver-positions)       | Driver positions and lap times |
 | [sensor.f1_top_three_p1](#top-three)                  | Dedicated sensors for current P1, P2 and P3 |
-| [sensor.f1_officials_race_control](#race-control)               | Race Control messages feed (flags, incidents, key updates) |
-| [sensor.f1_officials_track_limits](#track-limits)               | Track limits violations per driver (deletions, warnings, penalties) |
-| [sensor.f1_officials_investigations_penalties](#investigations)           | Active steward investigations and pending penalties |
-| [binary_sensor.f1_session_formation_start](#formation-start)  | Indicates when formation start procedure is ready |
-| [sensor.f1_championship_championship_prediction_drivers](#championship-prediction-drivers) | Drivers championship prediction (P1 and list) |
-| [sensor.f1_championship_championship_prediction_teams](#championship-prediction-teams)| Constructors championship prediction (P1 and list) |
+| [sensor.f1_race_control](#race-control)               | Race Control messages feed (flags, incidents, key updates) |
+| [sensor.f1_track_limits](#track-limits)               | Track limits violations per driver (deletions, warnings, penalties) |
+| [sensor.f1_investigations](#investigations)           | Active steward investigations and pending penalties |
+| [binary_sensor.f1_formation_start](#formation-start)  | Indicates when formation start procedure is ready |
+| [sensor.f1_championship_prediction_drivers](#championship-prediction-drivers) | Drivers championship prediction (P1 and list) |
+| [sensor.f1_championship_prediction_teams](#championship-prediction-teams)| Constructors championship prediction (P1 and list) |
 | [binary_sensor.f1_overtake_mode](#overtake-mode)      | ON when track-wide overtake mode is enabled (2026 regulation, experimental) |
 | [sensor.f1_straight_mode](#straight-mode)             | Active aerodynamic straight mode state (2026 regulation, experimental) |
 
@@ -179,7 +179,7 @@ After finalised or ended, logic resets and next session begins at **pre**.
 ---
 
 ## Current Session
-Human-readable label for the active session. Only shows a state when `sensor.f1_session_session_status` is `live`
+Human-readable label for the active session. Only shows a state when `sensor.f1_session_status` is `live`
 
 **State (enum/string)**
 - `Practice 1`, `Practice 2`, `Practice 3`, `Qualifying`, `Sprint Qualifying`, `Sprint`, `Race`, or `unknown` when inactive (e.g., outside live/eligible windows).
@@ -217,7 +217,7 @@ Qualifying
 This sensor is currently in beta. The behavior has not been verified across all session types, edge cases (red flags, suspensions, qualifying segments), and timing scenarios. Treat the values as indicative rather than definitive until further testing is complete.
 :::
 
-`sensor.f1_session_session_time_elapsed` - How much of the scheduled session time has passed, based on the F1 ExtrapolatedClock feed. The clock advances in real time while a session is running and pauses during interruptions such as red flags or safety car delays.
+`sensor.f1_session_time_elapsed` - How much of the scheduled session time has passed, based on the F1 ExtrapolatedClock feed. The clock advances in real time while a session is running and pauses during interruptions such as red flags or safety car delays.
 
 **State**
 - String: elapsed time formatted as `H:MM:SS` (e.g., `0:23:45`), or `unavailable` when no data is available.
@@ -263,7 +263,7 @@ This sensor is currently in beta. The behavior has not been verified across all 
 This sensor is currently in beta. The behavior has not been verified across all session types, edge cases (red flags, suspensions, qualifying segments), and timing scenarios. Treat the values as indicative rather than definitive until further testing is complete.
 :::
 
-`sensor.f1_session_session_time_remaining` - How much scheduled session time is left, based on the F1 ExtrapolatedClock feed. Like the elapsed sensor, this clock pauses during interruptions and resumes when the session restarts.
+`sensor.f1_session_time_remaining` - How much scheduled session time is left, based on the F1 ExtrapolatedClock feed. Like the elapsed sensor, this clock pauses during interruptions and resumes when the session restarts.
 
 **State**
 - String: remaining time formatted as `H:MM:SS` (e.g., `0:36:15`), or `unavailable` when no data is available.
@@ -292,7 +292,7 @@ This sensor is currently in beta. The behavior has not been verified across all 
 | clock_total_s | number | Total scheduled session duration in seconds, when known |
 
 :::info Session clock behavior
-The session clock counts down the scheduled duration of the session. It does not account for race laps — in a race, the session ends when the leader completes the required number of laps, which may happen before or (rarely) after the scheduled time expires. Use `sensor.f1_session_race_lap_count` for lap-based progress.
+The session clock counts down the scheduled duration of the session. It does not account for race laps — in a race, the session ends when the leader completes the required number of laps, which may happen before or (rarely) after the scheduled time expires. Use `sensor.f1_race_lap_count` for lap-based progress.
 :::
 
 ---
@@ -474,7 +474,7 @@ Each entry in `drivers` contains:
 
 **Get a driver's headshot URL:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_list', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_list', 'drivers') %}
 {% set ver = drivers | selectattr('tla', 'eq', 'VER') | first %}
 {% if ver %}
   {{ ver.headshot_large }}
@@ -483,7 +483,7 @@ Each entry in `drivers` contains:
 
 **Get team color for styling:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_list', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_list', 'drivers') %}
 {% set driver = drivers | selectattr('racing_number', 'eq', '44') | first %}
 {% if driver %}
   background-color: {{ driver.team_color }};
@@ -492,7 +492,7 @@ Each entry in `drivers` contains:
 
 **List all drivers for a team:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_list', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_list', 'drivers') %}
 {% for d in drivers if d.team == 'Ferrari' %}
   {{ d.name }} (#{{ d.racing_number }})
 {% endfor %}
@@ -500,14 +500,14 @@ Each entry in `drivers` contains:
 
 **Create a driver lookup by TLA:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_list', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_list', 'drivers') %}
 {% set lookup = dict.from_keys(drivers | map(attribute='tla') | list, drivers) %}
 {{ lookup.VER.name }} drives for {{ lookup.VER.team }}
 ```
 
 **Generate image elements for all drivers:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_list', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_list', 'drivers') %}
 {% for d in drivers %}
   <img src="{{ d.headshot_small }}" alt="{{ d.name }}" style="border: 2px solid {{ d.team_color }}">
 {% endfor %}
@@ -523,7 +523,7 @@ The headshot URLs are provided by F1 and may change between sessions. This senso
 
 ## Pit Stops
 
-`sensor.f1_drivers_pit_stops` - Live pit stop information from the F1 Live Timing feed, aggregated per car.
+`sensor.f1_pitstops` - Live pit stop information from the F1 Live Timing feed, aggregated per car.
 
 **State**
 - Integer: total number of pit stops recorded in the current session, or `0` when none are available.
@@ -679,7 +679,7 @@ Each entry in `drivers` contains:
 
 **Get a driver's current tyre:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_current_tyres', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_current_tyres', 'drivers') %}
 {% set ver = drivers | selectattr('tla', 'eq', 'VER') | first %}
 {% if ver %}
   VER on {{ ver.compound }} ({{ ver.stint_laps }} laps{% if ver.new %}, NEW{% endif %})
@@ -688,7 +688,7 @@ Each entry in `drivers` contains:
 
 **Count drivers on each compound:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_current_tyres', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_current_tyres', 'drivers') %}
 {% if drivers %}
   SOFT: {{ drivers | selectattr('compound', 'eq', 'SOFT') | list | length }}
   MEDIUM: {{ drivers | selectattr('compound', 'eq', 'MEDIUM') | list | length }}
@@ -698,7 +698,7 @@ Each entry in `drivers` contains:
 
 **List drivers on fresh tyres:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_current_tyres', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_current_tyres', 'drivers') %}
 {% for d in drivers if d.new %}
   {{ d.tla }} - fresh {{ d.compound }}
 {% endfor %}
@@ -706,7 +706,7 @@ Each entry in `drivers` contains:
 
 **Find driver with most laps on current stint:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_current_tyres', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_current_tyres', 'drivers') %}
 {% if drivers %}
   {% set longest = drivers | sort(attribute='stint_laps', reverse=true) | first %}
   {{ longest.tla }} has {{ longest.stint_laps }} laps on {{ longest.compound }}
@@ -715,7 +715,7 @@ Each entry in `drivers` contains:
 
 **Create a tyre summary with colors:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_current_tyres', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_current_tyres', 'drivers') %}
 {% for d in drivers | sort(attribute='position') %}
   P{{ d.position }} {{ d.tla }}: {{ d.compound_short }} ({{ d.stint_laps }} laps)
 {% endfor %}
@@ -727,7 +727,7 @@ Each entry in `drivers` contains:
 
 ## Tyre Statistics
 
-`sensor.f1_drivers_tyre_statistics` - Aggregated tyre performance statistics per compound, showing fastest times and usage across all drivers.
+`sensor.f1_tyre_statistics` - Aggregated tyre performance statistics per compound, showing fastest times and usage across all drivers.
 
 **State**
 - String: name of the fastest compound (e.g., "SOFT"), or `unknown` when not available.
@@ -831,12 +831,12 @@ Each entry in `start_compounds` contains:
 
 **Get the fastest compound:**
 ```jinja2
-Fastest compound: {{ states('sensor.f1_drivers_tyre_statistics') }}
+Fastest compound: {{ states('sensor.f1_tyre_statistics') }}
 ```
 
 **Get fastest time on a specific compound:**
 ```jinja2
-{% set compounds = state_attr('sensor.f1_drivers_tyre_statistics', 'compounds') %}
+{% set compounds = state_attr('sensor.f1_tyre_statistics', 'compounds') %}
 {% if compounds and compounds.SOFT %}
   {% set best = compounds.SOFT.best_times | first %}
   Fastest on SOFT: {{ best.time }} by {{ best.tla }}
@@ -845,7 +845,7 @@ Fastest compound: {{ states('sensor.f1_drivers_tyre_statistics') }}
 
 **Show delta between compounds:**
 ```jinja2
-{% set deltas = state_attr('sensor.f1_drivers_tyre_statistics', 'deltas') %}
+{% set deltas = state_attr('sensor.f1_tyre_statistics', 'deltas') %}
 {% if deltas %}
   MEDIUM vs SOFT: {{ deltas.MEDIUM | default('N/A') }}
   HARD vs SOFT: {{ deltas.HARD | default('N/A') }}
@@ -854,7 +854,7 @@ Fastest compound: {{ states('sensor.f1_drivers_tyre_statistics') }}
 
 **Count drivers who started on each compound:**
 ```jinja2
-{% set starts = state_attr('sensor.f1_drivers_tyre_statistics', 'start_compounds') %}
+{% set starts = state_attr('sensor.f1_tyre_statistics', 'start_compounds') %}
 {% if starts %}
   {% set mediums = starts | selectattr('compound', 'eq', 'MEDIUM') | list | length %}
   {% set hards = starts | selectattr('compound', 'eq', 'HARD') | list | length %}
@@ -865,7 +865,7 @@ Fastest compound: {{ states('sensor.f1_drivers_tyre_statistics') }}
 
 **Get total laps on all compounds:**
 ```jinja2
-{% set compounds = state_attr('sensor.f1_drivers_tyre_statistics', 'compounds') %}
+{% set compounds = state_attr('sensor.f1_tyre_statistics', 'compounds') %}
 {% if compounds %}
   {% set total = namespace(laps=0) %}
   {% for name, data in compounds.items() %}
@@ -885,7 +885,7 @@ Use the `compound_color` field to style your dashboard elements. The colors matc
 
 ## Driver Positions
 
-`sensor.f1_drivers_driver_positions` - Live driver positions and lap-by-lap timing data for all drivers in the session.
+`sensor.f1_driver_positions` - Live driver positions and lap-by-lap timing data for all drivers in the session.
 
 **State**
 - Integer: current lap number (leader's lap), or `unknown` when not available.
@@ -1002,7 +1002,7 @@ Each entry in `drivers` contains:
 
 **Get the race leader:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_positions', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_positions', 'drivers') %}
 {% if drivers %}
   {% set leader = drivers | selectattr('current_position', 'eq', '1') | first %}
   {% if leader %}
@@ -1013,7 +1013,7 @@ Each entry in `drivers` contains:
 
 **Get a specific driver by number:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_positions', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_positions', 'drivers') %}
 {% set driver = drivers | selectattr('racing_number', 'eq', '44') | first %}
 {% if driver %}
   {{ driver.name }} is in P{{ driver.current_position }}
@@ -1022,7 +1022,7 @@ Each entry in `drivers` contains:
 
 **Get driver's last lap time:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_positions', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_positions', 'drivers') %}
 {% set driver = drivers | selectattr('racing_number', 'eq', '1') | first %}
 {% if driver and driver.laps %}
   {% set last_lap = driver.completed_laps | string %}
@@ -1032,7 +1032,7 @@ Each entry in `drivers` contains:
 
 **List all drivers in pit lane:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_positions', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_positions', 'drivers') %}
 {% for d in drivers if d.status == 'pit_in' %}
   {{ d.tla }} is in the pits
 {% endfor %}
@@ -1040,8 +1040,8 @@ Each entry in `drivers` contains:
 
 **Show race progress:**
 ```jinja2
-{% set current = states('sensor.f1_drivers_driver_positions') %}
-{% set total = state_attr('sensor.f1_drivers_driver_positions', 'total_laps') %}
+{% set current = states('sensor.f1_driver_positions') %}
+{% set total = state_attr('sensor.f1_driver_positions', 'total_laps') %}
 {% if current != 'unknown' and total %}
   Lap {{ current }} of {{ total }}
 {% endif %}
@@ -1049,7 +1049,7 @@ Each entry in `drivers` contains:
 
 **Get position changes from grid:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_drivers_driver_positions', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_driver_positions', 'drivers') %}
 {% for d in drivers %}
   {% set change = d.grid_position | int - d.current_position | int %}
   {{ d.tla }}: {% if change > 0 %}+{% endif %}{{ change }}
@@ -1134,7 +1134,7 @@ YELLOW FLAG IN TURN 4
 
 ## Track Limits
 
-`sensor.f1_officials_track_limits` - Aggregated track limits violations per driver, including deleted lap times, black and white flag warnings, and penalties.
+`sensor.f1_track_limits` - Aggregated track limits violations per driver, including deleted lap times, black and white flag warnings, and penalties.
 
 **State**
 - Integer: total number of track limit violations (deletions + warnings) in this session.
@@ -1232,7 +1232,7 @@ Each entry in `violations` contains:
 
 **Get a driver's track limits count:**
 ```jinja2
-{% set by_driver = state_attr('sensor.f1_officials_track_limits', 'by_driver') %}
+{% set by_driver = state_attr('sensor.f1_track_limits', 'by_driver') %}
 {% set ham = by_driver.get('HAM') %}
 {% if ham %}
   HAM: {{ ham.deletions }} deletions{% if ham.warning %}, WARNING{% endif %}
@@ -1241,7 +1241,7 @@ Each entry in `violations` contains:
 
 **List drivers with warnings:**
 ```jinja2
-{% set by_driver = state_attr('sensor.f1_officials_track_limits', 'by_driver') %}
+{% set by_driver = state_attr('sensor.f1_track_limits', 'by_driver') %}
 {% for tla, data in by_driver.items() if data.warning %}
   {{ tla }} (#{{ data.racing_number }}) - {{ data.deletions }} deletions
 {% endfor %}
@@ -1249,7 +1249,7 @@ Each entry in `violations` contains:
 
 **Find drivers at risk (3+ deletions, no warning yet):**
 ```jinja2
-{% set by_driver = state_attr('sensor.f1_officials_track_limits', 'by_driver') %}
+{% set by_driver = state_attr('sensor.f1_track_limits', 'by_driver') %}
 {% for tla, data in by_driver.items() if data.deletions >= 3 and not data.warning %}
   {{ tla }}: {{ data.deletions }} deletions - at risk!
 {% endfor %}
@@ -1257,15 +1257,15 @@ Each entry in `violations` contains:
 
 **Get total session track limits:**
 ```jinja2
-{% set deletions = state_attr('sensor.f1_officials_track_limits', 'total_deletions') %}
-{% set warnings = state_attr('sensor.f1_officials_track_limits', 'total_warnings') %}
-{% set penalties = state_attr('sensor.f1_officials_track_limits', 'total_penalties') %}
+{% set deletions = state_attr('sensor.f1_track_limits', 'total_deletions') %}
+{% set warnings = state_attr('sensor.f1_track_limits', 'total_warnings') %}
+{% set penalties = state_attr('sensor.f1_track_limits', 'total_penalties') %}
 Deletions: {{ deletions }}, Warnings: {{ warnings }}, Penalties: {{ penalties }}
 ```
 
 **List drivers with penalties:**
 ```jinja2
-{% set by_driver = state_attr('sensor.f1_officials_track_limits', 'by_driver') %}
+{% set by_driver = state_attr('sensor.f1_track_limits', 'by_driver') %}
 {% for tla, data in by_driver.items() if data.penalty %}
   {{ tla }}: {{ data.penalty }}
 {% endfor %}
@@ -1281,7 +1281,7 @@ The typical track limits progression is: 3 deleted lap times → BLACK AND WHITE
 
 ## Investigations
 
-`sensor.f1_officials_investigations_penalties` - Active steward investigations and pending penalties. Shows only currently relevant information with automatic lifecycle management.
+`sensor.f1_investigations` - Active steward investigations and pending penalties. Shows only currently relevant information with automatic lifecycle management.
 
 **State**
 - Integer: count of actionable items (noted incidents + under investigation + pending penalties).
@@ -1396,7 +1396,7 @@ Each entry in `penalties` contains:
 
 **Check if a driver is under investigation:**
 ```jinja2
-{% set investigations = state_attr('sensor.f1_officials_investigations_penalties', 'under_investigation') %}
+{% set investigations = state_attr('sensor.f1_investigations', 'under_investigation') %}
 {% set ver_involved = investigations | selectattr('drivers', 'contains', 'VER') | list %}
 {% if ver_involved | length > 0 %}
   VER is under investigation!
@@ -1405,7 +1405,7 @@ Each entry in `penalties` contains:
 
 **List all pending penalties:**
 ```jinja2
-{% set penalties = state_attr('sensor.f1_officials_investigations_penalties', 'penalties') %}
+{% set penalties = state_attr('sensor.f1_investigations', 'penalties') %}
 {% for p in penalties %}
   {{ p.driver }}: {{ p.penalty }} ({{ p.reason }})
 {% endfor %}
@@ -1413,14 +1413,14 @@ Each entry in `penalties` contains:
 
 **Count active investigations:**
 ```jinja2
-{% set noted = state_attr('sensor.f1_officials_investigations_penalties', 'noted') | length %}
-{% set investigating = state_attr('sensor.f1_officials_investigations_penalties', 'under_investigation') | length %}
+{% set noted = state_attr('sensor.f1_investigations', 'noted') | length %}
+{% set investigating = state_attr('sensor.f1_investigations', 'under_investigation') | length %}
 Noted: {{ noted }}, Under Investigation: {{ investigating }}
 ```
 
 **Get post-race investigations:**
 ```jinja2
-{% set investigations = state_attr('sensor.f1_officials_investigations_penalties', 'under_investigation') %}
+{% set investigations = state_attr('sensor.f1_investigations', 'under_investigation') %}
 {% for inv in investigations if inv.after_race %}
   {{ inv.drivers | join(' vs ') }} - {{ inv.reason }} (after race)
 {% endfor %}
@@ -1428,7 +1428,7 @@ Noted: {{ noted }}, Under Investigation: {{ investigating }}
 
 **Show recent NFI decisions:**
 ```jinja2
-{% set nfi = state_attr('sensor.f1_officials_investigations_penalties', 'no_further_action') %}
+{% set nfi = state_attr('sensor.f1_investigations', 'no_further_action') %}
 {% for item in nfi %}
   {{ item.drivers | join('/') }}: No Further Action ({{ item.reason }})
 {% endfor %}
@@ -1436,7 +1436,7 @@ Noted: {{ noted }}, Under Investigation: {{ investigating }}
 
 **Create investigation summary:**
 ```jinja2
-{% set sensor = 'sensor.f1_officials_investigations_penalties' %}
+{% set sensor = 'sensor.f1_investigations' %}
 {% set total = states(sensor) | int %}
 {% if total > 0 %}
   {{ total }} active matter{{ 's' if total > 1 else '' }}:
@@ -1550,7 +1550,7 @@ Each entry in `drivers` (keyed by racing number) contains:
 
 **Get predicted champion:**
 ```jinja2
-{% set p1 = state_attr('sensor.f1_championship_championship_prediction_drivers', 'predicted_driver_p1') %}
+{% set p1 = state_attr('sensor.f1_championship_prediction_drivers', 'predicted_driver_p1') %}
 {% if p1 %}
   Predicted champion: {{ p1.tla }} with {{ p1.points }} points
 {% endif %}
@@ -1558,7 +1558,7 @@ Each entry in `drivers` (keyed by racing number) contains:
 
 **Show points gain prediction for a driver:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_championship_championship_prediction_drivers', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_championship_prediction_drivers', 'drivers') %}
 {% set ver = drivers.get('1') %}
 {% if ver %}
   {% set gain = ver.PredictedPoints - ver.CurrentPoints %}
@@ -1568,7 +1568,7 @@ Each entry in `drivers` (keyed by racing number) contains:
 
 **List drivers predicted to gain positions:**
 ```jinja2
-{% set drivers = state_attr('sensor.f1_championship_championship_prediction_drivers', 'drivers') %}
+{% set drivers = state_attr('sensor.f1_championship_prediction_drivers', 'drivers') %}
 {% for num, d in drivers.items() if d.PredictedPosition < d.CurrentPosition %}
   #{{ num }}: P{{ d.CurrentPosition }} -> P{{ d.PredictedPosition }}
 {% endfor %}
@@ -1576,8 +1576,8 @@ Each entry in `drivers` (keyed by racing number) contains:
 
 **Calculate predicted gap to leader:**
 ```jinja2
-{% set p1 = state_attr('sensor.f1_championship_championship_prediction_drivers', 'predicted_driver_p1') %}
-{% set drivers = state_attr('sensor.f1_championship_championship_prediction_drivers', 'drivers') %}
+{% set p1 = state_attr('sensor.f1_championship_prediction_drivers', 'predicted_driver_p1') %}
+{% set drivers = state_attr('sensor.f1_championship_prediction_drivers', 'drivers') %}
 {% set ham = drivers.get('44') %}
 {% if p1 and ham %}
   Gap to leader: {{ p1.points - ham.PredictedPoints }} points
@@ -1683,7 +1683,7 @@ Each entry in `teams` (keyed by team key) contains:
 
 **Get predicted constructors champion:**
 ```jinja2
-{% set p1 = state_attr('sensor.f1_championship_championship_prediction_teams', 'predicted_team_p1') %}
+{% set p1 = state_attr('sensor.f1_championship_prediction_teams', 'predicted_team_p1') %}
 {% if p1 %}
   Predicted constructors champion: {{ p1.team_name }}
 {% endif %}
@@ -1691,7 +1691,7 @@ Each entry in `teams` (keyed by team key) contains:
 
 **Compare two teams:**
 ```jinja2
-{% set teams = state_attr('sensor.f1_championship_championship_prediction_teams', 'teams') %}
+{% set teams = state_attr('sensor.f1_championship_prediction_teams', 'teams') %}
 {% set rb = teams.get('red_bull') %}
 {% set ferrari = teams.get('ferrari') %}
 {% if rb and ferrari %}
@@ -1701,7 +1701,7 @@ Each entry in `teams` (keyed by team key) contains:
 
 **List teams by predicted finish:**
 ```jinja2
-{% set teams = state_attr('sensor.f1_championship_championship_prediction_teams', 'teams') %}
+{% set teams = state_attr('sensor.f1_championship_prediction_teams', 'teams') %}
 {% for key, t in teams.items() | sort(attribute='1.PredictedPosition') %}
   P{{ t.PredictedPosition }}: {{ t.TeamName }} ({{ t.PredictedPoints }} pts)
 {% endfor %}
@@ -1709,7 +1709,7 @@ Each entry in `teams` (keyed by team key) contains:
 
 **Show teams predicted to change position:**
 ```jinja2
-{% set teams = state_attr('sensor.f1_championship_championship_prediction_teams', 'teams') %}
+{% set teams = state_attr('sensor.f1_championship_prediction_teams', 'teams') %}
 {% for key, t in teams.items() if t.PredictedPosition != t.CurrentPosition %}
   {{ t.TeamName }}: P{{ t.CurrentPosition }} -> P{{ t.PredictedPosition }}
 {% endfor %}

--- a/docs/entities/static_data.md
+++ b/docs/entities/static_data.md
@@ -10,7 +10,7 @@ Information that rarely changes, such as schedules, drivers, circuits, and champ
 
 | Entity                                                                            | Info                                              | 
 | ----------------------------------------------------------------------------------| --------------------------------------------------| 
-| [sensor.f1_race_next_race](#next-race)                                                 | Next race info                                    | 
+| [sensor.f1_next_race](#next-race)                                                       | Next race info                                    |
 | [sensor.f1_track_time](#track-time)                                               | Current local time at the next race circuit       |
 | [sensor.f1_current_season](#current-season)                                       | Full race schedule                                | 
 | [sensor.f1_driver_standings](#driver-standings)                                   | Current driver championship standings             | 
@@ -23,7 +23,7 @@ Information that rarely changes, such as schedules, drivers, circuits, and champ
 | [binary_sensor.f1_race_week](#race-week)                                          | `on` during race week                             | 
 | [sensor.f1_sprint_results](#sprint-results)                                       | Sprint classification results |
 | [sensor.f1_fia_documents](#fia-decision-documents)                                | FIA decisions and documents for the current weekend |
-| [calendar.f1_season](#season-calendar)                                            | Full season calendar with all sessions              |
+| [calendar.f1_race_season_calendar](#season-calendar)                              | Full season calendar with all sessions              |
 
 
 ::::info
@@ -33,7 +33,7 @@ Many schedule timestamps are provided in three variants: an explicit UTC value (
 ---
 
 ## Next Race 
-`sensor.f1_race_next_race` - Schedule for the next race; state is the race start timestamp (ISO‑8601).
+`sensor.f1_next_race` - Schedule for the next race; state is the race start timestamp (ISO‑8601).
 
 **State**
   - ISO‑8601 timestamp (UTC) of the race start, or `unknown` if not available.
@@ -914,7 +914,7 @@ The sensor maintains a history of up to 100 documents internally. When a new rac
 
 ## Season Calendar
 
-`calendar.f1_season` - Native Home Assistant calendar showing every session of the current Formula 1 season.
+`calendar.f1_race_season_calendar` - Native Home Assistant calendar showing every session of the current Formula 1 season.
 
 The calendar appears in the Home Assistant calendar panel and shows each session as a separate event: Practice 1, Practice 2, Practice 3, Qualifying, Sprint Qualifying, Sprint, and Race. On sprint weekends, Practice 3 is replaced by Sprint Qualifying and Sprint.
 

--- a/docs/example/custom-card-by.md
+++ b/docs/example/custom-card-by.md
@@ -184,7 +184,7 @@ custom_fields:
       
       // Build team color map from driver list
       const getTeamColors = () => {
-        const driverList = states['sensor.f1_drivers_driver_list']?.attributes?.drivers || [];
+        const driverList = states['sensor.f1_driver_list']?.attributes?.drivers || [];
         const colorMap = {};
         driverList.forEach(d => {
           if (d.team && d.team_color) {
@@ -195,7 +195,7 @@ custom_fields:
       };
 
       const getDriverData = () => {
-        const driverList = states['sensor.f1_drivers_driver_list']?.attributes?.drivers || [];
+        const driverList = states['sensor.f1_driver_list']?.attributes?.drivers || [];
         const dataMap = {};
         driverList.forEach(d => {
           if (d.tla) {
@@ -455,7 +455,7 @@ custom_fields:
 
       // Build team color map from driver list
       const getTeamColors = () => {
-        const driverList = states['sensor.f1_drivers_driver_list']?.attributes?.drivers || [];
+        const driverList = states['sensor.f1_driver_list']?.attributes?.drivers || [];
         const colorMap = {};
         driverList.forEach(d => {
           if (d.team && d.team_color) {

--- a/docs/example/e-ink.md
+++ b/docs/example/e-ink.md
@@ -26,7 +26,7 @@ The display is laid out as a compact race schedule overview:
 - **Upcoming sessions** — qualifying, practice, and sprint times for the current race weekend
 - **Following races** — the next three rounds at a glance
 
-All data comes from the `sensor.f1_race_next_race` and `sensor.f1_current_season` entities provided by F1 Sensor.
+All data comes from the `sensor.f1_next_race` and `sensor.f1_current_season` entities provided by F1 Sensor.
 
 ---
 

--- a/docs/features/live-delay.md
+++ b/docs/features/live-delay.md
@@ -22,7 +22,7 @@ By setting the delay accordingly, Home Assistant can react in sync with the live
 
 ## Option 1 - Manual delay adjustment
 
-At its core, Live Delay is a single value, stored in `number.f1_live_delay`
+At its core, Live Delay is a single value, stored in `number.f1_system_live_delay`
 
 Changing this value **directly updates** the Live Delay Controller and delays all live messages. This value represents how many seconds the live data stream should be delayed before it is exposed to sensors.
 
@@ -49,9 +49,9 @@ It uses these helper entities:
 
 | Entity | Purpose |
 | --- | --- |
-| `switch.f1_delay_calibration` | Arm calibration and start the timer |
-| `button.f1_match_live_delay` | Press when TV catches up to commit the delay |
-| `select.f1_live_delay_reference` | Choose when the timer starts |
+| `switch.f1_system_delay_calibration` | Arm calibration and start the timer |
+| `button.f1_system_match_live_delay` | Press when TV catches up to commit the delay |
+| `select.f1_system_live_delay_reference` | Choose when the timer starts |
 
 ![Manual Live Auto](/img/live_delay_auto.png)
 
@@ -59,7 +59,7 @@ It uses these helper entities:
 
 The calibration workflow publishes additional attributes so you can see what it is doing.
 
-The `number.f1_live_delay` entity also exposes:
+The `number.f1_system_live_delay` entity also exposes:
 
 | Attribute | Type | Description |
 | --- | --- | --- |
@@ -72,7 +72,7 @@ The `number.f1_live_delay` entity also exposes:
 | calibration_last_result | number | Most recent saved delay value in seconds (best effort) |
 | calibration_message | string | Human-readable status message (best effort) |
 
-The `switch.f1_delay_calibration` entity exposes:
+The `switch.f1_system_delay_calibration` entity exposes:
 
 | Attribute | Type | Description |
 | --- | --- | --- |
@@ -87,7 +87,7 @@ The `switch.f1_delay_calibration` entity exposes:
 
 ### Choose the calibration reference
 
-Use `select.f1_live_delay_reference` to choose when the calibration timer starts:
+Use `select.f1_system_live_delay_reference` to choose when the calibration timer starts:
 
 - **Session live** - Timer starts at lights out (races) or pit exit open (practice/qualifying). This is the most precise option.
 - **Formation start (race/sprint)** - Timer starts when the formation lap begins. This lets you focus on watching the start rather than pressing a button at lights out.
@@ -107,7 +107,7 @@ The formation lap start point is estimated with approximately one second accurac
 
 ### Step 1 - Arm the calibration
 
-Turn the switch `switch.f1_delay_calibration` **on** to start calibration mode.
+Turn the switch `switch.f1_system_delay_calibration` **on** to start calibration mode.
 
 What happens next depends on the chosen reference:
 
@@ -129,7 +129,7 @@ What happens next depends on the chosen reference:
 
 ### Step 2 - Match the TV broadcast
 
-When you see the reference point on your TV, press `button.f1_match_live_delay`. The elapsed time is measured and the result is written to `number.f1_live_delay`.
+When you see the reference point on your TV, press `button.f1_system_match_live_delay`. The elapsed time is measured and the result is written to `number.f1_system_live_delay`.
 
 **With session live reference:** Press when you see lights out (race) or pit exit open (practice/qualifying).
 

--- a/docs/features/replay-mode.md
+++ b/docs/features/replay-mode.md
@@ -23,20 +23,20 @@ Replay Mode adds several control entities to Home Assistant.
 
 | Entity | Purpose |
 | --- | --- |
-| `select.f1_replay_year` | Select the season year |
-| `select.f1_replay_session` | Select which session to replay |
-| `select.f1_replay_start_reference` | Choose where playback starts |
-| `button.f1_replay_load` | Download and prepare the selected session |
-| `button.f1_replay_play` | Start or resume playback |
-| `button.f1_replay_pause` | Pause playback |
-| `button.f1_replay_stop` | Stop playback and return to idle |
-| `button.f1_replay_refresh_sessions` | Refresh the session list |
+| `select.f1_system_replay_year` | Select the season year |
+| `select.f1_system_replay_session` | Select which session to replay |
+| `select.f1_system_replay_start_reference` | Choose where playback starts |
+| `button.f1_system_load_session` | Download and prepare the selected session |
+| `button.f1_system_play` | Start or resume playback |
+| `button.f1_system_pause` | Pause playback |
+| `button.f1_system_stop` | Stop playback and return to idle |
+| `button.f1_system_refresh_sessions` | Refresh the session list |
 
 ### Media player
 
 | Entity | Purpose |
 | --- | --- |
-| `media_player.f1_replay_player` | Standard media player with play, pause, stop and position tracking |
+| `media_player.f1_system_replay_player` | Standard media player with play, pause, stop and position tracking |
 
 The media player entity lets you control replay using any media player integration or remote control. It reports current position, duration, and playback state, making it easy to integrate with other media players in your setup.
 
@@ -52,8 +52,8 @@ The media player entity lets you control replay using any media player integrati
 
 ### Step 1 - Select a session
 
-1. Use `select.f1_replay_year` to choose the season
-2. Use `select.f1_replay_session` to pick a session from that year
+1. Use `select.f1_system_replay_year` to choose the season
+2. Use `select.f1_system_replay_session` to pick a session from that year
 
 The session list shows all completed sessions from the selected year, with the most recent first.
 
@@ -63,7 +63,7 @@ Session data is typically available 15–60 minutes after a session ends. If you
 
 ### Step 2 - Choose the start reference
 
-Use `select.f1_replay_start_reference` to choose where playback begins:
+Use `select.f1_system_replay_start_reference` to choose where playback begins:
 
 - **Formation start (race/sprint)** - Playback starts from the formation lap. This is the default and recommended for races and sprints, since you can focus on watching the start rather than pressing a button at lights out.
 - **Session live** - Playback starts from lights out (races) or pit exit open (practice/qualifying). This is the most precise option but requires you to press play at the exact moment.
@@ -78,13 +78,13 @@ The formation lap start point is estimated with approximately one second accurac
 
 ### Step 3 - Load the session
 
-Press `button.f1_replay_load` to download the session data.
+Press `button.f1_system_load_session` to download the session data.
 
 The `sensor.f1_replay_status` shows download progress. Session data is cached locally, so loading the same session again is faster.
 
 ### Step 4 - Sync with your broadcast
 
-Start the session on your TV or streaming service. When you see the session begin, press `button.f1_replay_play` or use `media_player.f1_replay_player` at that exact moment.
+Start the session on your TV or streaming service. When you see the session begin, press `button.f1_system_play` or use `media_player.f1_system_replay_player` at that exact moment.
 
 **For races and sprints** (with formation start reference): Press play when the formation lap begins.
 
@@ -96,15 +96,15 @@ From this point, all live sensors update in sync with what you see on screen.
 
 If you pause your TV, pause the replay to stay in sync. When you resume, resume the replay.
 
-- **Pause** - Press `button.f1_replay_pause` or pause `media_player.f1_replay_player`
-- **Resume** - Press `button.f1_replay_play` or play `media_player.f1_replay_player`
-- **Stop** - Press `button.f1_replay_stop` to end playback and return to idle
+- **Pause** - Press `button.f1_system_pause` or pause `media_player.f1_system_replay_player`
+- **Resume** - Press `button.f1_system_play` or play `media_player.f1_system_replay_player`
+- **Stop** - Press `button.f1_system_stop` to end playback and return to idle
 
 ---
 
 ## Media Player Entity
 
-The `media_player.f1_replay_player` entity provides standard media player controls for replay.
+The `media_player.f1_system_replay_player` entity provides standard media player controls for replay.
 
 **State (enum)**
 - One of: `idle`, `buffering`, `playing`, `paused`
@@ -171,12 +171,12 @@ automation:
         to: "paused"
     condition:
       - condition: state
-        entity_id: media_player.f1_replay_player
+        entity_id: media_player.f1_system_replay_player
         state: "playing"
     action:
       - service: media_player.media_pause
         target:
-          entity_id: media_player.f1_replay_player
+          entity_id: media_player.f1_system_replay_player
 
   - alias: "Resume F1 replay when Apple TV plays"
     trigger:
@@ -185,12 +185,12 @@ automation:
         to: "playing"
     condition:
       - condition: state
-        entity_id: media_player.f1_replay_player
+        entity_id: media_player.f1_system_replay_player
         state: "paused"
     action:
       - service: media_player.media_play
         target:
-          entity_id: media_player.f1_replay_player
+          entity_id: media_player.f1_system_replay_player
 ```
 
 Replace `media_player.apple_tv` with your actual media player entity. This works with any media player that reports play and pause states.

--- a/docs/getting-started/replay-mode.md
+++ b/docs/getting-started/replay-mode.md
@@ -23,20 +23,20 @@ Replay Mode adds several control entities to Home Assistant.
 
 | Entity | Purpose |
 | --- | --- |
-| `select.f1_replay_year` | Select the season year |
-| `select.f1_replay_session` | Select which session to replay |
-| `select.f1_replay_start_reference` | Choose where playback starts |
-| `button.f1_replay_load` | Download and prepare the selected session |
-| `button.f1_replay_play` | Start or resume playback |
-| `button.f1_replay_pause` | Pause playback |
-| `button.f1_replay_stop` | Stop playback and return to idle |
-| `button.f1_replay_refresh` | Refresh the session list |
+| `select.f1_system_replay_year` | Select the season year |
+| `select.f1_system_replay_session` | Select which session to replay |
+| `select.f1_system_replay_start_reference` | Choose where playback starts |
+| `button.f1_system_load_session` | Download and prepare the selected session |
+| `button.f1_system_play` | Start or resume playback |
+| `button.f1_system_pause` | Pause playback |
+| `button.f1_system_stop` | Stop playback and return to idle |
+| `button.f1_system_refresh_sessions` | Refresh the session list |
 
 ### Media player
 
 | Entity | Purpose |
 | --- | --- |
-| `media_player.f1_replay_player` | Standard media player with play, pause, stop and position tracking |
+| `media_player.f1_system_replay_player` | Standard media player with play, pause, stop and position tracking |
 
 The media player entity lets you control replay using any media player integration or remote control. It reports current position, duration, and playback state, making it easy to integrate with other media players in your setup.
 
@@ -52,8 +52,8 @@ The media player entity lets you control replay using any media player integrati
 
 ### Step 1 - Select a session
 
-1. Use `select.f1_replay_year` to choose the season
-2. Use `select.f1_replay_session` to pick a session from that year
+1. Use `select.f1_system_replay_year` to choose the season
+2. Use `select.f1_system_replay_session` to pick a session from that year
 
 The session list shows all completed sessions from the selected year, with the most recent first.
 
@@ -63,7 +63,7 @@ Session data is typically available 15–60 minutes after a session ends. If you
 
 ### Step 2 - Choose the start reference
 
-Use `select.f1_replay_start_reference` to choose where playback begins:
+Use `select.f1_system_replay_start_reference` to choose where playback begins:
 
 - **Formation start (race/sprint)** - Playback starts from the formation lap. This is the default and recommended for races and sprints, since you can focus on watching the start rather than pressing a button at lights out.
 - **Session live** - Playback starts from lights out (races) or pit exit open (practice/qualifying). This is the most precise option but requires you to press play at the exact moment.
@@ -78,13 +78,13 @@ The formation lap start point is estimated with approximately one second accurac
 
 ### Step 3 - Load the session
 
-Press `button.f1_replay_load` to download the session data.
+Press `button.f1_system_load_session` to download the session data.
 
 The `sensor.f1_replay_status` shows download progress. Session data is cached locally, so loading the same session again is faster.
 
 ### Step 4 - Sync with your broadcast
 
-Start the session on your TV or streaming service. When you see the session begin, press `button.f1_replay_play` or use `media_player.f1_replay_player` at that exact moment.
+Start the session on your TV or streaming service. When you see the session begin, press `button.f1_system_play` or use `media_player.f1_system_replay_player` at that exact moment.
 
 **For races and sprints** (with formation start reference): Press play when the formation lap begins.
 
@@ -96,15 +96,15 @@ From this point, all live sensors update in sync with what you see on screen.
 
 If you pause your TV, pause the replay to stay in sync. When you resume, resume the replay.
 
-- **Pause** - Press `button.f1_replay_pause` or pause `media_player.f1_replay_player`
-- **Resume** - Press `button.f1_replay_play` or play `media_player.f1_replay_player`
-- **Stop** - Press `button.f1_replay_stop` to end playback and return to idle
+- **Pause** - Press `button.f1_system_pause` or pause `media_player.f1_system_replay_player`
+- **Resume** - Press `button.f1_system_play` or play `media_player.f1_system_replay_player`
+- **Stop** - Press `button.f1_system_stop` to end playback and return to idle
 
 ---
 
 ## Media Player Entity
 
-The `media_player.f1_replay_player` entity provides standard media player controls for replay.
+The `media_player.f1_system_replay_player` entity provides standard media player controls for replay.
 
 **State (enum)**
 - One of: `idle`, `buffering`, `playing`, `paused`
@@ -165,12 +165,12 @@ automation:
         to: "paused"
     condition:
       - condition: state
-        entity_id: media_player.f1_replay_player
+        entity_id: media_player.f1_system_replay_player
         state: "playing"
     action:
       - service: media_player.media_pause
         target:
-          entity_id: media_player.f1_replay_player
+          entity_id: media_player.f1_system_replay_player
 
   - alias: "Resume F1 replay when Apple TV plays"
     trigger:
@@ -179,12 +179,12 @@ automation:
         to: "playing"
     condition:
       - condition: state
-        entity_id: media_player.f1_replay_player
+        entity_id: media_player.f1_system_replay_player
         state: "paused"
     action:
       - service: media_player.media_play
         target:
-          entity_id: media_player.f1_replay_player
+          entity_id: media_player.f1_system_replay_player
 ```
 
 Replace `media_player.apple_tv` with your actual media player entity. This works with any media player that reports play and pause states.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -36,7 +36,7 @@ In summary, the F1 sensors live in Home Assistant, you can mirror those entity s
 
 The integration does not create separate sensors for each practice or qualifying session by default (only for the race and overall “next race” info). 
 
-However, the schedule information for practice sessions and qualifying is included in the data. For example, the `sensor.f1_race_next_race` (next race info) or the season calendar sensor contains the timings for all sessions of the Grand Prix weekend. 
+However, the schedule information for practice sessions and qualifying is included in the data. For example, the `sensor.f1_next_race` (next race info) or the season calendar sensor contains the timings for all sessions of the Grand Prix weekend. 
 
 You can use those attributes in templates or in the calendar to know when FP1, FP2, FP3, Quali, etc., occur. There is currently no dedicated “FP1 sensor” or “qualifying sensor” – this has been requested as a feature, but for now you’ll use the provided schedule data from the existing sensors.
 </details>
@@ -67,8 +67,8 @@ See the [Replay Mode documentation](/features/replay-mode) for setup instruction
 
 The integration provides multiple ways to adjust the live delay:
 
-1. **Direct adjustment**: Change `number.f1_live_delay` to set the delay in seconds
-2. **Guided calibration**: Use the built-in calibration workflow with `switch.f1_delay_calibration`
+1. **Direct adjustment**: Change `number.f1_system_live_delay` to set the delay in seconds
+2. **Guided calibration**: Use the built-in calibration workflow with `switch.f1_system_delay_calibration`
 
 For detailed instructions including automatic calibration during a live session, see [**Live Delay**](/features/live-delay).
 </details>
@@ -80,7 +80,7 @@ For detailed instructions including automatic calibration during a live session,
 
 Race Control messages are available in two ways:
 
-1. **Sensor**: `sensor.f1_officials_race_control` shows the latest message and maintains a history. See [Race Control](/entities/live-data#race-control) for details.
+1. **Sensor**: `sensor.f1_race_control` shows the latest message and maintains a history. See [Race Control](/entities/live-data#race-control) for details.
 
 2. **Events**: Messages are also emitted as `f1_sensor_race_control_event` events for automation triggers. See [Events](/entities/events) for the event format.
 
@@ -92,7 +92,7 @@ For example automations, check the [Automation](/automation) page.
 <details>
 <summary>How can I tell which session is currently live (Practice, Qualifying, Race, etc.)?</summary>
 
-As of version 2.2.0, there is a sensor for this. The integration provides `sensor.f1_session_current_session` which indicates the name of the session that is currently running. 
+As of version 2.2.0, there is a sensor for this. The integration provides `sensor.f1_current_session` which indicates the name of the session that is currently running. 
 
 For example, it will show values like “Practice 1”, “Qualifying”, “Sprint Shootout”, or “Race” when those sessions are in progress. This complements the `f1_session_session_status` sensor (which shows the state like pre/live/finished) by telling you exactly which session is active. 
 
@@ -104,7 +104,7 @@ This is useful for automations or dashboards that need to behave differently for
 <details>
 <summary>Does the integration include live flag status and safety car information?</summary>
 
-Yes. The F1 Sensor integration has live sensors for track flags and safety car status. The entity `sensor.f1_session_track_status` reflects the current track flag/status in real time (possible states include CLEAR, YELLOW, VSC, SC, RED, etc.). 
+Yes. The F1 Sensor integration has live sensors for track flags and safety car status. The entity `sensor.f1_track_status` reflects the current track flag/status in real time (possible states include CLEAR, YELLOW, VSC, SC, RED, etc.). 
 
 Additionally, `binary_sensor.f1_safety_car` turns on whenever a Safety Car or Virtual Safety Car is active on track. These live sensors let you react to yellow/red flags or safety car deployments in your Home Assistant automations (for example, changing lights to red on a red flag).
 </details>
@@ -124,7 +124,7 @@ Not at the moment. The integration focuses on key session data (session status, 
 <details>
 <summary>How can I display “Lap X of Y” for the current race?</summary>
 
-The integration provides the current lap number as `sensor.f1_session_race_lap_count` during an active race. To get the total number of laps, use the sensor’s attributes. The `f1_session_race_lap_count` sensor has an attribute named `total_laps` that represents the total laps scheduled for the race. 
+The integration provides the current lap number as `sensor.f1_race_lap_count` during an active race. To get the total number of laps, use the sensor’s attributes. The `f1_session_race_lap_count` sensor has an attribute named `total_laps` that represents the total laps scheduled for the race. 
 
 For example, if the sensor state is `12` and the `total_laps` attribute is `56`, you can construct a template or use a custom card to show “Lap 12 of 56.” 
 


### PR DESCRIPTION
<!--
  IMPORTANT: Your PR must target the `dev` branch.
  PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## What does this PR do?

<!-- Describe what this PR changes and why. Be specific — what behavior changes, what was broken, what is new. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (corrects existing behavior without breaking anything)
- [ ] New feature (adds functionality to the integration)
- [ ] Breaking change (existing automations, entities, or config options will stop working or behave differently)
- [ ] Blueprint (new or updated blueprint)
- [X] Documentation only (no code changes)
- [ ] Refactoring or internal cleanup (no user-visible changes)
- [ ] Dependency update

## What area does this affect?

<!-- Check all that apply -->

- [ ] Integration core (data fetching, coordinator, SignalR, API)
- [ ] Sensor entities
- [ ] Binary sensors, buttons, selects, switches, or other platforms
- [ ] Configuration flow or options
- [ ] Live delay / calibration
- [ ] Replay mode
- [ ] Blueprint
- [X] Documentation
- [ ] Tests
- [ ] CI / release pipeline

## Have you tested this?

<!-- Describe how you tested the change. Be specific. -->

- [X] Tested locally with a real Home Assistant instance
- [ ] Tested with replay mode (if applicable)
- [ ] Verified that existing automations or dashboards still work as expected after the change

## Checklist

- [X] My PR targets the `dev` branch
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] The code has no commented-out blocks left behind
- [ ] Code is formatted with Ruff (`ruff format custom_components`)
- [ ] Code passes Ruff lint check (`ruff check custom_components`)
- [ ] Tests have been added or updated to cover the change
- [ ] All tests pass locally (`pytest custom_components/f1_sensor/tests`)
- [ ] Hassfest validation passes (`python3 -m script.hassfest`)
- [ ] Translations updated if new config options or UI strings were added
- [ ] This PR has no merge conflicts with `dev`

If this PR changes user-facing behavior, entities, or configuration:

- [ ] I have noted what users need to update or be aware of in the PR description above

If this PR adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

If this is a breaking change:

- [ ] I have clearly described in the PR description what will break and what users need to do to adapt
