### PR TITLE
fix: **Update F1 blueprints to modern automation syntax for stable tr…

### DIFF
--- a/blueprints/f1_race_control_notifications.yaml
+++ b/blueprints/f1_race_control_notifications.yaml
@@ -3,12 +3,14 @@ blueprint:
     min_version: 2024.6.0
   name: F1 Sensor - Race Control Notifications
   description: >
-    Send notifications from the F1 Sensor race control in a simple way, with optional filters.
+    Skicka notiser från F1 Sensor race control på ett enkelt sätt, med valfria filter.
 
-    Select the race control sensor, add optional filters, and then define your own notification actions
-    (for example mobile notifications, TTS, scripts, or other Home Assistant services).
+    Välj race control-sensor, lägg till valfria filter, och definiera sedan egna notifierings-actions
+    (till exempel mobilnotis, TTS, script eller andra Home Assistant-tjänster).
 
-    Available template variables in your actions:
+    Kräver att race control live-sensorn är aktiverad i F1 Sensor-inställningarna.
+
+    Tillgängliga template-variabler i dina actions:
     {{ notification_title }}, {{ notification_message }},
     {{ race_control_message }}, {{ race_control_category }}, {{ race_control_flag }},
     {{ race_control_scope }}, {{ race_control_sector }}, {{ race_control_car_number }},
@@ -478,11 +480,11 @@ variables:
     {% endif %}
     {{ ns.lines | join('\n') }}
 
-trigger:
-  - platform: state
+triggers:
+  - trigger: state
     entity_id: !input race_control_sensor
 
-condition:
+conditions:
   - condition: template
     value_template: "{{ trigger.to_state is not none }}"
   - condition: template
@@ -492,7 +494,7 @@ condition:
   - condition: template
     value_template: "{{ session_scope_ok and phase_ok and event_ok and flag_ok and category_ok and include_ok and exclude_ok }}"
 
-action:
+actions:
   - sequence: !input notification_actions
   - if:
       - condition: template

--- a/blueprints/f1_track_status.yaml
+++ b/blueprints/f1_track_status.yaml
@@ -572,17 +572,17 @@ variables:
   can_apply_track_light: >
     {{ session_scope_now_ok and is_active_phase and presence_ok and media_ok and not dnd_blocked }}
 
-trigger:
-  - platform: state
+triggers:
+  - trigger: state
     entity_id: !input track_status_entity
     id: track_update
-  - platform: state
+  - trigger: state
     entity_id: !input session_status_entity
     id: session_update
 
-condition: []
+conditions: []
 
-action:
+actions:
   - choose:
       - conditions:
           - condition: template
@@ -593,7 +593,7 @@ action:
                 value_template: "{{ snapshot_pre_race_enabled }}"
             then:
               - continue_on_error: true
-                service: scene.create
+                action: scene.create
                 data:
                   scene_id: "{{ pre_race_scene_id }}"
                   snapshot_entities:
@@ -613,7 +613,7 @@ action:
                   - condition: template
                     value_template: "{{ end_action_mode == 'turn_off' }}"
                 sequence:
-                  - service: "{{ light_turn_off_service }}"
+                  - action: "{{ light_turn_off_service }}"
                     target:
                       entity_id: !input light_target
 
@@ -621,7 +621,7 @@ action:
                   - condition: template
                     value_template: "{{ end_action_mode == 'neutral' }}"
                 sequence:
-                  - service: "{{ light_turn_on_service }}"
+                  - action: "{{ light_turn_on_service }}"
                     target:
                       entity_id: !input light_target
                     data:
@@ -634,7 +634,7 @@ action:
                     value_template: "{{ end_action_mode == 'restore_pre_race' and snapshot_pre_race_enabled }}"
                 sequence:
                   - continue_on_error: true
-                    service: scene.turn_on
+                    action: scene.turn_on
                     data:
                       entity_id: "{{ 'scene.' ~ pre_race_scene_id }}"
 
