### PR TITLE
Beta

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  push:
+    branches: [dev, beta, main]
+    paths:
+      - "custom_components/**/*.py"
+      - "custom_components/**/tests/**"
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Run pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install test dependencies
+        run: pip install pytest-homeassistant-custom-component pytest-cov
+
+      - name: Run tests
+        run: >
+          python -m pytest
+          custom_components/f1_sensor/tests/
+          --cov=custom_components.f1_sensor
+          --cov-report=term-missing
+          -q

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "pytest_homeassistant_custom_component"

--- a/custom_components/f1_sensor/tests/test_driver_positions_status.py
+++ b/custom_components/f1_sensor/tests/test_driver_positions_status.py
@@ -12,7 +12,7 @@ class DummyCoordinator(SimpleNamespace):
 
 def _make_sensor() -> F1DriverPositionsSensor:
     coord = DummyCoordinator(data={})
-    return F1DriverPositionsSensor(coord, "F1", "uid", "entry", "F1")
+    return F1DriverPositionsSensor(coord, "uid", "entry", "F1")
 
 
 def test_driver_status_pit_out_hold() -> None:

--- a/custom_components/f1_sensor/tests/test_fastest_lap.py
+++ b/custom_components/f1_sensor/tests/test_fastest_lap.py
@@ -114,7 +114,7 @@ def _driver_positions_payload() -> dict:
 
 def test_driver_positions_fastest_lap_race(hass) -> None:
     coord = DummyCoordinator(data=_driver_positions_payload())
