### PR TITLE
blue: **Add WLED playlist support and finished flag handling to the t…

### DIFF
--- a/blueprints/f1_track_status.yaml
+++ b/blueprints/f1_track_status.yaml
@@ -10,13 +10,13 @@ blueprint:
     Requires F1 Sensor live entities for track/session status to be enabled in integration settings.
 
     Advanced options include scene snapshots, timed or continuous flashing, clear-state auto-restore,
-    flexible session-end behavior, and optional WLED preset control.
+    flexible session-end behavior, and optional WLED preset or playlist control.
 
-    WLED preset mode is opt-in. When enabled with a valid preset entity, preset mappings override the
-    normal color and flash logic for the matching track states. Leave preset fields empty to keep the
-    standard light behavior.
+    WLED advanced mode is opt-in. When enabled with a valid preset or playlist entity, configured WLED
+    mappings override the normal color and flash logic for the matching track states. Leave WLED fields
+    empty to keep the standard light behavior.
 
-    Track states: CLEAR, YELLOW, VSC, SC, RED.
+    Track states: CLEAR, YELLOW, VSC, SC, RED. CLEAR covers the green-flag case.
     Session phases: pre, live, suspended, break, finished, finalised, ended.
 
     You can simulate state changes in Developer Tools -> States.
@@ -224,9 +224,10 @@ blueprint:
       collapsed: true
       description: >
         Optional WLED-native control for a single WLED light. Use this when your LED strip is exposed by
-        Home Assistant as a WLED light plus companion preset, palette, intensity, and speed entities.
-        When a valid preset is configured for a track state, that preset overrides the normal color and
-        flashing logic for that state. Presets should contain any desired animation, segment, or palette setup.
+        Home Assistant as a WLED light plus companion preset and/or playlist entities with optional palette,
+        intensity, and speed helpers. When a valid playlist or preset is configured for a track state, that
+        selection overrides the normal color and flashing logic for that state. Playlists take priority over
+        presets when both are configured for the same state.
       input:
         enable_wled_advanced:
           name: Enable WLED Advanced Mode
@@ -234,6 +235,15 @@ blueprint:
           default: false
           selector:
             boolean: {}
+        wled_playlist_entity:
+          name: WLED Playlist Entity (optional)
+          description: Select the WLED playlist select entity from the same device or segment as the target light.
+          default: ""
+          selector:
+            entity:
+              filter:
+                - domain: select
+              multiple: false
         wled_preset_entity:
           name: WLED Preset Entity (optional)
           description: Select the WLED preset select entity from the same device or segment as the target light.
@@ -270,33 +280,81 @@ blueprint:
               filter:
                 - domain: number
               multiple: false
+        wled_playlist_clear:
+          name: Playlist - CLEAR / Green Flag
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal CLEAR behavior.
+          default: ""
+          selector:
+            text: {}
         wled_preset_clear:
-          name: Preset - CLEAR
-          description: Optional. Must match a WLED preset option exactly. Leave empty to use normal CLEAR behavior.
+          name: Preset - CLEAR / Green Flag
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal CLEAR behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_yellow:
+          name: Playlist - YELLOW
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal YELLOW behavior.
           default: ""
           selector:
             text: {}
         wled_preset_yellow:
           name: Preset - YELLOW
-          description: Optional. Must match a WLED preset option exactly. Leave empty to use normal YELLOW behavior.
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal YELLOW behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_red:
+          name: Playlist - RED
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal RED behavior.
           default: ""
           selector:
             text: {}
         wled_preset_red:
           name: Preset - RED
-          description: Optional. Must match a WLED preset option exactly. Leave empty to use normal RED behavior.
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal RED behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_vsc:
+          name: Playlist - VSC
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal VSC behavior.
           default: ""
           selector:
             text: {}
         wled_preset_vsc:
           name: Preset - VSC
-          description: Optional. Must match a WLED preset option exactly. Leave empty to use normal VSC behavior.
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal VSC behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_sc:
+          name: Playlist - SC
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal SC behavior.
           default: ""
           selector:
             text: {}
         wled_preset_sc:
           name: Preset - SC
-          description: Optional. Must match a WLED preset option exactly. Leave empty to use normal SC behavior.
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal SC behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_finished:
+          name: Playlist - Finished / Checkered Flag
+          description: Optional. Must match a WLED playlist option exactly. When valid, it is shown on transition to finished before the end action runs.
+          default: ""
+          selector:
+            text: {}
+        wled_preset_finished:
+          name: Preset - Finished / Checkered Flag
+          description: Optional. Must match a WLED preset option exactly. When valid, it is shown on transition to finished before the end action runs.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_end:
+          name: Playlist - Session End Neutral
+          description: Optional. Used only when End Action is neutral and the playlist exists on the selected WLED playlist entity.
           default: ""
           selector:
             text: {}
@@ -554,27 +612,38 @@ variables:
   snapshot_before_alert_enabled: !input snapshot_before_alert
 
   wled_advanced_enabled: !input enable_wled_advanced
+  wled_playlist_entity: !input wled_playlist_entity
   wled_preset_entity: !input wled_preset_entity
   wled_palette_entity: !input wled_palette_entity
   wled_intensity_entity: !input wled_intensity_entity
   wled_speed_entity: !input wled_speed_entity
+  wled_playlist_clear_name: !input wled_playlist_clear
   wled_preset_clear_name: !input wled_preset_clear
+  wled_playlist_yellow_name: !input wled_playlist_yellow
   wled_preset_yellow_name: !input wled_preset_yellow
+  wled_playlist_red_name: !input wled_playlist_red
   wled_preset_red_name: !input wled_preset_red
+  wled_playlist_vsc_name: !input wled_playlist_vsc
   wled_preset_vsc_name: !input wled_preset_vsc
+  wled_playlist_sc_name: !input wled_playlist_sc
   wled_preset_sc_name: !input wled_preset_sc
+  wled_playlist_finished_name: !input wled_playlist_finished
+  wled_preset_finished_name: !input wled_preset_finished
+  wled_playlist_end_name: !input wled_playlist_end
   wled_preset_end_name: !input wled_preset_end
+  wled_has_playlist_entity: "{{ wled_playlist_entity | string | trim | length > 0 }}"
+  wled_has_preset_entity: "{{ wled_preset_entity | string | trim | length > 0 }}"
   wled_advanced_active: >-
     {{
       (wled_advanced_enabled | bool)
       and (is_single_light_target | bool)
       and not (is_group_target | bool)
-      and (wled_preset_entity | string | trim | length > 0)
+      and ((wled_has_playlist_entity | bool) or (wled_has_preset_entity | bool))
     }}
   wled_snapshot_entities_json: >-
     {% set ns = namespace(entities=[light_entity | string]) %}
     {% if wled_advanced_active | bool %}
-      {% for entity_id in [wled_preset_entity, wled_palette_entity, wled_intensity_entity, wled_speed_entity] %}
+      {% for entity_id in [wled_playlist_entity, wled_preset_entity, wled_palette_entity, wled_intensity_entity, wled_speed_entity] %}
         {% set entity_id = entity_id | string | trim %}
         {% if entity_id | length > 0 %}
           {% set ns.entities = ns.entities + [entity_id] %}
@@ -582,6 +651,29 @@ variables:
       {% endfor %}
     {% endif %}
     {{ ns.entities | to_json }}
+  desired_wled_track_playlist: >-
+    {% set current_track_state = states(track_status_entity) | upper %}
+    {% if current_track_state == 'CLEAR' %}
+      {{ wled_playlist_clear_name | string | trim }}
+    {% elif current_track_state == 'YELLOW' %}
+      {{ wled_playlist_yellow_name | string | trim }}
+    {% elif current_track_state == 'RED' %}
+      {{ wled_playlist_red_name | string | trim }}
+    {% elif current_track_state == 'VSC' %}
+      {{ wled_playlist_vsc_name | string | trim }}
+    {% elif current_track_state == 'SC' %}
+      {{ wled_playlist_sc_name | string | trim }}
+    {% else %}
+      ""
+    {% endif %}
+  has_valid_wled_track_playlist: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_playlist_entity | bool) %}
+      false
+    {% else %}
+      {% set playlist = desired_wled_track_playlist | string | trim %}
+      {% set options = state_attr(wled_playlist_entity, 'options') | default([], true) %}
+      {{ playlist | length > 0 and playlist in options }}
+    {% endif %}
   desired_wled_track_preset: >-
     {% set current_track_state = states(track_status_entity) | upper %}
     {% if current_track_state == 'CLEAR' %}
@@ -598,22 +690,100 @@ variables:
       ""
     {% endif %}
   has_valid_wled_track_preset: >-
-    {% if not (wled_advanced_active | bool) %}
+    {% if not (wled_advanced_active | bool) or not (wled_has_preset_entity | bool) %}
       false
     {% else %}
       {% set preset = desired_wled_track_preset | string | trim %}
       {% set options = state_attr(wled_preset_entity, 'options') | default([], true) %}
       {{ preset | length > 0 and preset in options }}
     {% endif %}
+  selected_wled_track_entity: >-
+    {% if has_valid_wled_track_playlist | bool %}
+      {{ wled_playlist_entity | string | trim }}
+    {% elif has_valid_wled_track_preset | bool %}
+      {{ wled_preset_entity | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  selected_wled_track_option: >-
+    {% if has_valid_wled_track_playlist | bool %}
+      {{ desired_wled_track_playlist | string | trim }}
+    {% elif has_valid_wled_track_preset | bool %}
+      {{ desired_wled_track_preset | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  has_valid_wled_track_selection: "{{ selected_wled_track_entity | string | trim not in ['', '\"\"'] }}"
+  desired_wled_finished_playlist: "{{ wled_playlist_finished_name | string | trim }}"
+  has_valid_wled_finished_playlist: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_playlist_entity | bool) %}
+      false
+    {% else %}
+      {% set playlist = desired_wled_finished_playlist | string | trim %}
+      {% set options = state_attr(wled_playlist_entity, 'options') | default([], true) %}
+      {{ playlist | length > 0 and playlist in options }}
+    {% endif %}
+  desired_wled_finished_preset: "{{ wled_preset_finished_name | string | trim }}"
+  has_valid_wled_finished_preset: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_preset_entity | bool) %}
+      false
+    {% else %}
+      {% set preset = desired_wled_finished_preset | string | trim %}
+      {% set options = state_attr(wled_preset_entity, 'options') | default([], true) %}
+      {{ preset | length > 0 and preset in options }}
+    {% endif %}
+  selected_wled_finished_entity: >-
+    {% if has_valid_wled_finished_playlist | bool %}
+      {{ wled_playlist_entity | string | trim }}
+    {% elif has_valid_wled_finished_preset | bool %}
+      {{ wled_preset_entity | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  selected_wled_finished_option: >-
+    {% if has_valid_wled_finished_playlist | bool %}
+      {{ desired_wled_finished_playlist | string | trim }}
+    {% elif has_valid_wled_finished_preset | bool %}
+      {{ desired_wled_finished_preset | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  has_valid_wled_finished_selection: "{{ selected_wled_finished_entity | string | trim not in ['', '\"\"'] }}"
+  desired_wled_end_playlist: "{{ wled_playlist_end_name | string | trim }}"
+  has_valid_wled_end_playlist: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_playlist_entity | bool) %}
+      false
+    {% else %}
+      {% set playlist = desired_wled_end_playlist | string | trim %}
+      {% set options = state_attr(wled_playlist_entity, 'options') | default([], true) %}
+      {{ playlist | length > 0 and playlist in options }}
+    {% endif %}
   desired_wled_end_preset: "{{ wled_preset_end_name | string | trim }}"
   has_valid_wled_end_preset: >-
-    {% if not (wled_advanced_active | bool) %}
+    {% if not (wled_advanced_active | bool) or not (wled_has_preset_entity | bool) %}
       false
     {% else %}
       {% set preset = desired_wled_end_preset | string | trim %}
       {% set options = state_attr(wled_preset_entity, 'options') | default([], true) %}
       {{ preset | length > 0 and preset in options }}
     {% endif %}
+  selected_wled_end_entity: >-
+    {% if has_valid_wled_end_playlist | bool %}
+      {{ wled_playlist_entity | string | trim }}
+    {% elif has_valid_wled_end_preset | bool %}
+      {{ wled_preset_entity | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  selected_wled_end_option: >-
+    {% if has_valid_wled_end_playlist | bool %}
+      {{ desired_wled_end_playlist | string | trim }}
+    {% elif has_valid_wled_end_preset | bool %}
+      {{ desired_wled_end_preset | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  has_valid_wled_end_selection: "{{ selected_wled_end_entity | string | trim not in ['', '\"\"'] }}"
 
   yellow_red_mode_input: !input yellow_red_mode
   yellow_red_after_flash_input: !input yellow_red_after_flash
@@ -638,6 +808,8 @@ variables:
 
   track_state: "{{ states(track_status_entity) | upper }}"
   session_phase: "{{ states(session_status_entity) | lower }}"
+  trigger_from_phase: "{{ (trigger.from_state.state if trigger.from_state is not none else '') | lower }}"
+  trigger_to_phase: "{{ (trigger.to_state.state if trigger.to_state is not none else '') | lower }}"
   current_session_now: >-
     {% if current_session_entity | string | length > 0 %}
       {{ states(current_session_entity) | string }}
@@ -692,19 +864,25 @@ variables:
     {% if trigger.id != 'session_enter_active' %}
       false
     {% else %}
-      {% set from_phase = (trigger.from_state.state if trigger.from_state is not none else '') | lower %}
-      {% set to_phase = (trigger.to_state.state if trigger.to_state is not none else '') | lower %}
-      {{ (session_scope_now_ok | bool) and to_phase in valid_session_phases and from_phase not in active_phases and to_phase in active_phases }}
+      {{ (session_scope_now_ok | bool) and trigger_to_phase in valid_session_phases and trigger_from_phase not in active_phases and trigger_to_phase in active_phases }}
     {% endif %}
 
   session_left_active: >
     {% if trigger.id != 'session_leave_active' %}
       false
     {% else %}
-      {% set from_phase = (trigger.from_state.state if trigger.from_state is not none else '') | lower %}
-      {% set to_phase = (trigger.to_state.state if trigger.to_state is not none else '') | lower %}
-      {{ (session_scope_ok | bool) and to_phase in valid_session_phases and from_phase in active_phases and to_phase not in active_phases }}
+      {{ (session_scope_ok | bool) and trigger_to_phase in valid_session_phases and trigger_from_phase in active_phases and trigger_to_phase not in active_phases }}
     {% endif %}
+
+  session_finished_with_wled_override: >
+    {{
+      (session_left_active | bool)
+      and trigger_to_phase == 'finished'
+      and (has_valid_wled_finished_selection | bool)
+    }}
+
+  should_run_standard_session_exit: >
+    {{ (session_left_active | bool) and not (session_finished_with_wled_override | bool) }}
 
   presence_ok: >
     {% if presence_list | count == 0 %}
@@ -784,89 +962,112 @@ actions:
   - choose:
       - conditions:
           - condition: template
-            value_template: "{{ session_left_active | bool }}"
+            value_template: "{{ session_finished_with_wled_override | bool }}"
+        sequence:
+          - if:
+              - condition: template
+                value_template: "{{ states(light_entity) == 'off' }}"
+            then:
+              - action: light.turn_on
+                target:
+                  entity_id: !input light_target
+          - action: select.select_option
+            data:
+              entity_id: "{{ selected_wled_finished_entity }}"
+              option: "{{ selected_wled_finished_option }}"
+          - delay:
+              minutes: !input end_delay_min
+      - conditions:
+          - condition: template
+            value_template: "{{ should_run_standard_session_exit | bool }}"
         sequence:
           - delay:
               minutes: !input end_delay_min
-          - condition: template
-            value_template: "{{ states(session_status_entity) | lower not in active_phases }}"
 
-          - choose:
-              - conditions:
-                  - condition: template
-                    value_template: "{{ end_action_mode == 'turn_off' }}"
-                sequence:
-                  - action: "{{ light_turn_off_service }}"
+  - if:
+      - condition: template
+        value_template: "{{ session_finished_with_wled_override | bool or should_run_standard_session_exit | bool }}"
+    then:
+      - condition: template
+        value_template: "{{ states(session_status_entity) | lower not in active_phases }}"
+
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ end_action_mode == 'turn_off' }}"
+            sequence:
+              - action: "{{ light_turn_off_service }}"
+                target:
+                  entity_id: !input light_target
+
+          - conditions:
+              - condition: template
+                value_template: "{{ end_action_mode == 'neutral' }}"
+            sequence:
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ has_valid_wled_end_selection }}"
+                    sequence:
+                      - if:
+                          - condition: template
+                            value_template: "{{ states(light_entity) == 'off' }}"
+                        then:
+                          - action: light.turn_on
+                            target:
+                              entity_id: !input light_target
+                      - action: select.select_option
+                        data:
+                          entity_id: "{{ selected_wled_end_entity }}"
+                          option: "{{ selected_wled_end_option }}"
+                default:
+                  - action: "{{ light_turn_on_service }}"
                     target:
                       entity_id: !input light_target
-
-              - conditions:
-                  - condition: template
-                    value_template: "{{ end_action_mode == 'neutral' }}"
-                sequence:
-                  - choose:
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ has_valid_wled_end_preset }}"
-                        sequence:
-                          - if:
-                              - condition: template
-                                value_template: "{{ states(light_entity) == 'off' }}"
-                            then:
-                              - action: light.turn_on
-                                target:
-                                  entity_id: !input light_target
-                          - action: select.select_option
-                            data:
-                              entity_id: "{{ wled_preset_entity }}"
-                              option: "{{ desired_wled_end_preset }}"
-                    default:
-                      - action: "{{ light_turn_on_service }}"
-                        target:
-                          entity_id: !input light_target
-                        data:
-                          brightness_pct: !input brightness_pct
-                          rgb_color: !input end_neutral_color
-                          transition: !input transition_s
-
-              - conditions:
-                  - condition: template
-                    value_template: "{{ end_action_mode == 'restore_pre_race' and snapshot_pre_race_enabled }}"
-                sequence:
-                  - continue_on_error: true
-                    action: scene.turn_on
                     data:
