### PR TITLE
fix: Prevent startup warnings when loading translated entity names

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -60,7 +60,11 @@ from .const import (
     STRAIGHT_MODE_NORMAL,
     SUPPORTED_SENSOR_KEYS,
 )
-from .entity import register_entry_name_settings, unregister_entry_name_settings
+from .entity import (
+    async_prepare_translation_names,
+    register_entry_name_settings,
+    unregister_entry_name_settings,
+)
 from .formation_start import FormationStartTracker
 from .helpers import (
     PersistentCache,
@@ -769,6 +773,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Dev-only: periodically report how many Jolpica requests actually hit the network.
     _ensure_jolpica_stats_reporting(hass)
     register_entry_name_settings(entry.entry_id, entry.data)
+    await async_prepare_translation_names(hass, entry.entry_id)
     # Build the effective set of enabled sensors.
     # ``disabled_sensors`` stores the keys the user explicitly unchecked.
     # Everything else (including new keys added in future versions) is enabled.

--- a/custom_components/f1_sensor/entity.py
+++ b/custom_components/f1_sensor/entity.py
@@ -1,9 +1,9 @@
 import asyncio
 from contextlib import suppress
-from functools import cache
 import json
 from pathlib import Path
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -22,6 +22,7 @@ from .const import (
 
 _TRANSLATIONS_DIR = Path(__file__).parent / "translations"
 _ENTRY_NAME_SETTINGS: dict[str, tuple[str, str]] = {}
+_TRANSLATION_NAME_CACHE: dict[str, dict[str, str]] = {}
 
 
 def _normalize_language(language: str | None) -> str:
@@ -46,9 +47,8 @@ def _translation_language_candidates(language: str | None) -> tuple[str, ...]:
     return tuple(candidates)
 
 
-@cache
-def _load_translation_names(language: str) -> dict[str, str]:
-    """Load entity display names from a bundled translation file."""
+def _read_translation_names(language: str) -> dict[str, str]:
+    """Read entity display names from a bundled translation file."""
     try:
         path = _TRANSLATIONS_DIR / f"{_normalize_language(language)}.json"
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -62,6 +62,28 @@ def _load_translation_names(language: str) -> dict[str, str]:
         return {}
 
 
+def _prime_translation_names(languages: tuple[str, ...]) -> None:
+    """Load translation files into memory outside the event loop."""
+    for language in languages:
+        normalized = _normalize_language(language)
+        if normalized in _TRANSLATION_NAME_CACHE:
+            continue
+        _TRANSLATION_NAME_CACHE[normalized] = _read_translation_names(normalized)
+
+
+async def async_prepare_translation_names(
+    hass: HomeAssistant, entry_id: str | None = None
+) -> None:
+    """Preload translation files that may be needed during entity setup."""
+    mode, language = _entry_name_settings(entry_id)
+    languages = list(_translation_language_candidates(DEFAULT_ENTITY_NAME_LANGUAGE))
+    if mode == ENTITY_NAME_MODE_LOCALIZED:
+        for candidate in _translation_language_candidates(language):
+            if candidate not in languages:
+                languages.append(candidate)
+    await hass.async_add_executor_job(_prime_translation_names, tuple(languages))
+
+
 def register_entry_name_settings(entry_id: str, data: dict) -> None:
     """Register naming settings for a config entry."""
     mode = data.get(CONF_ENTITY_NAME_MODE, ENTITY_NAME_MODE_LEGACY)
@@ -69,6 +91,15 @@ def register_entry_name_settings(entry_id: str, data: dict) -> None:
         mode = ENTITY_NAME_MODE_LEGACY
     language = _normalize_language(data.get(CONF_ENTITY_NAME_LANGUAGE))
     _ENTRY_NAME_SETTINGS[entry_id] = (mode, language)
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        languages = list(_translation_language_candidates(DEFAULT_ENTITY_NAME_LANGUAGE))
+        if mode == ENTITY_NAME_MODE_LOCALIZED:
+            for candidate in _translation_language_candidates(language):
+                if candidate not in languages:
+                    languages.append(candidate)
+        _prime_translation_names(tuple(languages))
 
 
 def unregister_entry_name_settings(entry_id: str) -> None:
@@ -79,6 +110,7 @@ def unregister_entry_name_settings(entry_id: str) -> None:
 def clear_entry_name_settings() -> None:
     """Clear cached entry naming settings for tests."""
     _ENTRY_NAME_SETTINGS.clear()
+    _TRANSLATION_NAME_CACHE.clear()
 
 
 def _entry_name_settings(entry_id: str | None) -> tuple[str, str]:
@@ -94,7 +126,7 @@ def _entry_name_settings(entry_id: str | None) -> tuple[str, str]:
 def _translated_entity_name(translation_key: str, language: str) -> str | None:
     """Return the first matching translated entity name for a language."""
     for candidate in _translation_language_candidates(language):
-        if name := _load_translation_names(candidate).get(translation_key):
+        if name := _TRANSLATION_NAME_CACHE.get(candidate, {}).get(translation_key):
             return name
     return None
 

--- a/custom_components/f1_sensor/tests/test_entity_naming.py
+++ b/custom_components/f1_sensor/tests/test_entity_naming.py
@@ -25,7 +25,10 @@ from custom_components.f1_sensor.const import (
     ENTITY_NAME_MODE_LOCALIZED,
     SUPPORTED_SENSOR_KEYS,
 )
-from custom_components.f1_sensor.entity import register_entry_name_settings
+from custom_components.f1_sensor.entity import (
+    async_prepare_translation_names,
+    register_entry_name_settings,
+)
 from custom_components.f1_sensor.helpers import format_entity_name
 from custom_components.f1_sensor.number import F1LiveDelayNumber
 
@@ -205,6 +208,7 @@ async def test_localized_aux_entity_keeps_english_entity_id(hass) -> None:
             CONF_ENTITY_NAME_LANGUAGE: "sv",
         },
     )
