### PR TITLE
chore: Upgrade actions/checkout to v6 across all workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lint & format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Ruff lint
         uses: astral-sh/ruff-action@v3

--- a/.github/workflows/sync-after-release.yml
+++ b/.github/workflows/sync-after-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/sync-content-after-push.yml
+++ b/.github/workflows/sync-content-after-push.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     name: Run pytest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
- Upgrades all workflow files from `actions/checkout@v4`/`@v5` to `@v6`, which uses Node.js 24.
- Resolves the Node.js 20 deprecation warning seen in CI.
- Also fixed the reusable sync workflows in `nicxe/.github` (directly on main) to add the correct `ref:` input, which was causing `sync-beta` to fail with \"src refspec main does not match any\".

## Test plan
- [ ] Verify GitHub Actions runs show no Node.js 20 deprecation warning
- [ ] Verify sync-beta succeeds on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)