-                      entity_id: "{{ 'scene.' ~ pre_race_scene_id }}"
+                      brightness_pct: !input brightness_pct
+                      rgb_color: !input end_neutral_color
+                      transition: !input transition_s
 
-          - if:
+          - conditions:
               - condition: template
-                value_template: "{{ notifications_enabled and notifications_on_session_end and has_notification_actions }}"
-            then:
-              - variables:
-                  notification_title: "F1 Session Ended"
-                  notification_track_state: "{{ states(track_status_entity) | upper }}"
-                  notification_session_phase: "{{ states(session_status_entity) | lower }}"
-                  notification_message: >-
-                    Session moved from
-                    {{ (trigger.from_state.state if trigger.from_state is not none else 'unknown') | lower }}
-                    to
-                    {{ (trigger.to_state.state if trigger.to_state is not none else 'unknown') | lower }}.
-                    Current track status: {{ states(track_status_entity) | upper }}.
-              - sequence: !input notification_actions
-
-          - if:
-              - condition: template
-                value_template: "{{ cleanup_scenes_after_end }}"
-            then:
+                value_template: "{{ end_action_mode == 'restore_pre_race' and snapshot_pre_race_enabled }}"
+            sequence:
               - continue_on_error: true
-                action: scene.delete
+                action: scene.turn_on
                 data:
                   entity_id: "{{ 'scene.' ~ pre_race_scene_id }}"
-              - continue_on_error: true
-                action: scene.delete
-                data:
-                  entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
 
+      - if:
+          - condition: template
+            value_template: "{{ notifications_enabled and notifications_on_session_end and has_notification_actions }}"
+        then:
+          - variables:
+              notification_title: "F1 Session Ended"
+              notification_track_state: "{{ states(track_status_entity) | upper }}"
+              notification_session_phase: "{{ states(session_status_entity) | lower }}"
+              notification_message: >-
+                Session moved from
+                {{ (trigger.from_state.state if trigger.from_state is not none else 'unknown') | lower }}
+                to
+                {{ (trigger.to_state.state if trigger.to_state is not none else 'unknown') | lower }}.
+                Current track status: {{ states(track_status_entity) | upper }}.
+          - sequence: !input notification_actions
+
+      - if:
+          - condition: template
+            value_template: "{{ cleanup_scenes_after_end }}"
+        then:
+          - continue_on_error: true
+            action: scene.delete
+            data:
+              entity_id: "{{ 'scene.' ~ pre_race_scene_id }}"
+          - continue_on_error: true
+            action: scene.delete
+            data:
+              entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+
+  - choose:
       - conditions:
           - condition: template
             value_template: "{{ should_apply_track_light | bool }}"
@@ -884,7 +1085,7 @@ actions:
           - choose:
               - conditions:
                   - condition: template
-                    value_template: "{{ has_valid_wled_track_preset }}"
+                    value_template: "{{ has_valid_wled_track_selection }}"
                 sequence:
                   - if:
                       - condition: template
@@ -895,8 +1096,8 @@ actions:
                           entity_id: !input light_target
                   - action: select.select_option
                     data:
-                      entity_id: "{{ wled_preset_entity }}"
-                      option: "{{ desired_wled_track_preset }}"
+                      entity_id: "{{ selected_wled_track_entity }}"
+                      option: "{{ selected_wled_track_option }}"
             default:
               - choose:
                   - conditions:

--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -14,13 +14,18 @@ import time
 from typing import Any
 from urllib.parse import urljoin
 
