### PR TITLE
Update track-status-light.md

### DIFF
--- a/docs/blueprints/track-status-light.md
+++ b/docs/blueprints/track-status-light.md
@@ -17,12 +17,12 @@ For the light to change at the same time as you see the flag on screen, configur
 
 ## Import the Blueprint
 
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FNicxe%2Ff1_sensor%2Fmain%2Fblueprints%2Ff1_session_track_status.yaml)
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FNicxe%2Ff1_sensor%2Fmain%2Fblueprints%2Ff1_track_status.yaml)
 
 Or go to **Settings > Automations & Scenes > Blueprints** and import manually using the URL:
 
 ```
-https://raw.githubusercontent.com/Nicxe/f1_sensor/main/blueprints/f1_session_track_status.yaml
+https://raw.githubusercontent.com/Nicxe/f1_sensor/main/blueprints/f1_track_status.yaml
 ```
 
 ---


### PR DESCRIPTION
<!--
  IMPORTANT: Your PR must target the `dev` branch.
  PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## What does this PR do?

<!-- Describe what this PR changes and why. Be specific — what behavior changes, what was broken, what is new. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (corrects existing behavior without breaking anything)
- [ ] New feature (adds functionality to the integration)
- [ ] Breaking change (existing automations, entities, or config options will stop working or behave differently)
- [ ] Blueprint (new or updated blueprint)
- [ ] Documentation only (no code changes)
- [ ] Refactoring or internal cleanup (no user-visible changes)
- [ ] Dependency update

## What area does this affect?

<!-- Check all that apply -->

- [ ] Integration core (data fetching, coordinator, SignalR, API)
- [ ] Sensor entities
- [ ] Binary sensors, buttons, selects, switches, or other platforms
- [ ] Configuration flow or options
- [ ] Live delay / calibration
- [ ] Replay mode
- [ ] Blueprint
- [ ] Documentation
- [ ] Tests
- [ ] CI / release pipeline

## Have you tested this?

<!-- Describe how you tested the change. Be specific. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Tested with replay mode (if applicable)
- [ ] Verified that existing automations or dashboards still work as expected after the change

## Checklist

- [ ] My PR targets the `dev` branch
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] The code has no commented-out blocks left behind
- [ ] Code is formatted with Ruff (`ruff format custom_components`)
- [ ] Code passes Ruff lint check (`ruff check custom_components`)
- [ ] Tests have been added or updated to cover the change
- [ ] All tests pass locally (`pytest custom_components/f1_sensor/tests`)
- [ ] Hassfest validation passes (`python3 -m script.hassfest`)
- [ ] Translations updated if new config options or UI strings were added
- [ ] This PR has no merge conflicts with `dev`

If this PR changes user-facing behavior, entities, or configuration:

- [ ] I have noted what users need to update or be aware of in the PR description above

If this PR adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

If this is a breaking change:

- [ ] I have clearly described in the PR description what will break and what users need to do to adapt
