### PR TITLE
Create F1 Replay Sync Automation Blueprint

### DIFF
--- a/blueprints/f1_replay_sync.yaml
+++ b/blueprints/f1_replay_sync.yaml
@@ -1,0 +1,56 @@
+blueprint:
+  name: F1 Replay Sync
+  description: Syncs the Play/Pause state of an F1 Replay player with a Main TV.
+  domain: automation
+  input:
+    main_tv:
+      name: Main TV
+      description: The Apple TV or Smart TV that you are watching the F1 replay on.
+      selector:
+        entity:
+          domain: media_player
+    f1_player:
+      name: F1 Replay Player
+      description: The media player running the F1 Replay (filtered for F1 integration).
+      selector:
+        entity:
+          filter:
+            integration: f1_sensor
+          domain: media_player
+
+triggers:
+  - trigger: state
+    entity_id: !input main_tv
+    to: "paused"
+    id: "pause_f1"
+  - trigger: state
+    entity_id: !input main_tv
+    to: "playing"
+    id: "resume_f1"
+
+actions:
+  - choose:
+      # Logic for Pausing
+      - conditions:
+          - condition: trigger
+            id: "pause_f1"
+          - condition: state
+            entity_id: !input f1_player
+            state: "playing"
+        sequence:
+          - action: media_player.media_pause
+            target:
+              entity_id: !input f1_player
+
+      # Logic for Resuming
+      - conditions:
+          - condition: trigger
+            id: "resume_f1"
+          - condition: state
+            entity_id: !input f1_player
+            state: "paused"
+        sequence:
+          - action: media_player.media_play
+            target:
+              entity_id: !input f1_player
+mode: single


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description
This blueprint automates the synchronization of the Play/Pause state between an F1 Replay player and a Main TV, allowing for seamless replay viewing.

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [x] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

< Started resist sensor then paused and un-paused main TV>

- [x] Tested locally with a real Home Assistant instance
- [x] Existing automations and dashboards still work as expected after the change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [x] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [x] The blueprint has been imported and tested in Home Assistant
- [x] Triggers and conditions work as expected in a live environment