+from homeassistant.components import websocket_api
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_COMPONENT_LOADED
-from homeassistant.core import HomeAssistant, callback as ha_callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback as ha_callback
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
+import voluptuous as vol
 
 from .calibration import LiveDelayCalibrationManager
 from .const import (
@@ -100,6 +105,20 @@ _ACTIVITY_FILTER_MARKER = "__f1_sensor_activity_filter__"
 _ACTIVITY_FILTER_REBIND_MARKER = "__f1_sensor_activity_filter_rebound__"
 _ACTIVITY_LOGBOOK_SUBSCRIBE_MARKER = "__f1_sensor_activity_logbook_subscribe__"
 _ACTIVITY_FILTER_COMPONENTS = frozenset({"recorder", "logbook"})
+_RC_LOG_SERVICE_MARKER = "__race_control_log_service_registered__"
+_RC_LOG_WS_MARKER = "__race_control_log_ws_registered__"
+_RC_LOG_SERVICE = "clear_race_control_log"
+_RC_LOG_STORE_KEY = "race_control_log_store"
+_RC_LOG_EVENT = f"{DOMAIN}_race_control_event"
+_RC_LOG_RESET_EVENT = f"{DOMAIN}_race_control_log_reset_event"
+_RC_LOG_WS_TYPE = f"{DOMAIN}/race_control_log/get"
+_DOMAIN_ROOT_INTERNAL_KEYS = frozenset(
+    {
+        _JOLPICA_STATS_KEY,
+        _RC_LOG_SERVICE_MARKER,
+        _RC_LOG_WS_MARKER,
+    }
+)
 
 
 def _is_replay_delay_reason(reason: str | None) -> bool:
@@ -242,6 +261,423 @@ def _apply_activity_log_filter_excludes(hass: HomeAssistant) -> None:
         if callable(wrapped_subscribe):
             logbook_helpers.async_subscribe_events = wrapped_subscribe
             logbook_websocket_api.async_subscribe_events = wrapped_subscribe
+
+
+def _rc_cleanup_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_race_control_timestamp(value: Any) -> str | None:
+    text = _rc_cleanup_string(value)
+    if not text:
+        return None
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC).isoformat(timespec="seconds")
+    except Exception:
+        return text
+
+
+def _format_race_control_state(payload: dict[str, Any]) -> str:
+    message = _rc_cleanup_string(payload.get("Message") or payload.get("Text"))
+    if message:
+        return message[:255]
+    flag = _rc_cleanup_string(payload.get("Flag"))
+    category = _rc_cleanup_string(
+        payload.get("Category") or payload.get("CategoryType")
+    )
+    scope = _rc_cleanup_string(payload.get("Scope"))
+    sector = _rc_cleanup_string(payload.get("Sector"))
+    parts = [part for part in (flag, category, scope, sector) if part]
+    return " - ".join(parts) if parts else "Race control update"
+
+
+def _normalize_race_control_log_item(
+    payload: dict[str, Any],
+    *,
+    received_at: str | None = None,
+    sequence: int | None = None,
+) -> dict[str, Any]:
+    utc = _normalize_race_control_timestamp(
+        payload.get("Utc")
+        or payload.get("utc")
+        or payload.get("processedAt")
+        or payload.get("timestamp")
+    )
+    category = _rc_cleanup_string(
+        payload.get("Category") or payload.get("CategoryType")
+    )
+    flag = _rc_cleanup_string(payload.get("Flag"))
+    scope = _rc_cleanup_string(payload.get("Scope"))
+    sector = _rc_cleanup_string(payload.get("Sector") or payload.get("TrackSegment"))
+    car_number = _rc_cleanup_string(
+        payload.get("CarNumber")
+        or payload.get("Number")
+        or payload.get("Car")
+        or payload.get("Driver")
+    )
+    message = _rc_cleanup_string(payload.get("Message") or payload.get("Text"))
+    event_id = RaceControlCoordinator._message_id(payload)
+    item = {
+        "event_id": event_id,
+        "utc": utc,
+        "received_at": received_at or dt_util.utcnow().isoformat(timespec="seconds"),
+        "category": category,
+        "flag": flag,
+        "scope": scope,
+        "sector": sector,
+        "car_number": car_number,
+        "message": message or _format_race_control_state(payload),
+        "sequence": sequence,
+    }
+    return item
+
+
+def _resolve_race_control_session_label(info: dict[str, Any]) -> str | None:
+    session_type = str(info.get("Type") or "").strip()
+    session_name = str(info.get("Name") or "").strip()
+    try:
+        number = int(info.get("Number")) if info.get("Number") is not None else None
+    except Exception:
+        number = None
+
+    if session_type == "Practice":
+        return f"Practice {number}" if number else (session_name or "Practice")
+    if session_type == "Qualifying":
+        lowered = session_name.lower()
+        if lowered.startswith("sprint qualifying") or lowered.startswith(
+            "sprint shootout"
+        ):
+            return "Sprint Qualifying"
+        return "Qualifying"
+    if session_type == "Race":
+        lowered = session_name.lower()
+        if lowered.startswith("sprint qualifying") or lowered.startswith(
+            "sprint shootout"
+        ):
+            return "Sprint Qualifying"
+        if lowered.startswith("sprint"):
+            return "Sprint"
+        return session_name or "Race"
+    return session_name or session_type or None
+
+
+def _race_control_entity_id_for_entry(hass: HomeAssistant, entry_id: str) -> str | None:
+    registry = er.async_get(hass)
+    return registry.async_get_entity_id("sensor", DOMAIN, f"{entry_id}_race_control")
+
+
+def _resolve_race_control_log_entry_id(
+    hass: HomeAssistant, entity_id: str
+) -> str | None:
+    registry = er.async_get(hass)
+    entry = registry.async_get(entity_id)
+    if entry is None or entry.platform != DOMAIN:
+        return None
+    if entry.unique_id != f"{entry.config_entry_id}_race_control":
+        return None
+    return entry.config_entry_id
+
+
+class RaceControlLogStore:
+    """Persist the full Race Control history for the active or latest session."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry_id: str,
+        *,
+        session_info_coordinator: DataUpdateCoordinator | None = None,
+        session_status_coordinator: DataUpdateCoordinator | None = None,
+        storage_version: int = 1,
+    ) -> None:
+        self._hass = hass
+        self._entry_id = entry_id
+        self._session_info_coordinator = session_info_coordinator
+        self._session_status_coordinator = session_status_coordinator
+        self._store = Store(
+            hass,
+            storage_version,
+            f"{DOMAIN}_{entry_id}_race_control_log_v{storage_version}",
+        )
+        self._session_key: str | None = None
+        self._items: list[dict[str, Any]] = []
+        self._event_ids: set[str] = set()
+        self._next_sequence = 1
+        self._listeners: list[Callable[[], None]] = []
+        self._save_task: asyncio.Task | None = None
+        self._loaded = False
+
+    async def async_initialize(self) -> None:
+        stored = await self._store.async_load()
+        if isinstance(stored, dict):
+            self._session_key = _rc_cleanup_string(stored.get("session_key"))
+            raw_items = stored.get("items")
+            if isinstance(raw_items, list):
+                self._items = [
+                    dict(item) for item in raw_items if isinstance(item, dict)
+                ]
+            self._event_ids = {
+                str(item.get("event_id"))
+                for item in self._items
+                if item.get("event_id")
+            }
+            last_sequence = 0
+            for item in self._items:
+                try:
+                    last_sequence = max(last_sequence, int(item.get("sequence") or 0))
+                except Exception:
+                    continue
+            self._next_sequence = (
+                last_sequence + 1 if last_sequence > 0 else len(self._items) + 1
+            )
+        self._loaded = True
+        if self._session_info_coordinator is not None:
+            self._listeners.append(
+                self._session_info_coordinator.async_add_listener(
+                    self._handle_session_context_update
+                )
+            )
+        if self._session_status_coordinator is not None:
+            self._listeners.append(
+                self._session_status_coordinator.async_add_listener(
+                    self._handle_session_context_update
+                )
+            )
+        self._sync_session_context(fire_reset=False)
+
+    async def async_close(self) -> None:
+        while self._listeners:
+            unsub = self._listeners.pop()
+            with suppress(Exception):
+                unsub()
+        if self._save_task and not self._save_task.done():
+            self._save_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._save_task
+        self._save_task = None
+
+    @property
+    def session_key(self) -> str | None:
+        return self._session_key
+
+    def get_items(self) -> list[dict[str, Any]]:
+        return [dict(item) for item in reversed(self._items)]
+
+    def append(
+        self, payload: dict[str, Any], *, received_at: str | None = None
+    ) -> dict[str, Any] | None:
+        if not isinstance(payload, dict):
+            return None
+        self._sync_session_context(force=True)
+        item = _normalize_race_control_log_item(
+            payload,
+            received_at=received_at,
+            sequence=self._next_sequence,
+        )
+        event_id = item.get("event_id")
+        if event_id and event_id in self._event_ids:
+            return None
+        self._items.append(item)
+        if event_id:
+            self._event_ids.add(str(event_id))
+        self._next_sequence += 1
+        self._schedule_save()
+        return dict(item)
+
+    async def async_clear(self, *, reason: str = "manual") -> None:
+        self._clear(reason=reason)
+
+    def clear_for_source_stop(self, *, reason: str | None = None) -> None:
+        """Clear saved history when the active source goes unavailable."""
+        clear_reason = _rc_cleanup_string(reason) or "source_unavailable"
+        if clear_reason == "init":
+            return
+        self._clear(reason=clear_reason)
+
+    def _clear(self, *, reason: str, fire_event: bool = True) -> None:
+        had_items = bool(self._items)
+        self._items = []
+        self._event_ids = set()
+        self._next_sequence = 1
+        self._schedule_save()
+        if fire_event and (had_items or reason == "session_change"):
+            self._fire_reset_event(reason)
+
+    def _schedule_save(self) -> None:
+        if not self._loaded:
+            return
+        if self._save_task and not self._save_task.done():
+            self._save_task.cancel()
+            self._save_task = None
+
+        async def _save() -> None:
+            try:
+                await self._store.async_save(
+                    {
+                        "session_key": self._session_key,
+                        "items": list(self._items),
+                    }
+                )
+            except Exception:
+                _LOGGER.debug("Failed to persist race control log", exc_info=True)
+
+        self._save_task = self._hass.async_create_task(_save())
+
+    def _handle_session_context_update(self) -> None:
+        self._sync_session_context(fire_reset=True)
+
+    def _sync_session_context(
+        self,
+        *,
+        fire_reset: bool = True,
+        force: bool = False,
+    ) -> None:
+        new_key = self._compute_session_key()
+        if not new_key:
+            return
+        if self._session_key is None:
+            self._session_key = new_key
+            self._schedule_save()
+            return
+        if new_key == self._session_key:
+            return
+        if not force and not self._is_session_active():
+            return
+        self._session_key = new_key
+        self._clear(
+            reason="session_change" if fire_reset else "init",
+            fire_event=fire_reset,
+        )
+
+    def _is_session_active(self) -> bool:
+        data = (
+            self._session_status_coordinator.data
+            if self._session_status_coordinator is not None
+            else None
+        )
+        if not isinstance(data, dict):
+            return False
+        status = str(data.get("Status") or data.get("Message") or "").strip()
+        started = data.get("Started")
+        if started is True:
+            return True
+        return status in {"Started", "Green", "GreenFlag", "Resumed"}
+
+    def _compute_session_key(self) -> str | None:
+        info = (
+            self._session_info_coordinator.data
+            if self._session_info_coordinator is not None
+            else None
+        )
+        if not isinstance(info, dict):
+            return None
+        meeting = info.get("Meeting") if isinstance(info.get("Meeting"), dict) else {}
+        label = _resolve_race_control_session_label(info)
+        meeting_key = meeting.get("Key")
+        start = info.get("StartDate")
+        if not (meeting_key or start or label):
+            return None
+        parts = [
+            str(meeting_key or "").strip(),
+            str(start or "").strip(),
+            str(label or "").strip(),
+        ]
+        return "|".join(parts)
+
+    def _fire_reset_event(self, reason: str) -> None:
+        try:
+            self._hass.bus.async_fire(
+                _RC_LOG_RESET_EVENT,
+                {
+                    "entry_id": self._entry_id,
+                    "entity_id": _race_control_entity_id_for_entry(
+                        self._hass,
+                        self._entry_id,
+                    ),
+                    "reason": reason,
+                    "session_key": self._session_key,
+                    "cleared_at": dt_util.utcnow().isoformat(timespec="seconds"),
+                },
+            )
+        except Exception:
+            _LOGGER.debug(
+                "Failed to publish race control log reset event", exc_info=True
+            )
+
+
+def _get_race_control_log_store_for_entity(
+    hass: HomeAssistant, entity_id: str
+) -> RaceControlLogStore | None:
+    entry_id = _resolve_race_control_log_entry_id(hass, entity_id)
+    if not entry_id:
+        return None
+    data = hass.data.get(DOMAIN, {}).get(entry_id, {}) or {}
+    store = data.get(_RC_LOG_STORE_KEY)
+    return store if isinstance(store, RaceControlLogStore) else None
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): _RC_LOG_WS_TYPE,
+        vol.Required("entity_id"): cv.entity_id,
+    }
+)
+@websocket_api.async_response
+async def _ws_get_race_control_log(
+    hass: HomeAssistant,
+    connection: Any,
+    msg: dict[str, Any],
+) -> None:
+    entity_id = msg["entity_id"]
+    store = _get_race_control_log_store_for_entity(hass, entity_id)
+    if store is None:
+        connection.send_error(
+            msg["id"],
+            "not_found",
+            "Race Control log is not available for this entity",
+        )
+        return
+    connection.send_result(
+        msg["id"],
+        {
+            "entity_id": entity_id,
+            "session_key": store.session_key,
+            "items": store.get_items(),
+        },
+    )
+
+
+async def _async_handle_clear_race_control_log(
+    hass: HomeAssistant, call: ServiceCall
+) -> None:
+    entity_id = call.data["entity_id"]
+    store = _get_race_control_log_store_for_entity(hass, entity_id)
+    if store is None:
+        raise ServiceValidationError(
+            f"Race Control log is not available for {entity_id}"
+        )
+    await store.async_clear(reason="manual")
+
+
+def _async_register_race_control_log_interfaces(hass: HomeAssistant) -> None:
+    root = hass.data.setdefault(DOMAIN, {})
+    if not root.get(_RC_LOG_SERVICE_MARKER):
+        hass.services.async_register(
+            DOMAIN,
+            _RC_LOG_SERVICE,
+            partial(_async_handle_clear_race_control_log, hass),
+            schema=vol.Schema({vol.Required("entity_id"): cv.entity_id}),
+        )
+        root[_RC_LOG_SERVICE_MARKER] = True
+    if not root.get(_RC_LOG_WS_MARKER):
+        websocket_api.async_register_command(hass, _ws_get_race_control_log)
+        root[_RC_LOG_WS_MARKER] = True
 
 
 def _compute_session_fingerprint(index_payload: Any) -> str | None:
@@ -1092,6 +1528,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     weather_data_coordinator = None
     lap_count_coordinator = None
     race_control_coordinator = None
+    race_control_log_store = None
     live_mode_coordinator = None
     top_three_coordinator = None
     hass.data[LATEST_TRACK_STATUS] = None
@@ -1180,6 +1617,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             delay_controller=delay_controller,
             live_state=live_state,
         )
+        race_control_log_store = RaceControlLogStore(
+            hass,
+            entry.entry_id,
+            session_info_coordinator=session_info_coordinator,
+            session_status_coordinator=session_status_coordinator,
+        )
+        await race_control_log_store.async_initialize()
         race_control_coordinator = RaceControlCoordinator(
             hass,
             session_coordinator,
@@ -1188,6 +1632,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             config_entry=entry,
             delay_controller=delay_controller,
             live_state=live_state,
+            log_store=race_control_log_store,
         )
         weather_data_coordinator = WeatherDataCoordinator(
             hass,
@@ -1358,6 +1803,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "session_info_coordinator": session_info_coordinator,
         "session_clock_coordinator": session_clock_coordinator,
         "race_control_coordinator": race_control_coordinator if enable_rc else None,
+        _RC_LOG_STORE_KEY: race_control_log_store if enable_rc else None,
         "live_mode_coordinator": live_mode_coordinator if enable_rc else None,
         "weather_data_coordinator": weather_data_coordinator if enable_rc else None,
         "lap_count_coordinator": lap_count_coordinator if enable_rc else None,
@@ -1397,6 +1843,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "activity_filter_unsub": None,
         "no_spoiler_unsub": None,
     }
+
+    if race_control_log_store is not None:
+        _async_register_race_control_log_interfaces(hass)
 
     _apply_activity_log_filter_excludes(hass)
     hass_data = hass.data.setdefault(DOMAIN, {}).get(entry.entry_id)
@@ -1617,6 +2066,7 @@ class RaceControlCoordinator(DataUpdateCoordinator):
         config_entry: ConfigEntry | None = None,
         delay_controller: LiveDelayController | None = None,
         live_state: LiveAvailabilityTracker | None = None,
+        log_store: RaceControlLogStore | None = None,
     ):
         super().__init__(
             hass,
@@ -1647,6 +2097,7 @@ class RaceControlCoordinator(DataUpdateCoordinator):
             and config_entry.data.get(CONF_OPERATION_MODE, DEFAULT_OPERATION_MODE)
             == OPERATION_MODE_DEVELOPMENT
         )
+        self._log_store = log_store
         self._live_state_unsub: Callable[[], None] | None = None
         if live_state is not None:
             self._live_state_unsub = live_state.add_listener(self._handle_live_state)
@@ -1816,6 +2267,8 @@ class RaceControlCoordinator(DataUpdateCoordinator):
         if not is_live:
             self._last_message = None
             self.data_list = []
+            if self._log_store is not None:
+                self._log_store.clear_for_source_stop(reason=reason)
             # Notify entities to clear their state
             self.async_set_updated_data(self._last_message)
         # In replay mode, disable the startup cutoff so historical messages are accepted
@@ -1829,10 +2282,14 @@ class RaceControlCoordinator(DataUpdateCoordinator):
         if _is_no_spoiler_blocked(self):
             return
         self.available = True
+        received_at = dt_util.utcnow().isoformat(timespec="seconds")
         # Maintain last message for visibility and parity with other coordinators
         self._last_message = item
         self.data_list = [item]
         self.async_set_updated_data(item)
+        log_item = None
+        if self._log_store is not None:
+            log_item = self._log_store.append(item, received_at=received_at)
         if _LOGGER.isEnabledFor(logging.DEBUG):
             with suppress(Exception):
                 cat = item.get("Category") or item.get("CategoryType")
@@ -1850,10 +2307,28 @@ class RaceControlCoordinator(DataUpdateCoordinator):
         # Publish on HA event bus with a consistent event name
         try:
             self.hass.bus.async_fire(
-                f"{DOMAIN}_race_control_event",
+                _RC_LOG_EVENT,
                 {
+                    "entry_id": self.config_entry.entry_id
+                    if self.config_entry
+                    else None,
+                    "entity_id": (
+                        _race_control_entity_id_for_entry(
+                            self.hass,
+                            self.config_entry.entry_id,
+                        )
+                        if self.config_entry is not None
+                        else None
+                    ),
                     "message": item,
-                    "received_at": dt_util.utcnow().isoformat(timespec="seconds"),
+                    "received_at": received_at,
+                    "event_id": self._message_id(item),
+                    "log_item": log_item,
+                    "session_key": (
+                        self._log_store.session_key
+                        if self._log_store is not None
+                        else None
+                    ),
                 },
             )
         except Exception:
@@ -4675,13 +5150,19 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         unregister_entry_name_settings(entry.entry_id)
         # If this was the last entry, remove dev-only stats reporter.
         if isinstance(data_root, dict):
-            # Keep only real entry dicts (exclude our global stats key)
+            # Keep only real entry dicts (exclude our domain-level markers)
             remaining_entries = [
                 k
                 for k in data_root.keys()
-                if isinstance(k, str) and k != _JOLPICA_STATS_KEY
+                if isinstance(k, str)
+                and k not in _DOMAIN_ROOT_INTERNAL_KEYS
+                and k != _NO_SPOILER_MANAGER_KEY
             ]
             if not remaining_entries:
+                if hass.services.has_service(DOMAIN, _RC_LOG_SERVICE):
+                    with suppress(Exception):
+                        hass.services.async_remove(DOMAIN, _RC_LOG_SERVICE)
+                data_root.pop(_RC_LOG_SERVICE_MARKER, None)
                 stats = data_root.get(_JOLPICA_STATS_KEY)
                 unsub = stats.get("unsub") if isinstance(stats, dict) else None
                 if callable(unsub):
@@ -6557,24 +7038,37 @@ class SessionClockCoordinator(DataUpdateCoordinator):
     def _schedule_deliver(self) -> None:
         self._deliver()
 
+    def _replay_controller_state(self) -> ReplayState | None:
+        """Return the current replay controller state when available."""
+        entry_id = getattr(getattr(self, "config_entry", None), "entry_id", None)
+        reg = (
+            self.hass.data.get(DOMAIN, {}).get(entry_id, {})
+            if entry_id is not None
+            else {}
+        )
+        replay_controller = reg.get("replay_controller")
+        with suppress(Exception):
+            if replay_controller is not None:
+                return replay_controller.state
+        return None
+
+    def _is_replay_temporarily_frozen(self) -> bool:
+        """Return True when replay should freeze the clock reference."""
+        return self._replay_controller_state() in (
+            ReplayState.PAUSED,
+            ReplayState.SEEKING,
+        )
+
+    def _is_replay_paused(self) -> bool:
+        """Return True when replay is explicitly paused."""
+        return self._replay_controller_state() == ReplayState.PAUSED
+
     def _server_now_utc(self) -> datetime:
-        if self._replay_mode:
-            entry_id = getattr(getattr(self, "config_entry", None), "entry_id", None)
-            reg = (
-                self.hass.data.get(DOMAIN, {}).get(entry_id, {})
-                if entry_id is not None
-                else {}
-            )
-            replay_controller = reg.get("replay_controller")
-            with suppress(Exception):
-                if replay_controller is not None and replay_controller.state in (
-                    ReplayState.PAUSED,
-                    ReplayState.SEEKING,
-                ):
-                    if isinstance(self._last_heartbeat_utc, datetime):
-                        return self._last_heartbeat_utc
-                    if isinstance(self._clock_anchor_utc, datetime):
-                        return self._clock_anchor_utc
+        if self._is_replay_temporarily_frozen():
+            if isinstance(self._last_heartbeat_utc, datetime):
+                return self._last_heartbeat_utc
+            if isinstance(self._clock_anchor_utc, datetime):
+                return self._clock_anchor_utc
         if (
             isinstance(self._last_heartbeat_utc, datetime)
             and self._last_heartbeat_mono is not None
@@ -6970,11 +7464,13 @@ class SessionClockCoordinator(DataUpdateCoordinator):
             clock_elapsed = clock_elapsed_from_start
 
         terminal = self._status_is_terminal(status)
+        replay_paused = self._is_replay_paused()
         clock_running = bool(
             self._clock_anchor_extrapolating
             and clock_remaining is not None
             and clock_remaining > 0
             and not terminal
+            and not replay_paused
         )
         if terminal or (
             clock_remaining == 0 and status in {"Finished", "Finalised", "Ends"}
@@ -6985,13 +7481,16 @@ class SessionClockCoordinator(DataUpdateCoordinator):
         elif (
             clock_remaining is not None
             and clock_remaining > 0
-            and status
-            in {
-                "Started",
-                "Resumed",
-                "Inactive",
-                "Aborted",
-            }
+            and (
+                replay_paused
+                or status
+                in {
+                    "Started",
+                    "Resumed",
+                    "Inactive",
+                    "Aborted",
+                }
+            )
         ):
             clock_phase = "paused"
         else:
@@ -7053,6 +7552,8 @@ class SessionClockCoordinator(DataUpdateCoordinator):
 
     def _should_tick(self, state: dict[str, Any]) -> bool:
         if not self.available:
+            return False
+        if self._is_replay_paused():
             return False
         if bool(state.get("clock_running")):
             return True

--- a/custom_components/f1_sensor/services.yaml
+++ b/custom_components/f1_sensor/services.yaml
@@ -1,0 +1,11 @@
+clear_race_control_log:
+  name: Clear race control log
+  description: Clear the saved race control messages for the current session.
+  fields:
+    entity_id:
+      name: Race control entity
+      description: The race control sensor to clear saved messages for.
+      required: true
+      example: sensor.f1_race_control
+      selector:
+        text:

--- a/custom_components/f1_sensor/tests/fixtures/f1_track_status.yaml
+++ b/custom_components/f1_sensor/tests/fixtures/f1_track_status.yaml
@@ -10,9 +10,13 @@ blueprint:
     Requires F1 Sensor live entities for track/session status to be enabled in integration settings.
 
     Advanced options include scene snapshots, timed or continuous flashing, clear-state auto-restore,
-    and flexible session-end behavior.
+    flexible session-end behavior, and optional WLED preset or playlist control.
 
-    Track states: CLEAR, YELLOW, VSC, SC, RED.
+    WLED advanced mode is opt-in. When enabled with a valid preset or playlist entity, configured WLED
+    mappings override the normal color and flash logic for the matching track states. Leave WLED fields
+    empty to keep the standard light behavior.
+
+    Track states: CLEAR, YELLOW, VSC, SC, RED. CLEAR covers the green-flag case.
     Session phases: pre, live, suspended, break, finished, finalised, ended.
 
     You can simulate state changes in Developer Tools -> States.
@@ -213,6 +217,153 @@ blueprint:
           default: true
           selector:
             boolean: {}
+
+    wled_advanced:
+      name: WLED Advanced
+      icon: mdi:led-strip-variant
+      collapsed: true
+      description: >
+        Optional WLED-native control for a single WLED light. Use this when your LED strip is exposed by
+        Home Assistant as a WLED light plus companion preset and/or playlist entities with optional palette,
+        intensity, and speed helpers. When a valid playlist or preset is configured for a track state, that
+        selection overrides the normal color and flashing logic for that state. Playlists take priority over
+        presets when both are configured for the same state.
+      input:
+        enable_wled_advanced:
+          name: Enable WLED Advanced Mode
+          description: Only applies to a single light entity. If light target is a group, normal light behavior is used.
+          default: false
+          selector:
+            boolean: {}
+        wled_playlist_entity:
+          name: WLED Playlist Entity (optional)
+          description: Select the WLED playlist select entity from the same device or segment as the target light.
+          default: ""
+          selector:
+            entity:
+              filter:
+                - domain: select
+              multiple: false
+        wled_preset_entity:
+          name: WLED Preset Entity (optional)
+          description: Select the WLED preset select entity from the same device or segment as the target light.
+          default: ""
+          selector:
+            entity:
+              filter:
+                - domain: select
+              multiple: false
+        wled_palette_entity:
+          name: WLED Palette Entity (optional)
+          description: Optional companion entity used only for snapshot and restore.
+          default: ""
+          selector:
+            entity:
+              filter:
+                - domain: select
+              multiple: false
+        wled_intensity_entity:
+          name: WLED Intensity Entity (optional)
+          description: Optional companion entity used only for snapshot and restore.
+          default: ""
+          selector:
+            entity:
+              filter:
+                - domain: number
+              multiple: false
+        wled_speed_entity:
+          name: WLED Speed Entity (optional)
+          description: Optional companion entity used only for snapshot and restore.
+          default: ""
+          selector:
+            entity:
+              filter:
+                - domain: number
+              multiple: false
+        wled_playlist_clear:
+          name: Playlist - CLEAR / Green Flag
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal CLEAR behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_preset_clear:
+          name: Preset - CLEAR / Green Flag
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal CLEAR behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_yellow:
+          name: Playlist - YELLOW
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal YELLOW behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_preset_yellow:
+          name: Preset - YELLOW
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal YELLOW behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_red:
+          name: Playlist - RED
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal RED behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_preset_red:
+          name: Preset - RED
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal RED behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_vsc:
+          name: Playlist - VSC
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal VSC behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_preset_vsc:
+          name: Preset - VSC
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal VSC behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_sc:
+          name: Playlist - SC
+          description: Optional. Must match a WLED playlist option exactly. Leave empty to use preset or normal SC behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_preset_sc:
+          name: Preset - SC
+          description: Optional. Must match a WLED preset option exactly. Leave empty to use playlist or normal SC behavior.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_finished:
+          name: Playlist - Finished / Checkered Flag
+          description: Optional. Must match a WLED playlist option exactly. When valid, it is shown on transition to finished before the end action runs.
+          default: ""
+          selector:
+            text: {}
+        wled_preset_finished:
+          name: Preset - Finished / Checkered Flag
+          description: Optional. Must match a WLED preset option exactly. When valid, it is shown on transition to finished before the end action runs.
+          default: ""
+          selector:
+            text: {}
+        wled_playlist_end:
+          name: Playlist - Session End Neutral
+          description: Optional. Used only when End Action is neutral and the playlist exists on the selected WLED playlist entity.
+          default: ""
+          selector:
+            text: {}
+        wled_preset_end:
+          name: Preset - Session End Neutral
+          description: Optional. Used only when End Action is neutral and the preset exists on the selected WLED preset entity.
+          default: ""
+          selector:
+            text: {}
 
     flag_colors:
       name: Flag Colors
@@ -446,8 +597,10 @@ variables:
   session_status_entity: !input session_status_entity
   active_phases: !input active_session_phases
   light_entity: !input light_target
-  light_turn_on_service: "{{ 'homeassistant.turn_on' if (light_entity | string).startswith('group.') else 'light.turn_on' }}"
-  light_turn_off_service: "{{ 'homeassistant.turn_off' if (light_entity | string).startswith('group.') else 'light.turn_off' }}"
+  is_group_target: "{{ (light_entity | string).startswith('group.') }}"
+  is_single_light_target: "{{ (light_entity | string).startswith('light.') }}"
+  light_turn_on_service: "{{ 'homeassistant.turn_on' if (is_group_target | bool) else 'light.turn_on' }}"
+  light_turn_off_service: "{{ 'homeassistant.turn_off' if (is_group_target | bool) else 'light.turn_off' }}"
 
   presence_list: !input presence_devices
   media_player_entity: !input media_player_gate
@@ -457,6 +610,180 @@ variables:
 
   snapshot_pre_race_enabled: !input snapshot_pre_race
   snapshot_before_alert_enabled: !input snapshot_before_alert
+
+  wled_advanced_enabled: !input enable_wled_advanced
+  wled_playlist_entity: !input wled_playlist_entity
+  wled_preset_entity: !input wled_preset_entity
+  wled_palette_entity: !input wled_palette_entity
+  wled_intensity_entity: !input wled_intensity_entity
+  wled_speed_entity: !input wled_speed_entity
+  wled_playlist_clear_name: !input wled_playlist_clear
+  wled_preset_clear_name: !input wled_preset_clear
+  wled_playlist_yellow_name: !input wled_playlist_yellow
+  wled_preset_yellow_name: !input wled_preset_yellow
+  wled_playlist_red_name: !input wled_playlist_red
+  wled_preset_red_name: !input wled_preset_red
+  wled_playlist_vsc_name: !input wled_playlist_vsc
+  wled_preset_vsc_name: !input wled_preset_vsc
+  wled_playlist_sc_name: !input wled_playlist_sc
+  wled_preset_sc_name: !input wled_preset_sc
+  wled_playlist_finished_name: !input wled_playlist_finished
+  wled_preset_finished_name: !input wled_preset_finished
+  wled_playlist_end_name: !input wled_playlist_end
+  wled_preset_end_name: !input wled_preset_end
+  wled_has_playlist_entity: "{{ wled_playlist_entity | string | trim | length > 0 }}"
+  wled_has_preset_entity: "{{ wled_preset_entity | string | trim | length > 0 }}"
+  wled_advanced_active: >-
+    {{
+      (wled_advanced_enabled | bool)
+      and (is_single_light_target | bool)
+      and not (is_group_target | bool)
+      and ((wled_has_playlist_entity | bool) or (wled_has_preset_entity | bool))
+    }}
+  wled_snapshot_entities_json: >-
+    {% set ns = namespace(entities=[light_entity | string]) %}
+    {% if wled_advanced_active | bool %}
+      {% for entity_id in [wled_playlist_entity, wled_preset_entity, wled_palette_entity, wled_intensity_entity, wled_speed_entity] %}
+        {% set entity_id = entity_id | string | trim %}
+        {% if entity_id | length > 0 %}
+          {% set ns.entities = ns.entities + [entity_id] %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+    {{ ns.entities | to_json }}
+  desired_wled_track_playlist: >-
+    {% set current_track_state = states(track_status_entity) | upper %}
+    {% if current_track_state == 'CLEAR' %}
+      {{ wled_playlist_clear_name | string | trim }}
+    {% elif current_track_state == 'YELLOW' %}
+      {{ wled_playlist_yellow_name | string | trim }}
+    {% elif current_track_state == 'RED' %}
+      {{ wled_playlist_red_name | string | trim }}
+    {% elif current_track_state == 'VSC' %}
+      {{ wled_playlist_vsc_name | string | trim }}
+    {% elif current_track_state == 'SC' %}
+      {{ wled_playlist_sc_name | string | trim }}
+    {% else %}
+      ""
+    {% endif %}
+  has_valid_wled_track_playlist: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_playlist_entity | bool) %}
+      false
+    {% else %}
+      {% set playlist = desired_wled_track_playlist | string | trim %}
+      {% set options = state_attr(wled_playlist_entity, 'options') | default([], true) %}
+      {{ playlist | length > 0 and playlist in options }}
+    {% endif %}
+  desired_wled_track_preset: >-
+    {% set current_track_state = states(track_status_entity) | upper %}
+    {% if current_track_state == 'CLEAR' %}
+      {{ wled_preset_clear_name | string | trim }}
+    {% elif current_track_state == 'YELLOW' %}
+      {{ wled_preset_yellow_name | string | trim }}
+    {% elif current_track_state == 'RED' %}
+      {{ wled_preset_red_name | string | trim }}
+    {% elif current_track_state == 'VSC' %}
+      {{ wled_preset_vsc_name | string | trim }}
+    {% elif current_track_state == 'SC' %}
+      {{ wled_preset_sc_name | string | trim }}
+    {% else %}
+      ""
+    {% endif %}
+  has_valid_wled_track_preset: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_preset_entity | bool) %}
+      false
+    {% else %}
+      {% set preset = desired_wled_track_preset | string | trim %}
+      {% set options = state_attr(wled_preset_entity, 'options') | default([], true) %}
+      {{ preset | length > 0 and preset in options }}
+    {% endif %}
+  selected_wled_track_entity: >-
+    {% if has_valid_wled_track_playlist | bool %}
+      {{ wled_playlist_entity | string | trim }}
+    {% elif has_valid_wled_track_preset | bool %}
+      {{ wled_preset_entity | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  selected_wled_track_option: >-
+    {% if has_valid_wled_track_playlist | bool %}
+      {{ desired_wled_track_playlist | string | trim }}
+    {% elif has_valid_wled_track_preset | bool %}
+      {{ desired_wled_track_preset | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  has_valid_wled_track_selection: "{{ selected_wled_track_entity | string | trim not in ['', '\"\"'] }}"
+  desired_wled_finished_playlist: "{{ wled_playlist_finished_name | string | trim }}"
+  has_valid_wled_finished_playlist: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_playlist_entity | bool) %}
+      false
+    {% else %}
+      {% set playlist = desired_wled_finished_playlist | string | trim %}
+      {% set options = state_attr(wled_playlist_entity, 'options') | default([], true) %}
+      {{ playlist | length > 0 and playlist in options }}
+    {% endif %}
+  desired_wled_finished_preset: "{{ wled_preset_finished_name | string | trim }}"
+  has_valid_wled_finished_preset: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_preset_entity | bool) %}
+      false
+    {% else %}
+      {% set preset = desired_wled_finished_preset | string | trim %}
+      {% set options = state_attr(wled_preset_entity, 'options') | default([], true) %}
+      {{ preset | length > 0 and preset in options }}
+    {% endif %}
+  selected_wled_finished_entity: >-
+    {% if has_valid_wled_finished_playlist | bool %}
+      {{ wled_playlist_entity | string | trim }}
+    {% elif has_valid_wled_finished_preset | bool %}
+      {{ wled_preset_entity | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  selected_wled_finished_option: >-
+    {% if has_valid_wled_finished_playlist | bool %}
+      {{ desired_wled_finished_playlist | string | trim }}
+    {% elif has_valid_wled_finished_preset | bool %}
+      {{ desired_wled_finished_preset | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  has_valid_wled_finished_selection: "{{ selected_wled_finished_entity | string | trim not in ['', '\"\"'] }}"
+  desired_wled_end_playlist: "{{ wled_playlist_end_name | string | trim }}"
+  has_valid_wled_end_playlist: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_playlist_entity | bool) %}
+      false
+    {% else %}
+      {% set playlist = desired_wled_end_playlist | string | trim %}
+      {% set options = state_attr(wled_playlist_entity, 'options') | default([], true) %}
+      {{ playlist | length > 0 and playlist in options }}
+    {% endif %}
+  desired_wled_end_preset: "{{ wled_preset_end_name | string | trim }}"
+  has_valid_wled_end_preset: >-
+    {% if not (wled_advanced_active | bool) or not (wled_has_preset_entity | bool) %}
+      false
+    {% else %}
+      {% set preset = desired_wled_end_preset | string | trim %}
+      {% set options = state_attr(wled_preset_entity, 'options') | default([], true) %}
+      {{ preset | length > 0 and preset in options }}
+    {% endif %}
+  selected_wled_end_entity: >-
+    {% if has_valid_wled_end_playlist | bool %}
+      {{ wled_playlist_entity | string | trim }}
+    {% elif has_valid_wled_end_preset | bool %}
+      {{ wled_preset_entity | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  selected_wled_end_option: >-
+    {% if has_valid_wled_end_playlist | bool %}
+      {{ desired_wled_end_playlist | string | trim }}
+    {% elif has_valid_wled_end_preset | bool %}
+      {{ desired_wled_end_preset | string | trim }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  has_valid_wled_end_selection: "{{ selected_wled_end_entity | string | trim not in ['', '\"\"'] }}"
 
   yellow_red_mode_input: !input yellow_red_mode
   yellow_red_after_flash_input: !input yellow_red_after_flash
@@ -481,6 +808,8 @@ variables:
 
   track_state: "{{ states(track_status_entity) | upper }}"
   session_phase: "{{ states(session_status_entity) | lower }}"
+  trigger_from_phase: "{{ (trigger.from_state.state if trigger.from_state is not none else '') | lower }}"
+  trigger_to_phase: "{{ (trigger.to_state.state if trigger.to_state is not none else '') | lower }}"
   current_session_now: >-
     {% if current_session_entity | string | length > 0 %}
       {{ states(current_session_entity) | string }}
@@ -535,19 +864,25 @@ variables:
     {% if trigger.id != 'session_enter_active' %}
       false
     {% else %}
-      {% set from_phase = (trigger.from_state.state if trigger.from_state is not none else '') | lower %}
-      {% set to_phase = (trigger.to_state.state if trigger.to_state is not none else '') | lower %}
-      {{ (session_scope_now_ok | bool) and to_phase in valid_session_phases and from_phase not in active_phases and to_phase in active_phases }}
+      {{ (session_scope_now_ok | bool) and trigger_to_phase in valid_session_phases and trigger_from_phase not in active_phases and trigger_to_phase in active_phases }}
     {% endif %}
 
   session_left_active: >
     {% if trigger.id != 'session_leave_active' %}
       false
     {% else %}
-      {% set from_phase = (trigger.from_state.state if trigger.from_state is not none else '') | lower %}
-      {% set to_phase = (trigger.to_state.state if trigger.to_state is not none else '') | lower %}
-      {{ (session_scope_ok | bool) and to_phase in valid_session_phases and from_phase in active_phases and to_phase not in active_phases }}
+      {{ (session_scope_ok | bool) and trigger_to_phase in valid_session_phases and trigger_from_phase in active_phases and trigger_to_phase not in active_phases }}
     {% endif %}
+
+  session_finished_with_wled_override: >
+    {{
+      (session_left_active | bool)
+      and trigger_to_phase == 'finished'
+      and (has_valid_wled_finished_selection | bool)
+    }}
+
+  should_run_standard_session_exit: >
+    {{ (session_left_active | bool) and not (session_finished_with_wled_override | bool) }}
 
   presence_ok: >
     {% if presence_list | count == 0 %}
@@ -622,32 +957,70 @@ actions:
             action: scene.create
             data:
               scene_id: "{{ pre_race_scene_id }}"
-              snapshot_entities:
-                - !input light_target
+              snapshot_entities: "{{ wled_snapshot_entities_json | from_json }}"
 
   - choose:
       - conditions:
           - condition: template
-            value_template: "{{ session_left_active | bool }}"
+            value_template: "{{ session_finished_with_wled_override | bool }}"
+        sequence:
+          - if:
+              - condition: template
+                value_template: "{{ states(light_entity) == 'off' }}"
+            then:
+              - action: light.turn_on
+                target:
+                  entity_id: !input light_target
+          - action: select.select_option
+            data:
+              entity_id: "{{ selected_wled_finished_entity }}"
+              option: "{{ selected_wled_finished_option }}"
+          - delay:
+              minutes: !input end_delay_min
+      - conditions:
+          - condition: template
+            value_template: "{{ should_run_standard_session_exit | bool }}"
         sequence:
           - delay:
               minutes: !input end_delay_min
-          - condition: template
-            value_template: "{{ states(session_status_entity) | lower not in active_phases }}"
 
-          - choose:
-              - conditions:
-                  - condition: template
-                    value_template: "{{ end_action_mode == 'turn_off' }}"
-                sequence:
-                  - action: "{{ light_turn_off_service }}"
-                    target:
-                      entity_id: !input light_target
+  - if:
+      - condition: template
+        value_template: "{{ session_finished_with_wled_override | bool or should_run_standard_session_exit | bool }}"
+    then:
+      - condition: template
+        value_template: "{{ states(session_status_entity) | lower not in active_phases }}"
 
-              - conditions:
-                  - condition: template
-                    value_template: "{{ end_action_mode == 'neutral' }}"
-                sequence:
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ end_action_mode == 'turn_off' }}"
+            sequence:
+              - action: "{{ light_turn_off_service }}"
+                target:
+                  entity_id: !input light_target
+
+          - conditions:
+              - condition: template
+                value_template: "{{ end_action_mode == 'neutral' }}"
+            sequence:
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ has_valid_wled_end_selection }}"
+                    sequence:
+                      - if:
+                          - condition: template
+                            value_template: "{{ states(light_entity) == 'off' }}"
+                        then:
+                          - action: light.turn_on
+                            target:
+                              entity_id: !input light_target
+                      - action: select.select_option
+                        data:
+                          entity_id: "{{ selected_wled_end_entity }}"
+                          option: "{{ selected_wled_end_option }}"
+                default:
                   - action: "{{ light_turn_on_service }}"
                     target:
                       entity_id: !input light_target
@@ -656,44 +1029,45 @@ actions:
                       rgb_color: !input end_neutral_color
                       transition: !input transition_s
 
-              - conditions:
-                  - condition: template
-                    value_template: "{{ end_action_mode == 'restore_pre_race' and snapshot_pre_race_enabled }}"
-                sequence:
-                  - continue_on_error: true
-                    action: scene.turn_on
-                    data:
-                      entity_id: "{{ 'scene.' ~ pre_race_scene_id }}"
-
-          - if:
+          - conditions:
               - condition: template
-                value_template: "{{ notifications_enabled and notifications_on_session_end and has_notification_actions }}"
-            then:
-              - variables:
-                  notification_title: "F1 Session Ended"
-                  notification_track_state: "{{ states(track_status_entity) | upper }}"
-                  notification_session_phase: "{{ states(session_status_entity) | lower }}"
-                  notification_message: >-
-                    Session moved from
-                    {{ (trigger.from_state.state if trigger.from_state is not none else 'unknown') | lower }}
-                    to
-                    {{ (trigger.to_state.state if trigger.to_state is not none else 'unknown') | lower }}.
-                    Current track status: {{ states(track_status_entity) | upper }}.
-              - sequence: !input notification_actions
-
-          - if:
-              - condition: template
-                value_template: "{{ cleanup_scenes_after_end }}"
-            then:
+                value_template: "{{ end_action_mode == 'restore_pre_race' and snapshot_pre_race_enabled }}"
+            sequence:
               - continue_on_error: true
-                action: scene.delete
+                action: scene.turn_on
                 data:
                   entity_id: "{{ 'scene.' ~ pre_race_scene_id }}"
-              - continue_on_error: true
-                action: scene.delete
-                data:
-                  entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
 
+      - if:
+          - condition: template
+            value_template: "{{ notifications_enabled and notifications_on_session_end and has_notification_actions }}"
+        then:
+          - variables:
+              notification_title: "F1 Session Ended"
+              notification_track_state: "{{ states(track_status_entity) | upper }}"
+              notification_session_phase: "{{ states(session_status_entity) | lower }}"
+              notification_message: >-
+                Session moved from
+                {{ (trigger.from_state.state if trigger.from_state is not none else 'unknown') | lower }}
+                to
+                {{ (trigger.to_state.state if trigger.to_state is not none else 'unknown') | lower }}.
+                Current track status: {{ states(track_status_entity) | upper }}.
+          - sequence: !input notification_actions
+
+      - if:
+          - condition: template
+            value_template: "{{ cleanup_scenes_after_end }}"
+        then:
+          - continue_on_error: true
+            action: scene.delete
+            data:
+              entity_id: "{{ 'scene.' ~ pre_race_scene_id }}"
+          - continue_on_error: true
+            action: scene.delete
+            data:
+              entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+
+  - choose:
       - conditions:
           - condition: template
             value_template: "{{ should_apply_track_light | bool }}"
@@ -706,407 +1080,423 @@ actions:
                 action: scene.create
                 data:
                   scene_id: "{{ pre_alert_scene_id }}"
-                  snapshot_entities:
-                    - !input light_target
+                  snapshot_entities: "{{ wled_snapshot_entities_json | from_json }}"
 
           - choose:
               - conditions:
                   - condition: template
-                    value_template: "{{ track_state == 'CLEAR' }}"
+                    value_template: "{{ has_valid_wled_track_selection }}"
                 sequence:
-                  - choose:
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ clear_behavior_mode_input == 'steady' or (clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay'] and not snapshot_before_alert_enabled) }}"
-                        sequence:
-                          - action: "{{ light_turn_on_service }}"
-                            target:
-                              entity_id: !input light_target
-                            data:
-                              brightness_pct: !input brightness_pct
-                              rgb_color: !input color_clear
-                              transition: !input transition_s
+                  - if:
+                      - condition: template
+                        value_template: "{{ states(light_entity) == 'off' }}"
+                    then:
+                      - action: light.turn_on
+                        target:
+                          entity_id: !input light_target
+                  - action: select.select_option
+                    data:
+                      entity_id: "{{ selected_wled_track_entity }}"
+                      option: "{{ selected_wled_track_option }}"
+            default:
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ track_state == 'CLEAR' }}"
+                    sequence:
+                      - choose:
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ clear_behavior_mode_input == 'steady' or (clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay'] and not snapshot_before_alert_enabled) }}"
+                            sequence:
+                              - action: "{{ light_turn_on_service }}"
+                                target:
+                                  entity_id: !input light_target
+                                data:
+                                  brightness_pct: !input brightness_pct
+                                  rgb_color: !input color_clear
+                                  transition: !input transition_s
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ clear_behavior_mode_input == 'restore_immediately' and snapshot_before_alert_enabled }}"
-                        sequence:
-                          - continue_on_error: true
-                            action: scene.turn_on
-                            data:
-                              entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ clear_behavior_mode_input == 'restore_immediately' and snapshot_before_alert_enabled }}"
+                            sequence:
+                              - continue_on_error: true
+                                action: scene.turn_on
+                                data:
+                                  entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ clear_behavior_mode_input == 'restore_after_delay' and snapshot_before_alert_enabled }}"
-                        sequence:
-                          - action: "{{ light_turn_on_service }}"
-                            target:
-                              entity_id: !input light_target
-                            data:
-                              brightness_pct: !input brightness_pct
-                              rgb_color: !input color_clear
-                              transition: !input transition_s
-                          - delay:
-                              seconds: !input clear_restore_delay_s
-                          - condition: template
-                            value_template: "{{ states(track_status_entity) | upper == 'CLEAR' }}"
-                          - continue_on_error: true
-                            action: scene.turn_on
-                            data:
-                              entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ clear_behavior_mode_input == 'restore_after_delay' and snapshot_before_alert_enabled }}"
+                            sequence:
+                              - action: "{{ light_turn_on_service }}"
+                                target:
+                                  entity_id: !input light_target
+                                data:
+                                  brightness_pct: !input brightness_pct
+                                  rgb_color: !input color_clear
+                                  transition: !input transition_s
+                              - delay:
+                                  seconds: !input clear_restore_delay_s
+                              - condition: template
+                                value_template: "{{ states(track_status_entity) | upper == 'CLEAR' }}"
+                              - continue_on_error: true
+                                action: scene.turn_on
+                                data:
+                                  entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
 
-              - conditions:
-                  - condition: template
-                    value_template: "{{ track_state == 'YELLOW' }}"
-                sequence:
-                  - choose:
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ yellow_red_mode_input == 'steady' }}"
-                        sequence:
-                          - action: "{{ light_turn_on_service }}"
-                            target:
-                              entity_id: !input light_target
-                            data:
-                              brightness_pct: !input brightness_pct
-                              rgb_color: !input color_yellow
-                              transition: !input transition_s
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ track_state == 'YELLOW' }}"
+                    sequence:
+                      - choose:
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ yellow_red_mode_input == 'steady' }}"
+                            sequence:
+                              - action: "{{ light_turn_on_service }}"
+                                target:
+                                  entity_id: !input light_target
+                                data:
+                                  brightness_pct: !input brightness_pct
+                                  rgb_color: !input color_yellow
+                                  transition: !input transition_s
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ yellow_red_mode_input == 'flash_continuous' }}"
-                        sequence:
-                          - repeat:
-                              while:
-                                - condition: template
-                                  value_template: "{{ states(track_status_entity) | upper == 'YELLOW' }}"
-                              sequence:
-                                - action: "{{ light_turn_on_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                  data:
-                                    brightness_pct: !input brightness_pct
-                                    rgb_color: !input color_yellow
-                                - delay:
-                                    seconds: !input flash_interval_s
-                                - action: "{{ light_turn_off_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                - delay:
-                                    seconds: !input flash_interval_s
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ yellow_red_mode_input == 'flash_continuous' }}"
+                            sequence:
+                              - repeat:
+                                  while:
+                                    - condition: template
+                                      value_template: "{{ states(track_status_entity) | upper == 'YELLOW' }}"
+                                  sequence:
+                                    - action: "{{ light_turn_on_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                      data:
+                                        brightness_pct: !input brightness_pct
+                                        rgb_color: !input color_yellow
+                                    - delay:
+                                        seconds: !input flash_interval_s
+                                    - action: "{{ light_turn_off_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                    - delay:
+                                        seconds: !input flash_interval_s
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ yellow_red_mode_input == 'flash_timed' }}"
-                        sequence:
-                          - variables:
-                              flash_end_ts: "{{ as_timestamp(now()) + (yellow_red_flash_duration_input | int(10)) }}"
-                          - repeat:
-                              while:
-                                - condition: template
-                                  value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'YELLOW' }}"
-                              sequence:
-                                - action: "{{ light_turn_on_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                  data:
-                                    brightness_pct: !input brightness_pct
-                                    rgb_color: !input color_yellow
-                                - delay:
-                                    seconds: !input flash_interval_s
-                                - action: "{{ light_turn_off_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                - delay:
-                                    seconds: !input flash_interval_s
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ yellow_red_mode_input == 'flash_timed' }}"
+                            sequence:
+                              - variables:
+                                  flash_end_ts: "{{ as_timestamp(now()) + (yellow_red_flash_duration_input | int(10)) }}"
+                              - repeat:
+                                  while:
+                                    - condition: template
+                                      value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'YELLOW' }}"
+                                  sequence:
+                                    - action: "{{ light_turn_on_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                      data:
+                                        brightness_pct: !input brightness_pct
+                                        rgb_color: !input color_yellow
+                                    - delay:
+                                        seconds: !input flash_interval_s
+                                    - action: "{{ light_turn_off_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                    - delay:
+                                        seconds: !input flash_interval_s
 
-                          - condition: template
-                            value_template: "{{ states(track_status_entity) | upper == 'YELLOW' }}"
-                          - choose:
-                              - conditions:
-                                  - condition: template
-                                    value_template: "{{ yellow_red_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
-                                sequence:
-                                  - continue_on_error: true
-                                    action: scene.turn_on
-                                    data:
-                                      entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
-                              - conditions:
-                                  - condition: template
-                                    value_template: "{{ yellow_red_after_flash_input == 'steady' or (yellow_red_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
-                                sequence:
-                                  - action: "{{ light_turn_on_service }}"
-                                    target:
-                                      entity_id: !input light_target
-                                    data:
-                                      brightness_pct: !input brightness_pct
-                                      rgb_color: !input color_yellow
-                                      transition: !input transition_s
+                              - condition: template
+                                value_template: "{{ states(track_status_entity) | upper == 'YELLOW' }}"
+                              - choose:
+                                  - conditions:
+                                      - condition: template
+                                        value_template: "{{ yellow_red_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
+                                    sequence:
+                                      - continue_on_error: true
+                                        action: scene.turn_on
+                                        data:
+                                          entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                                  - conditions:
+                                      - condition: template
+                                        value_template: "{{ yellow_red_after_flash_input == 'steady' or (yellow_red_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
+                                    sequence:
+                                      - action: "{{ light_turn_on_service }}"
+                                        target:
+                                          entity_id: !input light_target
+                                        data:
+                                          brightness_pct: !input brightness_pct
+                                          rgb_color: !input color_yellow
+                                          transition: !input transition_s
 
-              - conditions:
-                  - condition: template
-                    value_template: "{{ track_state == 'RED' }}"
-                sequence:
-                  - choose:
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ yellow_red_mode_input == 'steady' }}"
-                        sequence:
-                          - action: "{{ light_turn_on_service }}"
-                            target:
-                              entity_id: !input light_target
-                            data:
-                              brightness_pct: !input brightness_pct
-                              rgb_color: !input color_red
-                              transition: !input transition_s
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ track_state == 'RED' }}"
+                    sequence:
+                      - choose:
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ yellow_red_mode_input == 'steady' }}"
+                            sequence:
+                              - action: "{{ light_turn_on_service }}"
+                                target:
+                                  entity_id: !input light_target
+                                data:
+                                  brightness_pct: !input brightness_pct
+                                  rgb_color: !input color_red
+                                  transition: !input transition_s
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ yellow_red_mode_input == 'flash_continuous' }}"
-                        sequence:
-                          - repeat:
-                              while:
-                                - condition: template
-                                  value_template: "{{ states(track_status_entity) | upper == 'RED' }}"
-                              sequence:
-                                - action: "{{ light_turn_on_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                  data:
-                                    brightness_pct: !input brightness_pct
-                                    rgb_color: !input color_red
-                                - delay:
-                                    seconds: !input flash_interval_s
-                                - action: "{{ light_turn_off_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                - delay:
-                                    seconds: !input flash_interval_s
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ yellow_red_mode_input == 'flash_continuous' }}"
+                            sequence:
+                              - repeat:
+                                  while:
+                                    - condition: template
+                                      value_template: "{{ states(track_status_entity) | upper == 'RED' }}"
+                                  sequence:
+                                    - action: "{{ light_turn_on_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                      data:
+                                        brightness_pct: !input brightness_pct
+                                        rgb_color: !input color_red
+                                    - delay:
+                                        seconds: !input flash_interval_s
+                                    - action: "{{ light_turn_off_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                    - delay:
+                                        seconds: !input flash_interval_s
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ yellow_red_mode_input == 'flash_timed' }}"
-                        sequence:
-                          - variables:
-                              flash_end_ts: "{{ as_timestamp(now()) + (yellow_red_flash_duration_input | int(10)) }}"
-                          - repeat:
-                              while:
-                                - condition: template
-                                  value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'RED' }}"
-                              sequence:
-                                - action: "{{ light_turn_on_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                  data:
-                                    brightness_pct: !input brightness_pct
-                                    rgb_color: !input color_red
-                                - delay:
-                                    seconds: !input flash_interval_s
-                                - action: "{{ light_turn_off_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                - delay:
-                                    seconds: !input flash_interval_s
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ yellow_red_mode_input == 'flash_timed' }}"
+                            sequence:
+                              - variables:
+                                  flash_end_ts: "{{ as_timestamp(now()) + (yellow_red_flash_duration_input | int(10)) }}"
+                              - repeat:
+                                  while:
+                                    - condition: template
+                                      value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'RED' }}"
+                                  sequence:
+                                    - action: "{{ light_turn_on_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                      data:
+                                        brightness_pct: !input brightness_pct
+                                        rgb_color: !input color_red
+                                    - delay:
+                                        seconds: !input flash_interval_s
+                                    - action: "{{ light_turn_off_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                    - delay:
+                                        seconds: !input flash_interval_s
 
-                          - condition: template
-                            value_template: "{{ states(track_status_entity) | upper == 'RED' }}"
-                          - choose:
-                              - conditions:
-                                  - condition: template
-                                    value_template: "{{ yellow_red_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
-                                sequence:
-                                  - continue_on_error: true
-                                    action: scene.turn_on
-                                    data:
-                                      entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
-                              - conditions:
-                                  - condition: template
-                                    value_template: "{{ yellow_red_after_flash_input == 'steady' or (yellow_red_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
-                                sequence:
-                                  - action: "{{ light_turn_on_service }}"
-                                    target:
-                                      entity_id: !input light_target
-                                    data:
-                                      brightness_pct: !input brightness_pct
-                                      rgb_color: !input color_red
-                                      transition: !input transition_s
+                              - condition: template
+                                value_template: "{{ states(track_status_entity) | upper == 'RED' }}"
+                              - choose:
+                                  - conditions:
+                                      - condition: template
+                                        value_template: "{{ yellow_red_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
+                                    sequence:
+                                      - continue_on_error: true
+                                        action: scene.turn_on
+                                        data:
+                                          entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                                  - conditions:
+                                      - condition: template
+                                        value_template: "{{ yellow_red_after_flash_input == 'steady' or (yellow_red_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
+                                    sequence:
+                                      - action: "{{ light_turn_on_service }}"
+                                        target:
+                                          entity_id: !input light_target
+                                        data:
+                                          brightness_pct: !input brightness_pct
+                                          rgb_color: !input color_red
+                                          transition: !input transition_s
 
-              - conditions:
-                  - condition: template
-                    value_template: "{{ track_state == 'SC' }}"
-                sequence:
-                  - choose:
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ sc_vsc_mode_input == 'steady' }}"
-                        sequence:
-                          - action: "{{ light_turn_on_service }}"
-                            target:
-                              entity_id: !input light_target
-                            data:
-                              brightness_pct: !input brightness_pct
-                              rgb_color: !input color_sc
-                              transition: !input transition_s
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ track_state == 'SC' }}"
+                    sequence:
+                      - choose:
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ sc_vsc_mode_input == 'steady' }}"
+                            sequence:
+                              - action: "{{ light_turn_on_service }}"
+                                target:
+                                  entity_id: !input light_target
+                                data:
+                                  brightness_pct: !input brightness_pct
+                                  rgb_color: !input color_sc
+                                  transition: !input transition_s
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ sc_vsc_mode_input == 'flash_continuous' }}"
-                        sequence:
-                          - repeat:
-                              while:
-                                - condition: template
-                                  value_template: "{{ states(track_status_entity) | upper == 'SC' }}"
-                              sequence:
-                                - action: "{{ light_turn_on_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                  data:
-                                    brightness_pct: !input brightness_pct
-                                    rgb_color: !input color_sc
-                                - delay:
-                                    seconds: !input flash_interval_s
-                                - action: "{{ light_turn_off_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                - delay:
-                                    seconds: !input flash_interval_s
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ sc_vsc_mode_input == 'flash_continuous' }}"
+                            sequence:
+                              - repeat:
+                                  while:
+                                    - condition: template
+                                      value_template: "{{ states(track_status_entity) | upper == 'SC' }}"
+                                  sequence:
+                                    - action: "{{ light_turn_on_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                      data:
+                                        brightness_pct: !input brightness_pct
+                                        rgb_color: !input color_sc
+                                    - delay:
+                                        seconds: !input flash_interval_s
+                                    - action: "{{ light_turn_off_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                    - delay:
+                                        seconds: !input flash_interval_s
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ sc_vsc_mode_input == 'flash_timed' }}"
-                        sequence:
-                          - variables:
-                              flash_end_ts: "{{ as_timestamp(now()) + (sc_vsc_flash_duration_input | int(10)) }}"
-                          - repeat:
-                              while:
-                                - condition: template
-                                  value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'SC' }}"
-                              sequence:
-                                - action: "{{ light_turn_on_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                  data:
-                                    brightness_pct: !input brightness_pct
-                                    rgb_color: !input color_sc
-                                - delay:
-                                    seconds: !input flash_interval_s
-                                - action: "{{ light_turn_off_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                - delay:
-                                    seconds: !input flash_interval_s
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ sc_vsc_mode_input == 'flash_timed' }}"
+                            sequence:
+                              - variables:
+                                  flash_end_ts: "{{ as_timestamp(now()) + (sc_vsc_flash_duration_input | int(10)) }}"
+                              - repeat:
+                                  while:
+                                    - condition: template
+                                      value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'SC' }}"
+                                  sequence:
+                                    - action: "{{ light_turn_on_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                      data:
+                                        brightness_pct: !input brightness_pct
+                                        rgb_color: !input color_sc
+                                    - delay:
+                                        seconds: !input flash_interval_s
+                                    - action: "{{ light_turn_off_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                    - delay:
+                                        seconds: !input flash_interval_s
 
-                          - condition: template
-                            value_template: "{{ states(track_status_entity) | upper == 'SC' }}"
-                          - choose:
-                              - conditions:
-                                  - condition: template
-                                    value_template: "{{ sc_vsc_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
-                                sequence:
-                                  - continue_on_error: true
-                                    action: scene.turn_on
-                                    data:
-                                      entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
-                              - conditions:
-                                  - condition: template
-                                    value_template: "{{ sc_vsc_after_flash_input == 'steady' or (sc_vsc_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
-                                sequence:
-                                  - action: "{{ light_turn_on_service }}"
-                                    target:
-                                      entity_id: !input light_target
-                                    data:
-                                      brightness_pct: !input brightness_pct
-                                      rgb_color: !input color_sc
-                                      transition: !input transition_s
+                              - condition: template
+                                value_template: "{{ states(track_status_entity) | upper == 'SC' }}"
+                              - choose:
+                                  - conditions:
+                                      - condition: template
+                                        value_template: "{{ sc_vsc_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
+                                    sequence:
+                                      - continue_on_error: true
+                                        action: scene.turn_on
+                                        data:
+                                          entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                                  - conditions:
+                                      - condition: template
+                                        value_template: "{{ sc_vsc_after_flash_input == 'steady' or (sc_vsc_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
+                                    sequence:
+                                      - action: "{{ light_turn_on_service }}"
+                                        target:
+                                          entity_id: !input light_target
+                                        data:
+                                          brightness_pct: !input brightness_pct
+                                          rgb_color: !input color_sc
+                                          transition: !input transition_s
 
-              - conditions:
-                  - condition: template
-                    value_template: "{{ track_state == 'VSC' }}"
-                sequence:
-                  - choose:
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ sc_vsc_mode_input == 'steady' }}"
-                        sequence:
-                          - action: "{{ light_turn_on_service }}"
-                            target:
-                              entity_id: !input light_target
-                            data:
-                              brightness_pct: !input brightness_pct
-                              rgb_color: !input color_vsc
-                              transition: !input transition_s
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ track_state == 'VSC' }}"
+                    sequence:
+                      - choose:
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ sc_vsc_mode_input == 'steady' }}"
+                            sequence:
+                              - action: "{{ light_turn_on_service }}"
+                                target:
+                                  entity_id: !input light_target
+                                data:
+                                  brightness_pct: !input brightness_pct
+                                  rgb_color: !input color_vsc
+                                  transition: !input transition_s
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ sc_vsc_mode_input == 'flash_continuous' }}"
-                        sequence:
-                          - repeat:
-                              while:
-                                - condition: template
-                                  value_template: "{{ states(track_status_entity) | upper == 'VSC' }}"
-                              sequence:
-                                - action: "{{ light_turn_on_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                  data:
-                                    brightness_pct: !input brightness_pct
-                                    rgb_color: !input color_vsc
-                                - delay:
-                                    seconds: !input flash_interval_s
-                                - action: "{{ light_turn_off_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                - delay:
-                                    seconds: !input flash_interval_s
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ sc_vsc_mode_input == 'flash_continuous' }}"
+                            sequence:
+                              - repeat:
+                                  while:
+                                    - condition: template
+                                      value_template: "{{ states(track_status_entity) | upper == 'VSC' }}"
+                                  sequence:
+                                    - action: "{{ light_turn_on_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                      data:
+                                        brightness_pct: !input brightness_pct
+                                        rgb_color: !input color_vsc
+                                    - delay:
+                                        seconds: !input flash_interval_s
+                                    - action: "{{ light_turn_off_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                    - delay:
+                                        seconds: !input flash_interval_s
 
-                      - conditions:
-                          - condition: template
-                            value_template: "{{ sc_vsc_mode_input == 'flash_timed' }}"
-                        sequence:
-                          - variables:
-                              flash_end_ts: "{{ as_timestamp(now()) + (sc_vsc_flash_duration_input | int(10)) }}"
-                          - repeat:
-                              while:
-                                - condition: template
-                                  value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'VSC' }}"
-                              sequence:
-                                - action: "{{ light_turn_on_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                  data:
-                                    brightness_pct: !input brightness_pct
-                                    rgb_color: !input color_vsc
-                                - delay:
-                                    seconds: !input flash_interval_s
-                                - action: "{{ light_turn_off_service }}"
-                                  target:
-                                    entity_id: !input light_target
-                                - delay:
-                                    seconds: !input flash_interval_s
+                          - conditions:
+                              - condition: template
+                                value_template: "{{ sc_vsc_mode_input == 'flash_timed' }}"
+                            sequence:
+                              - variables:
+                                  flash_end_ts: "{{ as_timestamp(now()) + (sc_vsc_flash_duration_input | int(10)) }}"
+                              - repeat:
+                                  while:
+                                    - condition: template
+                                      value_template: "{{ as_timestamp(now()) < flash_end_ts and states(track_status_entity) | upper == 'VSC' }}"
+                                  sequence:
+                                    - action: "{{ light_turn_on_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                      data:
+                                        brightness_pct: !input brightness_pct
+                                        rgb_color: !input color_vsc
+                                    - delay:
+                                        seconds: !input flash_interval_s
+                                    - action: "{{ light_turn_off_service }}"
+                                      target:
+                                        entity_id: !input light_target
+                                    - delay:
+                                        seconds: !input flash_interval_s
 
-                          - condition: template
-                            value_template: "{{ states(track_status_entity) | upper == 'VSC' }}"
-                          - choose:
-                              - conditions:
-                                  - condition: template
-                                    value_template: "{{ sc_vsc_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
-                                sequence:
-                                  - continue_on_error: true
-                                    action: scene.turn_on
-                                    data:
-                                      entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
-                              - conditions:
-                                  - condition: template
-                                    value_template: "{{ sc_vsc_after_flash_input == 'steady' or (sc_vsc_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
-                                sequence:
-                                  - action: "{{ light_turn_on_service }}"
-                                    target:
-                                      entity_id: !input light_target
-                                    data:
-                                      brightness_pct: !input brightness_pct
-                                      rgb_color: !input color_vsc
-                                      transition: !input transition_s
+                              - condition: template
+                                value_template: "{{ states(track_status_entity) | upper == 'VSC' }}"
+                              - choose:
+                                  - conditions:
+                                      - condition: template
+                                        value_template: "{{ sc_vsc_after_flash_input == 'restore_previous' and snapshot_before_alert_enabled }}"
+                                    sequence:
+                                      - continue_on_error: true
+                                        action: scene.turn_on
+                                        data:
+                                          entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                                  - conditions:
+                                      - condition: template
+                                        value_template: "{{ sc_vsc_after_flash_input == 'steady' or (sc_vsc_after_flash_input == 'restore_previous' and not snapshot_before_alert_enabled) }}"
+                                    sequence:
+                                      - action: "{{ light_turn_on_service }}"
+                                        target:
+                                          entity_id: !input light_target
+                                        data:
+                                          brightness_pct: !input brightness_pct
+                                          rgb_color: !input color_vsc
+                                          transition: !input transition_s
 
           - if:
               - condition: template

--- a/custom_components/f1_sensor/tests/test_practice_card_logic.py
+++ b/custom_components/f1_sensor/tests/test_practice_card_logic.py
@@ -1,0 +1,284 @@
+"""Regression tests for the practice timing card session gating and lap logic."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+CARD_PATH = ROOT / "www" / "f1-sensor-live-data-card.js"
+
+NODE_PROBE_SCRIPT = r"""
+const fs = require("node:fs");
+
+const payload = JSON.parse(process.env.CARD_PROBE_PAYLOAD || "{}");
+const source = fs.readFileSync(process.env.CARD_PROBE_PATH, "utf8");
+
+function findMatchingBrace(text, openIndex) {
+  let depth = 0;
+  for (let idx = openIndex; idx < text.length; idx += 1) {
+    const ch = text[idx];
+    if (ch === "{") {
+      depth += 1;
+    } else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return idx;
+      }
+    }
+  }
+  throw new Error(`Unmatched brace starting at ${openIndex}`);
+}
+
+function extractMethod(text, signature) {
+  const start = text.indexOf(signature);
+  if (start === -1) {
+    throw new Error(`Method signature not found: ${signature}`);
+  }
+  const braceStart = text.indexOf("{", start);
+  const end = findMatchingBrace(text, braceStart);
+  return text.slice(start, end + 1);
+}
+
+const classStart = source.indexOf("class F1PracticeTimingCard extends LitElement");
+const classEnd = source.indexOf("class F1PracticeTimingCardEditor extends LitElement");
+if (classStart === -1 || classEnd === -1 || classEnd <= classStart) {
+  throw new Error("Unable to locate practice timing card class boundaries");
+}
+const classSource = source.slice(classStart, classEnd);
+
+const methodSources = [
+  extractMethod(classSource, "_buildRows(positionDrivers, tyresDrivers, driverList) {"),
+  extractMethod(classSource, "_buildTitle(sessionState) {"),
+  extractMethod(classSource, "_practiceSessionNumber(sessionState) {"),
+  extractMethod(classSource, "_isPracticeSession(sessionState, sessionStatusState) {"),
+  extractMethod(classSource, "_isPracticeLikeLabel(label) {"),
+  extractMethod(classSource, "_asDriversList(value) {"),
+  extractMethod(classSource, "_buildLapSnapshot(positionInfo) {"),
+  extractMethod(classSource, "_normalizeLapEntries(laps) {"),
+  extractMethod(classSource, "_resolveLastLapEntry(entries, completedLaps) {"),
+  extractMethod(classSource, "_resolveBestLapEntry(entries) {"),
+  extractMethod(classSource, "_parseLapTimeSeconds(value) {"),
+  extractMethod(classSource, "_isLapTimeMatch(left, right) {"),
+  extractMethod(classSource, "_statusInfo(info) {"),
+  extractMethod(classSource, "_parsePosition(value) {"),
+  extractMethod(classSource, "_parsePositiveInt(value) {"),
+  extractMethod(classSource, "_compareRacingNumber(a, b) {"),
+  extractMethod(classSource, "_formatLaps(value) {"),
+  extractMethod(classSource, "_normalizeCompoundKey(value) {"),
+  extractMethod(classSource, "_compoundDisplayName(value) {"),
+  extractMethod(classSource, "_normalizeColor(value) {"),
+];
+
+const Harness = new Function(
+  `
+  const COMPOUND_FALLBACK = {
+    SOFT: "#ff3b30",
+    MEDIUM: "#ffd60a",
+    HARD: "#e5e5e5",
+    INTERMEDIATE: "#34c759",
+    WET: "#0a84ff",
+  };
+  const getTeamLogoMeta = () => null;
+
+  class Harness {
+    constructor() {
+      this.config = {
+        title: "Free Practice",
+        show_team_logo: false,
+        team_logo_style: "color",
+      };
+    }
+
+    ${methodSources.join("\n\n")}
+  }
+
+  return Harness;
+`,
+)();
+
+const harness = new Harness();
+const rows = harness._buildRows(
+  payload.positionDrivers || [],
+  payload.tyresDrivers || [],
+  payload.driverList || [],
+);
+
+process.stdout.write(
+  JSON.stringify({
+    sessionVisible: harness._isPracticeSession(
+      payload.sessionState || {},
+      payload.sessionStatusState || {},
+    ),
+    title: harness._buildTitle(payload.sessionState || {}),
+    rows,
+    usesPracticeRowsCall: classSource.includes(
+      "const rows = this._buildRows(positionDrivers, tyresDrivers, driverList);",
+    ),
+    readsPositionsFastestLap: classSource.includes(
+      "positionsState?.attributes?.fastest_lap",
+    ),
+  }),
+);
+"""
+
+
+def _run_card_probe(
+    *,
+    session_state: dict,
+    session_status_state: dict,
+    position_drivers: list[dict] | None = None,
+    tyres_drivers: list[dict] | None = None,
+    driver_list: list[dict] | None = None,
+) -> dict:
+    """Execute the practice-card logic from the actual JS source."""
+    if not CARD_PATH.exists():
+        pytest.skip(f"card JS not found at {CARD_PATH}")
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for practice card regression tests")
+
+    env = os.environ.copy()
+    env["CARD_PROBE_PATH"] = str(CARD_PATH)
+    env["CARD_PROBE_PAYLOAD"] = json.dumps(
+        {
+            "sessionState": session_state,
+            "sessionStatusState": session_status_state,
+            "positionDrivers": position_drivers or [],
+            "tyresDrivers": tyres_drivers or [],
+            "driverList": driver_list or [],
+        }
+    )
+
+    completed = subprocess.run(
+        [node, "-e", NODE_PROBE_SCRIPT],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    return json.loads(completed.stdout)
+
+
+def test_practice_card_stays_visible_for_suspended_practice_last_label() -> None:
+    """Suspended practice sessions should stay visible via last_label fallback."""
+    result = _run_card_probe(
+        session_state={"state": "", "attributes": {"last_label": "Practice 2"}},
+        session_status_state={"state": "suspended"},
+    )
+
+    assert result["sessionVisible"] is True
+    assert result["title"] == "Free Practice 2"
+
+
+def test_practice_card_prefers_session_number_for_title() -> None:
+    """Header should use the session number from current_session when available."""
+    result = _run_card_probe(
+        session_state={"state": "Practice 3", "attributes": {"number": 3}},
+        session_status_state={"state": "live"},
+    )
+
+    assert result["title"] == "Free Practice 3"
+
+
+def test_practice_card_derives_laps_and_status_from_driver_history() -> None:
+    """Rows should sort by position and derive practice fastest laps locally."""
+    result = _run_card_probe(
+        session_state={"state": "Practice 1", "attributes": {"number": 1}},
+        session_status_state={"state": "live"},
+        position_drivers=[
+            {
+                "racing_number": "63",
+                "tla": "RUS",
+                "team": "Mercedes",
+                "team_color": "#00D2BE",
+                "current_position": "2",
+                "completed_laps": 2,
+                "in_pit": True,
+                "laps": {
+                    "1": "1:21.000",
+                    "2": "1:20.750",
+                },
+            },
+            {
+                "racing_number": "55",
+                "tla": "SAI",
+                "team": "Ferrari",
+                "team_color": "#DC0000",
+                "current_position": "1",
+                "completed_laps": 1,
+                "laps": {
+                    "1": "1:20.900",
+                },
+            },
+            {
+                "racing_number": "43",
+                "tla": "COL",
+                "team": "Williams",
+                "team_color": "#005AFF",
+                "current_position": "22",
+                "completed_laps": 0,
+                "laps": {},
+            },
+        ],
+        tyres_drivers=[
+            {
+                "racing_number": "63",
+                "compound": "MEDIUM",
+                "compound_short": "M",
+                "stint_laps": 13,
+            },
+            {
+                "racing_number": "55",
+                "compound": "SOFT",
+                "compound_short": "S",
+                "stint_laps": 5,
+            },
+            {
+                "racing_number": "43",
+                "compound": "HARD",
+                "compound_short": "H",
+                "stint_laps": 1,
+            },
+        ],
+        driver_list=[
+            {"racing_number": "63", "tla": "RUS", "team": "Mercedes"},
+            {"racing_number": "55", "tla": "SAI", "team": "Ferrari"},
+            {"racing_number": "43", "tla": "COL", "team": "Williams"},
+        ],
+    )
+
+    rows = result["rows"]
+
+    assert result["usesPracticeRowsCall"] is True
+    assert result["readsPositionsFastestLap"] is False
+
+    assert [row["tla"] for row in rows] == ["SAI", "RUS", "COL"]
+
+    leader = rows[0]
+    assert leader["position"] == 1
+    assert leader["last_lap"] == "1:20.900"
+    assert leader["best_lap"] == "1:20.900"
+    assert leader["is_fastest"] is False
+
+    russell = rows[1]
+    assert russell["position"] == 2
+    assert russell["status_label"] == "PIT"
+    assert russell["status_key"] == "pit-in"
+    assert russell["last_lap"] == "1:20.750"
+    assert russell["best_lap"] == "1:20.750"
+    assert russell["is_fastest"] is True
+    assert russell["compound_short"] == "M"
+    assert russell["tyre_age"] == 13
+
+    colapinto = rows[2]
+    assert colapinto["position"] == 22
+    assert colapinto["last_lap"] is None
+    assert colapinto["best_lap"] is None
+    assert colapinto["is_fastest"] is False

--- a/custom_components/f1_sensor/tests/test_qualifying_card_logic.py
+++ b/custom_components/f1_sensor/tests/test_qualifying_card_logic.py
@@ -1,0 +1,210 @@
+"""Regression tests for the qualifying timing card Q-part handling."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+CARD_PATH = ROOT / "www" / "f1-sensor-live-data-card.js"
+
+NODE_PROBE_SCRIPT = r"""
+const fs = require("node:fs");
+
+const payload = JSON.parse(process.env.CARD_PROBE_PAYLOAD || "{}");
+const source = fs.readFileSync(process.env.CARD_PROBE_PATH, "utf8");
+
+function findMatchingBrace(text, openIndex) {
+  let depth = 0;
+  for (let idx = openIndex; idx < text.length; idx += 1) {
+    const ch = text[idx];
+    if (ch === "{") {
+      depth += 1;
+    } else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return idx;
+      }
+    }
+  }
+  throw new Error(`Unmatched brace starting at ${openIndex}`);
+}
+
+function extractMethod(signature) {
+  const start = source.indexOf(signature);
+  if (start === -1) {
+    throw new Error(`Method signature not found: ${signature}`);
+  }
+  const braceStart = source.indexOf("{", start);
+  const end = findMatchingBrace(source, braceStart);
+  return source.slice(start, end + 1);
+}
+
+const methodSources = [
+  extractMethod(
+    "_buildRows(positionDrivers, tyresDrivers, driverList, currentQPart)",
+  ),
+  extractMethod("_resolveDisplayQualifyingPart(sessionState, ...parts)"),
+  extractMethod("_normalizeQualifyingPart(value)"),
+  extractMethod("_inferQualifyingPartFromDrivers(drivers)"),
+];
+
+const Harness = new Function(
+  `
+  const COMPOUND_FALLBACK = {
+    SOFT: "#ff3b30",
+    MEDIUM: "#ffd60a",
+    HARD: "#e5e5e5",
+    INTERMEDIATE: "#34c759",
+    WET: "#0a84ff",
+  };
+  const getTeamLogoMeta = () => null;
+
+  class Harness {
+    constructor() {
+      this.config = {
+        show_team_logo: false,
+        team_logo_style: "color",
+      };
+    }
+
+    _normalizeColor(value) {
+      return value ?? null;
+    }
+
+    _resolveLastLapTime(pos) {
+      return pos.last_lap ?? null;
+    }
+
+    _statusInfo() {
+      return {
+        label: null,
+        key: null,
+      };
+    }
+
+    _parsePosition(value) {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    ${methodSources.join("\n\n")}
+  }
+
+  return Harness;
+`,
+)();
+
+const harness = new Harness();
+const sessionPart = harness._resolveDisplayQualifyingPart(
+  { state: payload.sessionState },
+  payload.currentQPart,
+  payload.positionDrivers,
+);
+const rows = harness._buildRows(
+  payload.positionDrivers,
+  [],
+  [],
+  payload.currentQPart,
+);
+
+process.stdout.write(
+  JSON.stringify({
+    callUsesSessionPart: source.includes(
+      "const rows = this._buildRows(positionDrivers, tyresDrivers, driverList, sessionPart);",
+    ),
+    sessionPart,
+    rows,
+  }),
+);
+"""
+
+
+def _run_card_probe(
+    *,
+    current_q_part: str | int | None,
+    position_drivers: list[dict],
+    session_state: str = "Qualifying",
+) -> dict:
+    """Execute the qualifying-card row logic from the actual JS source."""
+    if not CARD_PATH.exists():
+        pytest.skip(f"card JS not found at {CARD_PATH}")
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for qualifying card regression tests")
+
+    env = os.environ.copy()
+    env["CARD_PROBE_PATH"] = str(CARD_PATH)
+    env["CARD_PROBE_PAYLOAD"] = json.dumps(
+        {
+            "currentQPart": current_q_part,
+            "positionDrivers": position_drivers,
+            "sessionState": session_state,
+        }
+    )
+
+    completed = subprocess.run(
+        [node, "-e", NODE_PROBE_SCRIPT],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    return json.loads(completed.stdout)
+
+
+def test_qualifying_card_reuses_inferred_qpart_for_rows() -> None:
+    """Missing current_qualifying_part must still render Q2 row data."""
+    result = _run_card_probe(
+        current_q_part=None,
+        position_drivers=[
+            {
+                "racing_number": "81",
+                "tla": "PIA",
+                "team": "McLaren",
+                "q1_time": "1:19.664",
+                "q1_position": 11,
+                "q2_time": "1:19.525",
+                "q2_position": 3,
+                "q3_time": None,
+                "q3_position": None,
+                "current_position": "11",
+            }
+        ],
+    )
+
+    assert result["callUsesSessionPart"] is True
+    assert result["sessionPart"] == 2
+    assert result["rows"][0]["position"] == 3
+    assert result["rows"][0]["current_segment_best_lap"] == "1:19.525"
+
+
+def test_qualifying_card_normalizes_string_qpart_for_rows() -> None:
+    """String-valued current_qualifying_part must still drive Q3 row data."""
+    result = _run_card_probe(
+        current_q_part="3",
+        position_drivers=[
+            {
+                "racing_number": "63",
+                "tla": "RUS",
+                "team": "Mercedes",
+                "q1_time": "1:19.507",
+                "q1_position": 7,
+                "q2_time": "1:18.934",
+                "q2_position": 5,
+                "q3_time": "1:18.518",
+                "q3_position": 1,
+                "current_position": "7",
+            }
+        ],
+    )
+
+    assert result["sessionPart"] == 3
+    assert result["rows"][0]["position"] == 1
+    assert result["rows"][0]["current_segment_best_lap"] == "1:18.518"

--- a/custom_components/f1_sensor/tests/test_replay_seek.py
+++ b/custom_components/f1_sensor/tests/test_replay_seek.py
@@ -719,3 +719,66 @@ async def test_replay_pause_freezes_session_clock(hass, tmp_path: Path) -> None:
     assert session_clock.data["clock_remaining_s"] == paused_remaining
 
     await controller.async_stop()
+
+
+@pytest.mark.asyncio
+async def test_replay_pause_freezes_session_clock_without_replay_mode_flag(
+    hass, tmp_path: Path
+) -> None:
+    initial_state = {
+        "SessionInfo": {"Type": "Race", "Name": "Race"},
+        "SessionStatus": {"Status": "Started", "Started": True},
+        "SessionData": {
+            "StatusSeries": {
+                "0": {"Utc": "2025-12-07T13:00:00Z", "SessionStatus": "Started"}
+            }
+        },
+        "ExtrapolatedClock": {
+            "Utc": "2025-12-07T13:00:00Z",
+            "Remaining": "02:00:00",
+            "Extrapolating": True,
+        },
+        "Heartbeat": {"Utc": "2025-12-07T13:00:00Z"},
+    }
+    frames = [
+        (0, "SessionInfo", initial_state["SessionInfo"]),
+        (0, "SessionStatus", initial_state["SessionStatus"]),
+        (0, "SessionData", initial_state["SessionData"]),
+        (0, "ExtrapolatedClock", initial_state["ExtrapolatedClock"]),
+        (0, "Heartbeat", initial_state["Heartbeat"]),
+        (
+            10_000,
+            "ExtrapolatedClock",
+            {
+                "Utc": "2025-12-07T13:00:10Z",
+                "Remaining": "01:59:50",
+                "Extrapolating": True,
+            },
+        ),
+        (10_000, "Heartbeat", {"Utc": "2025-12-07T13:00:10Z"}),
+    ]
+    controller, session_clock = await _setup_session_clock_harness(
+        hass,
+        tmp_path,
+        initial_state=initial_state,
+        frames=frames,
+    )
+
+    await controller.async_play()
+    await controller.async_seek_by(10)
+
+    # Reproduce the runtime path where session clock did not carry the replay flag
+    # even though the replay controller had entered a paused state.
+    session_clock._replay_mode = False
+
+    await controller.async_pause()
+    paused_remaining = session_clock.data["clock_remaining_s"]
+
+    await asyncio.sleep(1.2)
+
+    assert controller.state == ReplayState.PAUSED
+    assert session_clock.data["clock_running"] is False
+    assert session_clock.data["clock_phase"] == "paused"
+    assert session_clock.data["clock_remaining_s"] == paused_remaining
+
+    await controller.async_stop()

--- a/custom_components/f1_sensor/tests/test_setup.py
+++ b/custom_components/f1_sensor/tests/test_setup.py
@@ -8,6 +8,12 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.f1_sensor import (
+    _NO_SPOILER_MANAGER_KEY,
+    _RC_LOG_RESET_EVENT,
+    _RC_LOG_SERVICE,
+    _RC_LOG_SERVICE_MARKER,
+    RaceControlCoordinator,
+    RaceControlLogStore,
     _is_activity_log_excluded_entity,
     _refresh_recorder_entity_filter,
     _wrap_activity_filter,
@@ -44,9 +50,24 @@ class FakeLiveBus:
 class DummyCoordinator:
     def __init__(self, *args, **kwargs) -> None:
         self.config_entry = kwargs.get("config_entry")
+        self.data = kwargs.get("data", {})
+        self._listeners = []
 
     async def async_config_entry_first_refresh(self) -> None:
         return None
+
+    def async_add_listener(self, update_callback):
+        self._listeners.append(update_callback)
+
+        def _unsubscribe() -> None:
+            if update_callback in self._listeners:
+                self._listeners.remove(update_callback)
+
+        return _unsubscribe
+
+    def trigger_update(self) -> None:
+        for listener in list(self._listeners):
+            listener()
 
 
 class FakeReplayController:
@@ -192,6 +213,154 @@ def test_logbook_subscribe_wrapper_filters_excluded_entities() -> None:
         SimpleNamespace(data={"entity_id": "sensor.f1_next_race"})
     )
     assert seen == ["called"]
+
+
+@pytest.mark.asyncio
+async def test_race_control_log_store_keeps_newest_first_and_resets(hass) -> None:
+    session_info = DummyCoordinator(
+        data={
+            "Meeting": {"Key": 1001},
+            "StartDate": "2026-03-12T14:00:00Z",
+            "Type": "Race",
+            "Name": "Grand Prix",
+        }
+    )
+    session_status = DummyCoordinator(data={"Status": "Started", "Started": True})
+    store = RaceControlLogStore(
+        hass,
+        "entry-1",
+        session_info_coordinator=session_info,
+        session_status_coordinator=session_status,
+    )
+    reset_events = []
+    unsub = hass.bus.async_listen(
+        _RC_LOG_RESET_EVENT,
+        lambda event: reset_events.append(event.data),
+    )
+
+    try:
+        await store.async_initialize()
+
+        first = store.append(
+            {
+                "Utc": "2026-03-12T14:01:00Z",
+                "Flag": "YELLOW",
+                "Message": "Yellow flag in sector 1",
+            }
+        )
+        second = store.append(
+            {
+                "Utc": "2026-03-12T14:02:00Z",
+                "Category": "SafetyCar",
+                "Message": "Safety car deployed",
+            }
+        )
+        await hass.async_block_till_done()
+
+        assert first is not None
+        assert second is not None
+        assert [item["message"] for item in store.get_items()] == [
+            "Safety car deployed",
+            "Yellow flag in sector 1",
+        ]
+        assert [item["sequence"] for item in store.get_items()] == [2, 1]
+
+        await store.async_clear(reason="manual")
+        await hass.async_block_till_done()
+
+        assert store.get_items() == []
+        assert reset_events[-1]["reason"] == "manual"
+        assert reset_events[-1]["entry_id"] == "entry-1"
+
+        after_clear = store.append(
+            {
+                "Utc": "2026-03-12T14:03:00Z",
+                "Flag": "GREEN",
+                "Message": "Track clear",
+            }
+        )
+        assert after_clear is not None
+        assert after_clear["sequence"] == 1
+
+        session_info.data = {
+            "Meeting": {"Key": 1002},
+            "StartDate": "2026-03-19T14:00:00Z",
+            "Type": "Race",
+            "Name": "Grand Prix",
+        }
+        session_info.trigger_update()
+        await hass.async_block_till_done()
+
+        assert store.get_items() == []
+        assert reset_events[-1]["reason"] == "session_change"
+        assert reset_events[-1]["session_key"] == "1002|2026-03-19T14:00:00Z|Grand Prix"
+    finally:
+        unsub()
+        await store.async_close()
+
+
+@pytest.mark.asyncio
+async def test_race_control_log_clears_when_source_stops(hass) -> None:
+    session_info = DummyCoordinator(
+        data={
+            "Meeting": {"Key": 1001},
+            "StartDate": "2026-03-12T14:00:00Z",
+            "Type": "Race",
+            "Name": "Grand Prix",
+        }
+    )
+    session_status = DummyCoordinator(data={"Status": "Started", "Started": True})
+    store = RaceControlLogStore(
+        hass,
+        "entry-1",
+        session_info_coordinator=session_info,
+        session_status_coordinator=session_status,
+    )
+    live_state = LiveAvailabilityTracker()
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry-1",
+        data={CONF_OPERATION_MODE: OPERATION_MODE_LIVE},
+    )
+    config_entry.add_to_hass(hass)
+    coordinator = RaceControlCoordinator(
+        hass,
+        session_coord=object(),
+        bus=FakeLiveBus(None, None),
+        config_entry=config_entry,
+        live_state=live_state,
+        log_store=store,
+    )
+    reset_events = []
+    unsub = hass.bus.async_listen(
+        _RC_LOG_RESET_EVENT,
+        lambda event: reset_events.append(event.data),
+    )
+
+    try:
+        await store.async_initialize()
+
+        coordinator._deliver(  # noqa: SLF001 - targeted behavior test
+            {
+                "Utc": "2026-03-12T14:01:00Z",
+                "Flag": "YELLOW",
+                "Message": "Yellow flag in sector 1",
+            }
+        )
+        await hass.async_block_till_done()
+        assert [item["message"] for item in store.get_items()] == [
+            "Yellow flag in sector 1"
+        ]
+
+        live_state.set_state(False, "replay-stopped")
+        await hass.async_block_till_done()
+
+        assert store.get_items() == []
+        assert reset_events[-1]["reason"] == "replay-stopped"
+    finally:
+        unsub()
+        await coordinator.async_close()
+        await store.async_close()
 
 
 @pytest.mark.asyncio
@@ -357,3 +526,27 @@ async def test_async_unload_entry_keeps_runtime_data_on_failed_platform_unload(
     assert entry.entry_id in hass.data[DOMAIN]
     assert unsubscribed == []
     assert closed == []
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_removes_race_control_service_for_last_entry(
+    hass,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    hass.services.async_register(DOMAIN, _RC_LOG_SERVICE, lambda call: None)
+    hass.data.setdefault(DOMAIN, {})[_NO_SPOILER_MANAGER_KEY] = object()
+    hass.data[DOMAIN][_RC_LOG_SERVICE_MARKER] = True
+    hass.data[DOMAIN][entry.entry_id] = {}
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+    result = await async_unload_entry(hass, entry)
+
+    assert result is True
+    assert not hass.services.has_service(DOMAIN, _RC_LOG_SERVICE)

--- a/custom_components/f1_sensor/tests/test_track_status_blueprint.py
+++ b/custom_components/f1_sensor/tests/test_track_status_blueprint.py
@@ -10,6 +10,7 @@ import pytest
 BLUEPRINT_SOURCE = Path(__file__).resolve().parent / "fixtures" / "f1_track_status.yaml"
 BLUEPRINT_DEST = Path("blueprints/automation/homeassistant/f1_track_status.yaml")
 AUTOMATION_ENTITY_ID = "automation.track_status_blueprint_test"
+StateSpec = str | tuple[str, dict[str, Any]]
 
 
 async def _install_blueprint(hass: HomeAssistant) -> None:
@@ -20,23 +21,31 @@ async def _install_blueprint(hass: HomeAssistant) -> None:
     )
 
 
-def _register_light_services(
+def _register_services(
     hass: HomeAssistant,
 ) -> list[tuple[str, dict[str, Any]]]:
     calls: list[tuple[str, dict[str, Any]]] = []
     register_service = getattr(hass.services, "async_" + "register")
 
-    async def _record(call: ServiceCall) -> None:
-        calls.append((call.service, dict(call.data)))
+    def _recorder(domain: str):
+        async def _record(call: ServiceCall) -> None:
+            calls.append((f"{domain}.{call.service}", dict(call.data)))
 
-    register_service("light", "turn_on", _record)
-    register_service("light", "turn_off", _record)
+        return _record
+
+    register_service("light", "turn_on", _recorder("light"))
+    register_service("light", "turn_off", _recorder("light"))
+    register_service("select", "select_option", _recorder("select"))
     return calls
 
 
-async def _set_states(hass: HomeAssistant, states: dict[str, str]) -> None:
-    for entity_id, state in states.items():
-        hass.states.async_set(entity_id, state)
+async def _set_states(hass: HomeAssistant, states: dict[str, StateSpec]) -> None:
+    for entity_id, value in states.items():
+        if isinstance(value, tuple):
+            state, attributes = value
+        else:
+            state, attributes = value, {}
+        hass.states.async_set(entity_id, state, attributes)
     await hass.async_block_till_done()
 
 
@@ -45,7 +54,32 @@ async def _setup_blueprint_automation(
     *,
     clear_color: list[int] | None = None,
     yellow_color: list[int] | None = None,
+    extra_inputs: dict[str, Any] | None = None,
 ) -> bool:
+    blueprint_inputs: dict[str, Any] = {
+        "session_status_entity": "sensor.test_session_status",
+        "track_status_entity": "sensor.test_track_status",
+        "light_target": "light.test_track_status",
+        "active_session_phases": ["live", "suspended"],
+        "enable_current_session_filter": False,
+        "transition_s": 0,
+        "snapshot_pre_race": False,
+        "snapshot_before_alert": False,
+        "clear_behavior_mode": "steady",
+        "yellow_red_mode": "steady",
+        "yellow_red_after_flash": "steady",
+        "sc_vsc_mode": "steady",
+        "sc_vsc_after_flash": "steady",
+        "end_delay_min": 0,
+        "end_action": "turn_off",
+        "cleanup_scenes_on_end": False,
+        "enable_notifications": False,
+        "color_clear": clear_color or [11, 22, 33],
+        "color_yellow": yellow_color or [44, 55, 66],
+    }
+    if extra_inputs:
+        blueprint_inputs.update(extra_inputs)
+
     config = {
         "automation": [
             {
@@ -53,27 +87,7 @@ async def _setup_blueprint_automation(
                 "alias": "Track Status Blueprint Test",
                 "use_blueprint": {
                     "path": "homeassistant/f1_track_status.yaml",
-                    "input": {
-                        "session_status_entity": "sensor.test_session_status",
-                        "track_status_entity": "sensor.test_track_status",
-                        "light_target": "light.test_track_status",
-                        "active_session_phases": ["live", "suspended"],
-                        "enable_current_session_filter": False,
-                        "transition_s": 0,
-                        "snapshot_pre_race": False,
-                        "snapshot_before_alert": False,
-                        "clear_behavior_mode": "steady",
-                        "yellow_red_mode": "steady",
-                        "yellow_red_after_flash": "steady",
-                        "sc_vsc_mode": "steady",
-                        "sc_vsc_after_flash": "steady",
-                        "end_delay_min": 0,
-                        "end_action": "turn_off",
-                        "cleanup_scenes_on_end": False,
-                        "enable_notifications": False,
-                        "color_clear": clear_color or [11, 22, 33],
-                        "color_yellow": yellow_color or [44, 55, 66],
-                    },
+                    "input": blueprint_inputs,
                 },
             }
         ]
@@ -94,7 +108,7 @@ async def test_blueprint_syncs_track_light_when_session_enters_active(
     hass: HomeAssistant,
 ) -> None:
     await _install_blueprint(hass)
-    calls = _register_light_services(hass)
+    calls = _register_services(hass)
     await _set_states(
         hass,
         {
@@ -110,7 +124,7 @@ async def test_blueprint_syncs_track_light_when_session_enters_active(
 
     assert calls == [
         (
-            "turn_on",
+            "light.turn_on",
             {
                 "entity_id": ["light.test_track_status"],
                 "brightness_pct": 100,
@@ -126,7 +140,7 @@ async def test_blueprint_ignores_internal_session_updates_without_track_change(
     hass: HomeAssistant,
 ) -> None:
     await _install_blueprint(hass)
-    calls = _register_light_services(hass)
+    calls = _register_services(hass)
     await _set_states(
         hass,
         {
@@ -141,7 +155,7 @@ async def test_blueprint_ignores_internal_session_updates_without_track_change(
     await _set_states(hass, {"sensor.test_session_status": "live"})
     assert calls == [
         (
-            "turn_on",
+            "light.turn_on",
             {
                 "entity_id": ["light.test_track_status"],
                 "brightness_pct": 100,
@@ -165,7 +179,7 @@ async def test_blueprint_keeps_end_action_on_session_exit(
     hass: HomeAssistant,
 ) -> None:
     await _install_blueprint(hass)
-    calls = _register_light_services(hass)
+    calls = _register_services(hass)
     await _set_states(
         hass,
         {
@@ -181,9 +195,171 @@ async def test_blueprint_keeps_end_action_on_session_exit(
 
     assert calls == [
         (
-            "turn_off",
+            "light.turn_off",
             {
                 "entity_id": ["light.test_track_status"],
             },
         )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_blueprint_prefers_wled_playlist_over_preset_for_track_status(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_services(hass)
+    await _set_states(
+        hass,
+        {
+            "sensor.test_track_status": "SC",
+            "sensor.test_session_status": "pre",
+            "light.test_track_status": "off",
+            "select.test_wled_playlist": (
+                "Idle",
+                {"options": ["Safety Car Playlist"]},
+            ),
+            "select.test_wled_preset": (
+                "Idle",
+                {"options": ["Safety Car Preset"]},
+            ),
+        },
+    )
+
+    assert await _setup_blueprint_automation(
+        hass,
+        extra_inputs={
+            "enable_wled_advanced": True,
+            "wled_playlist_entity": "select.test_wled_playlist",
+            "wled_preset_entity": "select.test_wled_preset",
+            "wled_playlist_sc": "Safety Car Playlist",
+            "wled_preset_sc": "Safety Car Preset",
+        },
+    )
+    calls.clear()
+
+    await _set_states(hass, {"sensor.test_session_status": "live"})
+
+    assert calls == [
+        (
+            "light.turn_on",
+            {
+                "entity_id": ["light.test_track_status"],
+            },
+        ),
+        (
+            "select.select_option",
+            {
+                "entity_id": "select.test_wled_playlist",
+                "option": "Safety Car Playlist",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_blueprint_falls_back_to_preset_when_playlist_is_invalid(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_services(hass)
+    await _set_states(
+        hass,
+        {
+            "sensor.test_track_status": "SC",
+            "sensor.test_session_status": "pre",
+            "light.test_track_status": "off",
+            "select.test_wled_playlist": (
+                "Idle",
+                {"options": ["Different Playlist"]},
+            ),
+            "select.test_wled_preset": (
+                "Idle",
+                {"options": ["Safety Car Preset"]},
+            ),
+        },
+    )
+
+    assert await _setup_blueprint_automation(
+        hass,
+        extra_inputs={
+            "enable_wled_advanced": True,
+            "wled_playlist_entity": "select.test_wled_playlist",
+            "wled_preset_entity": "select.test_wled_preset",
+            "wled_playlist_sc": "Safety Car Playlist",
+            "wled_preset_sc": "Safety Car Preset",
+        },
+    )
+    calls.clear()
+
+    await _set_states(hass, {"sensor.test_session_status": "live"})
+
+    assert calls == [
+        (
+            "light.turn_on",
+            {
+                "entity_id": ["light.test_track_status"],
+            },
+        ),
+        (
+            "select.select_option",
+            {
+                "entity_id": "select.test_wled_preset",
+                "option": "Safety Car Preset",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_blueprint_applies_finished_override_before_end_action(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_services(hass)
+    await _set_states(
+        hass,
+        {
+            "sensor.test_track_status": "CLEAR",
+            "sensor.test_session_status": "live",
+            "light.test_track_status": "off",
+            "select.test_wled_playlist": (
+                "Idle",
+                {"options": ["Checkered Playlist"]},
+            ),
+        },
+    )
+
+    assert await _setup_blueprint_automation(
+        hass,
+        extra_inputs={
+            "enable_wled_advanced": True,
+            "wled_playlist_entity": "select.test_wled_playlist",
+            "wled_playlist_finished": "Checkered Playlist",
+        },
+    )
+    calls.clear()
+
+    await _set_states(hass, {"sensor.test_session_status": "finished"})
+
+    assert calls == [
+        (
+            "light.turn_on",
+            {
+                "entity_id": ["light.test_track_status"],
+            },
+        ),
+        (
+            "select.select_option",
+            {
+                "entity_id": "select.test_wled_playlist",
+                "option": "Checkered Playlist",
+            },
+        ),
+        (
+            "light.turn_off",
+            {
+                "entity_id": ["light.test_track_status"],
+            },
+        ),
     ]

--- a/docs/blueprints/track-status-light.md
+++ b/docs/blueprints/track-status-light.md
@@ -9,7 +9,7 @@ Turn any RGB light into a live F1 race status indicator. The light color changes
 
 The blueprint is built around the [Track Status](/entities/live-data#track-status) and [Session Status](/entities/live-data#session-status) sensors from F1 Sensor, and includes optional gates for presence, media player state, and a do-not-disturb time window.
 
-For WLED users, an optional advanced mode lets you map track states directly to WLED presets instead of plain RGB colors, giving you full control over animations, segments, and palettes.
+For WLED users, an optional advanced mode lets you map track states directly to WLED playlists or presets instead of plain RGB colors, giving you full control over animations, segments, and palettes.
 
 :::tip Sync with your TV
 For the light to change at the same time as you see the flag on screen, configure the [Live Delay](/features/live-delay) to match your broadcast offset.
@@ -33,7 +33,7 @@ https://raw.githubusercontent.com/Nicxe/f1_sensor/main/blueprints/f1_track_statu
 
 - F1 Sensor integration installed with live data enabled
 - An RGB-capable light entity (or a group entity containing lights) in Home Assistant
-- For WLED Advanced mode: a [WLED](https://kno.wled.ge/) light with its companion preset, palette, intensity, and speed entities exposed in Home Assistant (optional)
+- For WLED Advanced mode: a [WLED](https://kno.wled.ge/) light with its companion playlist and/or preset entities, plus optional palette, intensity, and speed helper entities exposed in Home Assistant (optional)
 
 ---
 
@@ -103,7 +103,7 @@ Snapshots are temporary scenes stored in Home Assistant for the duration of the 
 
 ### Step 5 — WLED Advanced (Optional)
 
-If your light is a WLED device, you can map track states directly to WLED presets instead of using plain RGB colors. This gives you full control over animations, segments, and palettes for each flag state. This section is collapsed by default.
+If your light is a WLED device, you can map track states directly to WLED playlists or presets instead of using plain RGB colors. This gives you full control over animations, segments, and palettes for each flag state. This section is collapsed by default.
 
 :::info
 WLED Advanced mode only applies to a single light entity. If the light target is a group, normal light behavior is used instead.
@@ -111,27 +111,38 @@ WLED Advanced mode only applies to a single light entity. If the light target is
 
 | Setting | Description |
 | --- | --- |
-| **Enable WLED Advanced Mode** | Master switch for WLED preset control. Disabled by default |
-| **WLED Preset Entity** | Select the WLED preset `select` entity from the same device as the target light |
+| **Enable WLED Advanced Mode** | Master switch for WLED playlist and preset control. Disabled by default |
+| **WLED Playlist Entity** | Optional. Select the WLED playlist `select` entity from the same device as the target light |
+| **WLED Preset Entity** | Optional. Select the WLED preset `select` entity from the same device as the target light |
 | **WLED Palette Entity** | Optional companion `select` entity, used only for snapshot and restore |
 | **WLED Intensity Entity** | Optional companion `number` entity, used only for snapshot and restore |
 | **WLED Speed Entity** | Optional companion `number` entity, used only for snapshot and restore |
 
-#### Per-state presets
+You can configure a playlist entity, a preset entity, or both. When both are configured for the same track state, the playlist takes priority over the preset.
 
-Each track state can be assigned a WLED preset by name. The name must match an existing preset on the WLED device exactly. Leave a field empty to fall back to the normal color and flash behavior for that state.
+#### Per-state playlists and presets
+
+Each track state can be assigned a WLED playlist and/or preset by name. The name must match an existing playlist or preset on the WLED device exactly. Leave a field empty to fall back to the other option or the normal color and flash behavior for that state.
 
 | Setting | Description |
 | --- | --- |
-| **Preset — CLEAR** | Preset activated when the track is clear |
-| **Preset — YELLOW** | Preset activated on a yellow flag |
-| **Preset — RED** | Preset activated on a red flag |
-| **Preset — VSC** | Preset activated when Virtual Safety Car is deployed |
-| **Preset — SC** | Preset activated when the Safety Car is deployed |
-| **Preset — Session End Neutral** | Preset used when the session end action is **Set neutral color** |
+| **Playlist — CLEAR** | Playlist activated when the track is clear |
+| **Preset — CLEAR** | Preset activated when the track is clear (used if no playlist is set) |
+| **Playlist — YELLOW** | Playlist activated on a yellow flag |
+| **Preset — YELLOW** | Preset activated on a yellow flag (used if no playlist is set) |
+| **Playlist — RED** | Playlist activated on a red flag |
+| **Preset — RED** | Preset activated on a red flag (used if no playlist is set) |
+| **Playlist — VSC** | Playlist activated when Virtual Safety Car is deployed |
+| **Preset — VSC** | Preset activated when Virtual Safety Car is deployed (used if no playlist is set) |
+| **Playlist — SC** | Playlist activated when the Safety Car is deployed |
+| **Preset — SC** | Preset activated when the Safety Car is deployed (used if no playlist is set) |
+| **Playlist — Finished / Checkered Flag** | Playlist shown when the session transitions to finished, before the end action runs |
+| **Preset — Finished / Checkered Flag** | Preset shown when the session transitions to finished, before the end action runs (used if no playlist is set) |
+| **Playlist — Session End Neutral** | Playlist used when the session end action is **Set neutral color** |
+| **Preset — Session End Neutral** | Preset used when the session end action is **Set neutral color** (used if no playlist is set) |
 
 :::tip
-Create your presets in the WLED web UI first, then select the matching name in the blueprint. Presets can include custom effects, color palettes, segment layouts, and brightness — anything WLED supports.
+Create your playlists and presets in the WLED web UI first, then enter the exact matching name in the blueprint. Both playlists and presets can include custom effects, color palettes, segment layouts, and brightness — anything WLED supports.
 :::
 
 ---
@@ -298,9 +309,9 @@ YELLOW, RED, SC, and VSC each support three modes: a steady color, timed flashin
 
 When the CLEAR status arrives, the light can show the clear color, restore immediately to the pre-alert state, or show the clear color briefly before restoring.
 
-When WLED Advanced mode is enabled and a valid preset is configured for the current track state, the preset is activated directly on the WLED device instead of using the normal color and flash logic. States without a preset configured fall back to the standard RGB behavior. The companion palette, intensity, and speed entities are included in snapshots and restores so the full WLED state is preserved.
+When WLED Advanced mode is enabled and a valid playlist or preset is configured for the current track state, it is activated directly on the WLED device instead of using the normal color and flash logic. When both a playlist and a preset are configured for the same state, the playlist takes priority. States with neither a playlist nor a preset configured fall back to the standard RGB behavior. The companion palette, intensity, and speed entities are included in snapshots and restores so the full WLED state is preserved.
 
-When the session leaves active phases, the configured end action runs after an optional delay. If a WLED session-end preset is configured and the end action is **Set neutral color**, that preset is used instead of the neutral color. Temporary scenes created during the session are cleaned up automatically when the session ends.
+When the session transitions to the finished phase and a WLED finished playlist or preset is configured, it is activated briefly before the end action runs. When the session leaves active phases, the configured end action runs after an optional delay. If a WLED session-end playlist or preset is configured and the end action is **Set neutral color**, it is used instead of the neutral color. Temporary scenes created during the session are cleaned up automatically when the session ends.
 
 ---
 


### PR DESCRIPTION
…rack status blueprint**

The track status blueprint now supports WLED playlists as well as presets, so you can use either option for CLEAR, YELLOW, RED, VSC, SC, and session-finished effects. When both are configured for the same state, the playlist takes priority. The blueprint also adds a dedicated finished/checkered mapping that runs when the session moves to finished, holds for the existing end delay, and then continues with the normal end-of-session action. CLEAR remains the green-flag case, so no separate green state was added.

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [X] 📋 Blueprint (new or updated blueprint)
- [X] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
