### PR TITLE
chore: Fix blueprint test path resolution for CI

### DIFF
--- a/custom_components/f1_sensor/tests/test_race_control_notifications_blueprint.py
+++ b/custom_components/f1_sensor/tests/test_race_control_notifications_blueprint.py
@@ -7,13 +7,16 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 import pytest
 
-BLUEPRINT_SOURCE = (
-    Path(__file__).resolve().parents[3]
-    / "blueprints"
-    / "automation"
-    / "homeassistant"
-    / "f1_race_control_notifications.yaml"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_BLUEPRINT_FILENAME = "f1_race_control_notifications.yaml"
+
+# In the repo the blueprint lives directly under blueprints/, while in a
+# Home Assistant dev instance it sits under blueprints/automation/homeassistant/.
+_REPO_PATH = _REPO_ROOT / "blueprints" / _BLUEPRINT_FILENAME
+_HA_PATH = (
+    _REPO_ROOT / "blueprints" / "automation" / "homeassistant" / _BLUEPRINT_FILENAME
 )
+BLUEPRINT_SOURCE = _REPO_PATH if _REPO_PATH.exists() else _HA_PATH
 BLUEPRINT_DEST = Path(
     "blueprints/automation/homeassistant/f1_race_control_notifications.yaml"
 )


### PR DESCRIPTION
## Summary
- Blueprint test was hardcoded to the Home Assistant dev instance path (`blueprints/automation/homeassistant/`), which doesn't exist in the repository layout where blueprints sit directly under `blueprints/`.
- The path lookup now tries the repo layout first, falling back to the HA dev instance layout, so tests pass in both CI and the local dev environment.

## Test plan
- [ ] Verify GitHub Actions tests pass (specifically the `test_race_control_notifications_blueprint` tests)
- [ ] Verify tests still pass in local HA dev instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)