-    sensor = F1DriverPositionsSensor(coord, "F1", "uid", "entry", "F1")
+    sensor = F1DriverPositionsSensor(coord, "uid", "entry", "F1")
     sensor.hass = hass
     sensor._session_info_coordinator = SimpleNamespace(
         data={"Type": "Race", "Name": "Race"}
@@ -132,7 +132,7 @@ def test_driver_positions_fastest_lap_race(hass) -> None:
 
 def test_driver_positions_fastest_lap_hidden_non_race(hass) -> None:
     coord = DummyCoordinator(data=_driver_positions_payload())
-    sensor = F1DriverPositionsSensor(coord, "F1", "uid", "entry", "F1")
+    sensor = F1DriverPositionsSensor(coord, "uid", "entry", "F1")
     sensor.hass = hass
     sensor._session_info_coordinator = SimpleNamespace(
         data={"Type": "Practice", "Name": "Practice 1"}

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -229,7 +229,6 @@ async def test_current_season_sensor_state_attributes_and_availability(hass) -> 
 
     sensor = F1CurrentSeasonSensor(
         coordinator,
-        "F1 Current season",
         f"{entry_id}_current_season",
         entry_id,
         "F1",
@@ -286,7 +285,6 @@ async def test_current_season_sensor_excludes_races_from_recorder(hass) -> None:
 
     sensor = F1CurrentSeasonSensor(
         coordinator,
-        "F1 Current season",
         f"{entry_id}_current_season",
         entry_id,
         "F1",
@@ -316,7 +314,6 @@ async def test_season_results_sensor_excludes_races_from_recorder(hass) -> None:
 
     sensor = F1SeasonResultsSensor(
         coordinator,
-        "F1 Season results",
         f"{entry_id}_season_results",
         entry_id,
         "F1",
@@ -339,7 +336,6 @@ async def test_sprint_results_sensor_excludes_races_from_recorder(hass) -> None:
 
     sensor = F1SprintResultsSensor(
         coordinator,
-        "F1 Sprint results",
         f"{entry_id}_sprint_results",
         entry_id,
         "F1",
@@ -364,7 +360,6 @@ async def test_driver_points_progression_excludes_heavy_attrs_from_recorder(
 
     sensor = F1DriverPointsProgressionSensor(
         coordinator,
-        "F1 Driver points progression",
         f"{entry_id}_driver_points_progression",
         entry_id,
         "F1",
@@ -394,7 +389,6 @@ async def test_constructor_points_progression_excludes_heavy_attrs_from_recorder
 
     sensor = F1ConstructorPointsProgressionSensor(
         coordinator,
-        "F1 Constructor points progression",
         f"{entry_id}_constructor_points_progression",
         entry_id,
         "F1",
@@ -422,7 +416,6 @@ async def test_pitstops_sensor_excludes_cars_from_recorder(hass) -> None:
 
     sensor = F1PitStopsSensor(
         coordinator,
-        "F1 Pitstops",
         f"{entry_id}_pitstops",
         entry_id,
         "F1",
@@ -447,7 +440,6 @@ async def test_driver_positions_sensor_excludes_drivers_from_recorder(hass) -> N
 
     sensor = F1DriverPositionsSensor(
         coordinator,
-        "F1 Driver positions",
         f"{entry_id}_driver_positions",
         entry_id,
         "F1",
@@ -476,7 +468,6 @@ async def test_recorder_payload_size_stays_below_limit_for_large_season_results(
 
     sensor = F1SeasonResultsSensor(
         coordinator,
-        "F1 Season results",
         f"{entry_id}_season_results",
         entry_id,
         "F1",
@@ -497,7 +488,6 @@ async def test_recorder_payload_size_stays_below_limit_for_large_driver_position
 
     sensor = F1DriverPositionsSensor(
         coordinator,
-        "F1 Driver positions",
         f"{entry_id}_driver_positions",
         entry_id,
         "F1",
@@ -548,14 +538,12 @@ async def test_standings_sensor_counts_expandable(hass) -> None:
 
     driver_sensor = F1DriverStandingsSensor(
         coordinator,
-        "F1 Driver standings",
         f"{entry_id}_driver_standings",
         entry_id,
         "F1",
     )
     constructor_sensor = F1ConstructorStandingsSensor(
         coordinator,
-        "F1 Constructor standings",
         f"{entry_id}_constructor_standings",
         entry_id,
         "F1",
@@ -583,7 +571,6 @@ def test_weather_sensor_uses_celsius_unit(hass) -> None:
 
     sensor = F1WeatherSensor(
         coordinator,
-        "F1 Weather",
         f"{entry_id}_weather",
         entry_id,
         "F1",
@@ -624,7 +611,6 @@ async def test_driver_list_sensor_handles_22_drivers(hass) -> None:
 
     sensor = F1DriverListSensor(
         coordinator,
-        "F1 Driver list",
         f"{entry_id}_driver_list",
         entry_id,
         "F1",

--- a/custom_components/f1_sensor/tests/test_session_clock.py
+++ b/custom_components/f1_sensor/tests/test_session_clock.py
@@ -298,7 +298,6 @@ async def test_session_time_remaining_sensor_uses_coordinator_data(hass) -> None
 
     sensor = F1SessionTimeRemainingSensor(
         coordinator,
-        "F1 session remaining",
         f"{entry_id}_session_remaining",
         entry_id,
         "F1",
@@ -353,7 +352,6 @@ async def test_race_three_hour_sensor_hidden_for_sprint(hass) -> None:
 
     sensor = F1RaceTimeToThreeHourLimitSensor(
         coordinator,
-        "F1 race to cap",
         f"{entry_id}_race_cap",
         entry_id,
         "F1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ ignore = [
 [tool.ruff.lint.isort]
 force-sort-within-sections = true
 combine-as-imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"


### PR DESCRIPTION
<!--
  IMPORTANT: Your PR must target the `dev` branch.
  PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## What does this PR do?

<!-- Describe what this PR changes and why. Be specific — what behavior changes, what was broken, what is new. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (corrects existing behavior without breaking anything)
- [ ] New feature (adds functionality to the integration)
- [ ] Breaking change (existing automations, entities, or config options will stop working or behave differently)
- [ ] Blueprint (new or updated blueprint)
- [ ] Documentation only (no code changes)
- [ ] Refactoring or internal cleanup (no user-visible changes)
- [ ] Dependency update

## What area does this affect?

<!-- Check all that apply -->

- [ ] Integration core (data fetching, coordinator, SignalR, API)
- [ ] Sensor entities
- [ ] Binary sensors, buttons, selects, switches, or other platforms
- [ ] Configuration flow or options
- [ ] Live delay / calibration
- [ ] Replay mode
- [ ] Blueprint
- [ ] Documentation
- [X] Tests
- [X] CI / release pipeline

## Have you tested this?

<!-- Describe how you tested the change. Be specific. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Tested with replay mode (if applicable)
- [ ] Verified that existing automations or dashboards still work as expected after the change

## Checklist

- [ ] My PR targets the `dev` branch
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] The code has no commented-out blocks left behind
- [ ] Code is formatted with Ruff (`ruff format custom_components`)
- [ ] Code passes Ruff lint check (`ruff check custom_components`)
- [X] Tests have been added or updated to cover the change
- [ ] All tests pass locally (`pytest custom_components/f1_sensor/tests`)
- [ ] Hassfest validation passes (`python3 -m script.hassfest`)
- [ ] Translations updated if new config options or UI strings were added
- [ ] This PR has no merge conflicts with `dev`

If this PR changes user-facing behavior, entities, or configuration:

- [ ] I have noted what users need to update or be aware of in the PR description above

If this PR adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

If this is a breaking change:

- [ ] I have clearly described in the PR description what will break and what users need to do to adapt
