### PR TITLE
blue: Add optional Activation Conditions to F1 race control and track…

### DIFF
--- a/blueprints/f1_race_control_notifications.yaml
+++ b/blueprints/f1_race_control_notifications.yaml
@@ -3,14 +3,14 @@ blueprint:
     min_version: 2024.6.0
   name: F1 Sensor - Race Control Notifications
   description: >
-    Skicka notiser från F1 Sensor race control på ett enkelt sätt, med valfria filter.
+    Send notifications from F1 Sensor Race Control in a simple way, with optional filters.
 
-    Välj race control-sensor, lägg till valfria filter, och definiera sedan egna notifierings-actions
-    (till exempel mobilnotis, TTS, script eller andra Home Assistant-tjänster).
+    Select the Race Control sensor, add optional filters, and then define your own notification actions
+    (for example mobile notifications, TTS, scripts, or other Home Assistant services).
 
-    Kräver att race control live-sensorn är aktiverad i F1 Sensor-inställningarna.
+    Requires that the Race Control live sensor is enabled in the F1 Sensor settings.
 
-    Tillgängliga template-variabler i dina actions:
+    Available template variables in your actions:
     {{ notification_title }}, {{ notification_message }},
     {{ race_control_message }}, {{ race_control_category }}, {{ race_control_flag }},
     {{ race_control_scope }}, {{ race_control_sector }}, {{ race_control_car_number }},
@@ -243,6 +243,19 @@ blueprint:
           default: []
           selector:
             action: {}
+
+    activation_conditions:
+      name: Activation Conditions
+      icon: mdi:filter-check
+      collapsed: true
+      description: Optional extra conditions. If not met, notifications are not sent.
+      input:
+        activation_condition:
+          name: Activation Condition
+          description: Optional condition block for advanced users (state, not-state, and/or/not, etc).
+          default: []
+          selector:
+            condition: {}
 
 variables:
   current_session_filter_enabled: !input enable_current_session_filter
@@ -491,6 +504,8 @@ conditions:
     value_template: "{{ trigger.to_state.state not in ['unknown', 'unavailable', 'none', 'None', ''] }}"
   - condition: template
     value_template: "{{ notification_actions_input | count > 0 }}"
+  - condition: and
+    conditions: !input activation_condition
   - condition: template
     value_template: "{{ (session_scope_ok | bool) and (phase_ok | bool) and (event_ok | bool) and (flag_ok | bool) and (category_ok | bool) and (include_ok | bool) and (exclude_ok | bool) }}"
 

--- a/blueprints/f1_track_status.yaml
+++ b/blueprints/f1_track_status.yaml
@@ -125,11 +125,11 @@ blueprint:
       name: Activation Conditions
       icon: mdi:filter-check
       collapsed: true
-      description: Optional gates that must pass before track updates control the light.
+      description: Optional gates that must pass before any blueprint actions run.
       input:
         presence_devices:
           name: Presence Devices
-          description: Optional. At least one selected device must be home.
+          description: Optional. At least one selected device must be home for this automation to run.
           default: []
           selector:
             entity:
@@ -138,7 +138,7 @@ blueprint:
               multiple: true
         media_player_gate:
           name: Media Player Gate
-          description: Optional. Selected media player must be on, idle, or playing.
+          description: Optional. Selected media player must be on, idle, or playing for this automation to run.
           default: ""
           selector:
             entity:
@@ -147,7 +147,7 @@ blueprint:
               multiple: false
         enable_dnd:
           name: Enable Do Not Disturb Window
-          description: Blocks track updates inside the configured time window.
+          description: Blocks this automation inside the configured time window.
           default: false
           selector:
             boolean: {}
@@ -161,6 +161,12 @@ blueprint:
           default: "07:00:00"
           selector:
             time: {}
+        activation_condition:
+          name: Activation Condition
+          description: Optional extra conditions for power users. If not met, no actions in this automation run.
+          default: []
+          selector:
+            condition: {}
 
     light_behavior:
       name: Light Behavior
@@ -570,7 +576,7 @@ variables:
     {% endif %}
 
   can_apply_track_light: >
-    {{ (session_scope_now_ok | bool) and (is_active_phase | bool) and (presence_ok | bool) and (media_ok | bool) and not (dnd_blocked | bool) }}
+    {{ (session_scope_now_ok | bool) and (is_active_phase | bool) }}
 
 triggers:
   - trigger: state
@@ -580,7 +586,11 @@ triggers:
     entity_id: !input session_status_entity
     id: session_update
 
-conditions: []
+conditions:
+  - condition: template
+    value_template: "{{ (presence_ok | bool) and (media_ok | bool) and not (dnd_blocked | bool) }}"
+  - condition: and
+    conditions: !input activation_condition
 
 actions:
   - choose:


### PR DESCRIPTION

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

Both blueprints now include a new optional Activation Condition field so advanced users can add flexible state-based logic, including combinations like state, not-state, and grouped conditions. This gives more control over when notifications and light behavior should run.

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #339 

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [X] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [X] Tested locally with a real Home Assistant instance
- [X] Existing automations and dashboards still work as expected after the change

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [X] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [X] The blueprint has been imported and tested in Home Assistant
- [X] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
