### PR TITLE
chore: Add Context7 ownership verification file

### DIFF
--- a/static/context7.json
+++ b/static/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/nicxe_github_io_f1_sensor",
+  "public_key": "pk_3AJoxtjYa3FqEusglqKIK"
+}


### PR DESCRIPTION
Adds `static/context7.json` required to claim ownership of the f1_sensor documentation on Context7 (https://context7.com/websites/nicxe_github_io_f1_sensor).

Once merged and deployed to GitHub Pages, the file will be accessible at `https://nicxe.github.io/f1_sensor/context7.json` and ownership can be verified via the Context7 admin panel.