@@ -659,11 +659,11 @@ action:
                 value_template: "{{ cleanup_scenes_after_end }}"
             then:
               - continue_on_error: true
-                service: scene.delete
+                action: scene.delete
                 data:
                   entity_id: "{{ 'scene.' ~ pre_race_scene_id }}"
               - continue_on_error: true
-                service: scene.delete
+                action: scene.delete
                 data:
                   entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
 
@@ -676,7 +676,7 @@ action:
                 value_template: "{{ snapshot_before_alert_enabled and trigger.id == 'track_update' and track_state in ['YELLOW', 'RED', 'SC', 'VSC'] }}"
             then:
               - continue_on_error: true
-                service: scene.create
+                action: scene.create
                 data:
                   scene_id: "{{ pre_alert_scene_id }}"
                   snapshot_entities:
@@ -692,7 +692,7 @@ action:
                           - condition: template
                             value_template: "{{ clear_behavior_mode_input == 'steady' or (clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay'] and not snapshot_before_alert_enabled) }}"
                         sequence:
-                          - service: "{{ light_turn_on_service }}"
+                          - action: "{{ light_turn_on_service }}"
                             target:
                               entity_id: !input light_target
                             data:
@@ -705,7 +705,7 @@ action:
                             value_template: "{{ clear_behavior_mode_input == 'restore_immediately' and snapshot_before_alert_enabled }}"
                         sequence:
                           - continue_on_error: true
-                            service: scene.turn_on
+                            action: scene.turn_on
                             data:
                               entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
 
@@ -713,7 +713,7 @@ action:
                           - condition: template
                             value_template: "{{ clear_behavior_mode_input == 'restore_after_delay' and snapshot_before_alert_enabled }}"
                         sequence:
-                          - service: "{{ light_turn_on_service }}"
+                          - action: "{{ light_turn_on_service }}"
                             target:
                               entity_id: !input light_target
                             data:
@@ -725,7 +725,7 @@ action:
                           - condition: template
                             value_template: "{{ states(track_status_entity) | upper == 'CLEAR' }}"
                           - continue_on_error: true
-                            service: scene.turn_on
+                            action: scene.turn_on
                             data:
                               entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
 
@@ -738,7 +738,7 @@ action:
                           - condition: template
                             value_template: "{{ yellow_red_mode_input == 'steady' }}"
                         sequence:
-                          - service: "{{ light_turn_on_service }}"
+                          - action: "{{ light_turn_on_service }}"
                             target:
                               entity_id: !input light_target
                             data:
@@ -755,7 +755,7 @@ action:
                                 - condition: template
                                   value_template: "{{ states(track_status_entity) | upper == 'YELLOW' }}"
                               sequence:
-                                - service: "{{ light_turn_on_service }}"
+                                - action: "{{ light_turn_on_service }}"
                                   target:
                                     entity_id: !input light_target
                                   data:
@@ -763,7 +763,7 @@ action:
                                     rgb_color: !input color_yellow
                                 - delay:
                                     seconds: !input flash_interval_s
-                                - service: "{{ light_turn_off_service }}"
+                                - action: "{{ light_turn_off_service }}"
                                   target:
                                     entity_id: !input light_target
                                 - delay:
@@ -780,7 +780,7 @@ action:
                                 - condition: template
                                   value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'YELLOW' }}"
                               sequence:
-                                - service: "{{ light_turn_on_service }}"
+                                - action: "{{ light_turn_on_service }}"
                                   target:
                                     entity_id: !input light_target
                                   data:
@@ -788,7 +788,7 @@ action:
                                     rgb_color: !input color_yellow
                                 - delay:
                                     seconds: !input flash_interval_s
-                                - service: "{{ light_turn_off_service }}"
+                                - action: "{{ light_turn_off_service }}"
                                   target:
                                     entity_id: !input light_target
                                 - delay:
