### PR TITLE
fix: Correct Context7 refresh API endpoint URL

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Trigger Context7 re-index
         run: |
-          curl -s -X POST https://context7.com/v1/refresh \
+          curl -s -X POST https://context7.com/api/v1/refresh \
             -H "Authorization: Bearer ${{ secrets.CONTEXT7_API_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{"libraryName": "nicxe_github_io_f1_sensor"}' \


### PR DESCRIPTION
The refresh action was calling `/v1/refresh` which returned an HTML page instead of processing the request. The correct endpoint is `/api/v1/refresh`.