### PR TITLE
Add missing translation

### DIFF
--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -61,7 +61,7 @@
     },
     "abort": {
       "reconfigure_successful": "F1 Sensor was successfully reconfigured."
-    }
+    },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
       "replay_missing": "Replay dump file not found or unreadable."


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

<img width="585" height="198" alt="image" src="https://github.com/user-attachments/assets/7c3ebcd3-a2d2-482e-b300-274d9877be8e" />

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

N/A

## Type of change

- [x] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [x] Tested locally with a real Home Assistant instance
- [x] Existing automations and dashboards still work as expected after the change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [x] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [x] Tests have been added or updated and pass locally — if applicable
- [x] Translations updated if new UI strings were added — if applicable
- [x] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