@@ -802,14 +802,14 @@ action:
                                     value_template: "{{ yellow_red_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
                                 sequence:
                                   - continue_on_error: true
-                                    service: scene.turn_on
+                                    action: scene.turn_on
                                     data:
                                       entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
                               - conditions:
                                   - condition: template
                                     value_template: "{{ yellow_red_after_flash_input == 'steady' or (yellow_red_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
                                 sequence:
-                                  - service: "{{ light_turn_on_service }}"
+                                  - action: "{{ light_turn_on_service }}"
                                     target:
                                       entity_id: !input light_target
                                     data:
@@ -826,7 +826,7 @@ action:
                           - condition: template
                             value_template: "{{ yellow_red_mode_input == 'steady' }}"
                         sequence:
-                          - service: "{{ light_turn_on_service }}"
+                          - action: "{{ light_turn_on_service }}"
                             target:
                               entity_id: !input light_target
                             data:
@@ -843,7 +843,7 @@ action:
                                 - condition: template
                                   value_template: "{{ states(track_status_entity) | upper == 'RED' }}"
                               sequence:
-                                - service: "{{ light_turn_on_service }}"
+                                - action: "{{ light_turn_on_service }}"
                                   target:
                                     entity_id: !input light_target
                                   data:
@@ -851,7 +851,7 @@ action:
                                     rgb_color: !input color_red
                                 - delay:
                                     seconds: !input flash_interval_s
-                                - service: "{{ light_turn_off_service }}"
+                                - action: "{{ light_turn_off_service }}"
                                   target:
                                     entity_id: !input light_target
                                 - delay:
@@ -868,7 +868,7 @@ action:
                                 - condition: template
                                   value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'RED' }}"
                               sequence:
-                                - service: "{{ light_turn_on_service }}"
+                                - action: "{{ light_turn_on_service }}"
                                   target:
                                     entity_id: !input light_target
                                   data:
@@ -876,7 +876,7 @@ action:
                                     rgb_color: !input color_red
                                 - delay:
                                     seconds: !input flash_interval_s
-                                - service: "{{ light_turn_off_service }}"
+                                - action: "{{ light_turn_off_service }}"
                                   target:
                                     entity_id: !input light_target
                                 - delay:
@@ -890,14 +890,14 @@ action:
                                     value_template: "{{ yellow_red_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
                                 sequence:
                                   - continue_on_error: true
-                                    service: scene.turn_on
+                                    action: scene.turn_on
                                     data:
                                       entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
                               - conditions:
                                   - condition: template
                                     value_template: "{{ yellow_red_after_flash_input == 'steady' or (yellow_red_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
                                 sequence:
-                                  - service: "{{ light_turn_on_service }}"
+                                  - action: "{{ light_turn_on_service }}"
                                     target:
                                       entity_id: !input light_target
                                     data:
@@ -914,7 +914,7 @@ action:
                           - condition: template
                             value_template: "{{ sc_vsc_mode_input == 'steady' }}"
                         sequence:
-                          - service: "{{ light_turn_on_service }}"
+                          - action: "{{ light_turn_on_service }}"
                             target:
                               entity_id: !input light_target
                             data:
@@ -931,7 +931,7 @@ action:
                                 - condition: template
                                   value_template: "{{ states(track_status_entity) | upper == 'SC' }}"
                               sequence:
-                                - service: "{{ light_turn_on_service }}"
+                                - action: "{{ light_turn_on_service }}"
                                   target:
                                     entity_id: !input light_target
                                   data:
@@ -939,7 +939,7 @@ action:
                                     rgb_color: !input color_sc
                                 - delay:
                                     seconds: !input flash_interval_s
-                                - service: "{{ light_turn_off_service }}"
+                                - action: "{{ light_turn_off_service }}"
                                   target:
                                     entity_id: !input light_target
                                 - delay:
