### PR TITLE
chore: Add automated issue version check and auto-close workflows

### DIFF
--- a/.github/workflows/close-outdated-version-issues.yml
+++ b/.github/workflows/close-outdated-version-issues.yml
@@ -1,0 +1,49 @@
+name: Close Outdated Version Issues
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # Every hour
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  close-outdated:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues with outdated-version label after 24 hours of inactivity
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'outdated-version',
+            });
+
+            for (const issue of issues) {
+              if (new Date(issue.updated_at) < cutoff) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: [
+                    'This issue has been automatically closed due to no response after the request to update to the latest version.',
+                    '',
+                    'If you\'re still experiencing this issue after updating, please open a new report with the latest version and relevant logs.',
+                  ].join('\n'),
+                });
+
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'not_planned',
+                });
+              }
+            }

--- a/.github/workflows/issue-version-check.yml
+++ b/.github/workflows/issue-version-check.yml
@@ -1,0 +1,92 @@
+name: Issue Version Check
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    steps:
+      - name: Check reported version against latest release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const normalize = v => v.trim().replace(/^v/i, '');
+
+            const body = context.payload.issue.body || '';
+            const issueNumber = context.payload.issue.number;
+
+            // Skip if already labeled (avoid duplicate comments on re-open)
+            const labels = context.payload.issue.labels.map(l => l.name);
+            if (labels.includes('outdated-version')) return;
+
+            // Extract reported version from issue body
+            const versionMatch = body.match(/### F1 Sensor Version\s*\n+([^\n#]+)/);
+            if (!versionMatch) return;
+            const reportedVersion = normalize(versionMatch[1]);
+            if (!reportedVersion) return;
+
+            // Get latest release
+            let latestRelease;
+            try {
+              const { data } = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              latestRelease = data;
+            } catch {
+              // No releases yet — nothing to compare against
+              return;
+            }
+
+            const latestVersion = normalize(latestRelease.tag_name);
+
+            if (reportedVersion === latestVersion) return;
+
+            // Ensure the label exists
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'outdated-version',
+                color: 'e4e669',
+                description: 'Issue reported on an outdated version',
+              });
+            } catch {
+              // Label already exists — ignore
+            }
+
+            // Add label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['outdated-version'],
+            });
+
+            // Post comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                '👋 Thanks for the report!',
+                '',
+                `I noticed you're running version **${reportedVersion}**, but the latest release of F1 Sensor is **${latestVersion}**.`,
+                '',
+                'Please update to the latest version and check whether the issue still occurs — many problems are already fixed in newer releases.',
+                '',
+                '**How to update via HACS:**',
+                '1. Go to **HACS** in your Home Assistant sidebar',
+                '2. Find **F1 Sensor**, click **Download**, and select the latest version',
+                '3. Restart Home Assistant',
+                '',
+                'If the issue persists after updating, please comment here and we\'ll continue investigating.',
+                'If we don\'t hear back within **24 hours**, this issue will be automatically closed.',
+              ].join('\n'),
+            });


### PR DESCRIPTION
## Summary
- Adds `issue-version-check.yml`: triggers on new bug reports and compares the reported version against the latest release. If outdated, posts a comment with update instructions and adds the `outdated-version` label.
- Adds `close-outdated-version-issues.yml`: runs hourly and auto-closes issues tagged `outdated-version` that have had no activity for 24 hours.

Version normalization handles both `v1.0.0` and `1.0.0` formats.

## Test plan
- [ ] Open a bug report with an outdated version → verify comment is posted and label applied
- [ ] Open a bug report with the current version → verify no action is taken
- [ ] Manually trigger `Close Outdated Version Issues` via workflow_dispatch → verify eligible issues are closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)