### PR TITLE
blue: **Add an option to mute blue flag notifications in the Race Con…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ custom_components/f1_sensor/skills/
 custom_components/f1_sensor/AGENTS.md
 custom_components/f1_sensor/CLAUDE.md
 custom_components/f1_sensor/github_bug_issue_audit_2026-03-08.md
+context7.md

--- a/blueprints/f1_race_control_notifications.yaml
+++ b/blueprints/f1_race_control_notifications.yaml
@@ -163,6 +163,12 @@ blueprint:
                   value: BLACK
                 - label: CHEQUERED
                   value: CHEQUERED
+        filter_blue_flags:
+          name: Filter Out Blue Flags
+          description: If enabled, BLUE flag race control messages are skipped before other flag filters are applied.
+          default: false
+          selector:
+            boolean: {}
         allowed_categories:
           name: Allowed Categories
           description: Comma or semicolon separated category names. Empty means all categories.
@@ -266,6 +272,7 @@ variables:
   active_phases: !input active_session_phases
   require_phase_gate: !input require_active_phase
   allowed_flags_input: !input allowed_flags
+  filter_blue_flags_input: !input filter_blue_flags
   allowed_categories_raw: !input allowed_categories
   include_keywords_raw: !input include_keywords
   exclude_keywords_raw: !input exclude_keywords
@@ -412,7 +419,9 @@ variables:
       true
     {% endif %}
   flag_ok: >-
-    {% if allowed_flags_input | count == 0 %}
+    {% if filter_blue_flags_input and (race_control_flag | upper == 'BLUE') %}
+      false
+    {% elif allowed_flags_input | count == 0 %}
       true
     {% else %}
       {{ race_control_flag | upper in allowed_flags_input }}

--- a/docs/blueprints/race-control-notifications.md
+++ b/docs/blueprints/race-control-notifications.md
@@ -82,9 +82,14 @@ All filters are optional and collapsed by default. Leave them empty to receive e
 | Setting | Description |
 | --- | --- |
 | **Allowed Flags** | Only notify for specific flag types. Leave empty to allow all flags |
+| **Filter Out Blue Flags** | Skip notifications for `BLUE` flag messages. Useful if waved blue flags create too much noise |
 | **Allowed Categories** | Comma or semicolon-separated category names. Leave empty to allow all categories |
 | **Include Keywords** | Only notify when the message contains at least one of these words |
 | **Exclude Keywords** | Skip notifications when the message contains any of these words |
+
+:::info
+**Filter Out Blue Flags** is applied before the regular flag allow-list. If you enable it, blue flag messages are suppressed even when `BLUE` is included in **Allowed Flags**.
+:::
 
 **Available flag values:**
 
@@ -200,6 +205,12 @@ Enable **Require Active Session Phase** and set **Active Session Phases** to `li
 ### Exclude administrative messages
 
 Set **Exclude Keywords** to `clerk, official, document` to filter out FIA document references.
+
+---
+
+### Silence blue flag spam
+
+Enable **Filter Out Blue Flags** if you want to keep Race Control notifications for incidents, penalties, and safety car events without receiving repeated waved blue flag messages late in the race.
 
 ---
 


### PR DESCRIPTION
…trol blueprint**

Blue flag messages can now be filtered out in the Race Control Notifications blueprint. This helps reduce notification spam during busy parts of a race while keeping other race control alerts active. Existing automations keep their current behavior until you enable the new filter.

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [X] 📋 Blueprint (new or updated blueprint)
- [X] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [X] Tested locally with a real Home Assistant instance
- [X] Existing automations and dashboards still work as expected after the change

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [X] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [X] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [X] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [X] The blueprint has been imported and tested in Home Assistant
- [X] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
