### PR TITLE
chore: fix open security advisories via npm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,10 @@
     "node": ">=20.0"
   },
   "overrides": {
-    "tar": "^7.5.3",
+    "tar": "^7.5.10",
     "cross-spawn": "^7.0.6",
-    "brace-expansion": "^2.0.2"
+    "brace-expansion": "^2.0.2",
+    "minimatch": "^3.1.4",
+    "serialize-javascript": "^7.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Adds missing entries to the `overrides` block in `package.json` to resolve all remaining open Dependabot security advisories.

All vulnerabilities are in **transitive npm dependencies** used by Docusaurus (docs site) and semantic-release (CI tooling). They are not part of the Home Assistant integration itself and are never installed on end-user systems.

### Changes

- `tar`: bumped override from `^7.5.3` → `^7.5.10` (fixes GHSA-qffp-2rhf-9h96 — hardlink path traversal)
- `minimatch`: added override `^3.1.4` (fixes GHSA for ReDoS via nested extglobs and multiple GLOBSTAR segments)
- `serialize-javascript`: added override `^7.0.3` (fixes RCE via `RegExp.flags` / `Date.prototype.toISOString`)

### After merging

Run `npm install` locally (or let CI do it) to regenerate `package-lock.json` with the pinned versions applied. Dependabot alerts #16, #19, #20, #21, and #23 should close automatically once the lock file is updated.