+    await async_prepare_translation_names(hass, entry_id)
     entity = F1LiveDelayNumber(
         controller=_DummyDelayController(7),
         calibration=None,
@@ -221,6 +225,36 @@ async def test_localized_aux_entity_keeps_english_entity_id(hass) -> None:
     state = hass.states.get(entity.entity_id)
     assert state is not None
     assert state.attributes["friendly_name"] == "Livefördröjning"
+
+
+@pytest.mark.asyncio
+async def test_localized_aux_entity_name_uses_preloaded_translations_only(
+    hass, monkeypatch
+) -> None:
+    entry_id = "localized_preload_entry"
+    register_entry_name_settings(
+        entry_id,
+        {
+            CONF_ENTITY_NAME_MODE: ENTITY_NAME_MODE_LOCALIZED,
+            CONF_ENTITY_NAME_LANGUAGE: "sv",
+        },
+    )
+    await async_prepare_translation_names(hass, entry_id)
+
+    def _fail_read_text(*_args, **_kwargs):
+        raise AssertionError("translation files should already be cached")
+
+    monkeypatch.setattr("pathlib.Path.read_text", _fail_read_text)
+
+    entity = F1LiveDelayNumber(
+        controller=_DummyDelayController(7),
+        calibration=None,
+        unique_id="localized_delay_number",
+        entry_id=entry_id,
+        device_name="RaceHub",
+    )
+
+    assert entity.name == "Livefördröjning"
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_race_control_notifications_blueprint.py
+++ b/custom_components/f1_sensor/tests/test_race_control_notifications_blueprint.py
@@ -10,6 +10,8 @@ import pytest
 BLUEPRINT_SOURCE = (
     Path(__file__).resolve().parents[3]
     / "blueprints"
+    / "automation"
+    / "homeassistant"
     / "f1_race_control_notifications.yaml"
 )
 BLUEPRINT_DEST = Path(


### PR DESCRIPTION
This update removes a startup issue that could trigger Home Assistant blocking I/O warnings when the integration loaded translated entity names during setup. Entity names are now prepared safely before registration, which makes startup cleaner and more reliable without changing existing behavior for users.

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