@@ -956,7 +956,7 @@ action:
                                 - condition: template
                                   value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'SC' }}"
                               sequence:
-                                - service: "{{ light_turn_on_service }}"
+                                - action: "{{ light_turn_on_service }}"
                                   target:
                                     entity_id: !input light_target
                                   data:
@@ -964,7 +964,7 @@ action:
                                     rgb_color: !input color_sc
                                 - delay:
                                     seconds: !input flash_interval_s
-                                - service: "{{ light_turn_off_service }}"
+                                - action: "{{ light_turn_off_service }}"
                                   target:
                                     entity_id: !input light_target
                                 - delay:
@@ -978,14 +978,14 @@ action:
                                     value_template: "{{ sc_vsc_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
                                 sequence:
                                   - continue_on_error: true
-                                    service: scene.turn_on
+                                    action: scene.turn_on
                                     data:
                                       entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
                               - conditions:
                                   - condition: template
                                     value_template: "{{ sc_vsc_after_flash_input == 'steady' or (sc_vsc_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
                                 sequence:
-                                  - service: "{{ light_turn_on_service }}"
+                                  - action: "{{ light_turn_on_service }}"
                                     target:
                                       entity_id: !input light_target
                                     data:
@@ -1002,7 +1002,7 @@ action:
                           - condition: template
                             value_template: "{{ sc_vsc_mode_input == 'steady' }}"
                         sequence:
-                          - service: "{{ light_turn_on_service }}"
+                          - action: "{{ light_turn_on_service }}"
                             target:
                               entity_id: !input light_target
                             data:
@@ -1019,7 +1019,7 @@ action:
                                 - condition: template
                                   value_template: "{{ states(track_status_entity) | upper == 'VSC' }}"
                               sequence:
-                                - service: "{{ light_turn_on_service }}"
+                                - action: "{{ light_turn_on_service }}"
                                   target:
                                     entity_id: !input light_target
                                   data:
@@ -1027,7 +1027,7 @@ action:
                                     rgb_color: !input color_vsc
                                 - delay:
                                     seconds: !input flash_interval_s
-                                - service: "{{ light_turn_off_service }}"
+                                - action: "{{ light_turn_off_service }}"
                                   target:
                                     entity_id: !input light_target
                                 - delay:
@@ -1044,7 +1044,7 @@ action:
                                 - condition: template
                                   value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'VSC' }}"
                               sequence:
-                                - service: "{{ light_turn_on_service }}"
+                                - action: "{{ light_turn_on_service }}"
                                   target:
                                     entity_id: !input light_target
                                   data:
@@ -1052,7 +1052,7 @@ action:
                                     rgb_color: !input color_vsc
                                 - delay:
                                     seconds: !input flash_interval_s
-                                - service: "{{ light_turn_off_service }}"
+                                - action: "{{ light_turn_off_service }}"
                                   target:
                                     entity_id: !input light_target
                                 - delay:
@@ -1066,14 +1066,14 @@ action:
                                     value_template: "{{ sc_vsc_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
                                 sequence:
                                   - continue_on_error: true
-                                    service: scene.turn_on
+                                    action: scene.turn_on
                                     data:
                                       entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
                               - conditions:
                                   - condition: template
                                     value_template: "{{ sc_vsc_after_flash_input == 'steady' or (sc_vsc_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
                                 sequence:
-                                  - service: "{{ light_turn_on_service }}"
+                                  - action: "{{ light_turn_on_service }}"
                                     target:
                                       entity_id: !input light_target
                                     data:


### PR DESCRIPTION
…igger traces**

The Track Status Light and Race Control Notifications blueprints now use Home Assistant’s modern syntax for triggers, conditions, and actions. This fixes cases where automation traces showed trigger description errors such as the “includes” message even when the automation fired. The change improves compatibility with current Home Assistant versions while keeping the existing blueprint behavior unchanged.

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #333 

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [X] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [X] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
