### PR TITLE
fix: Freeze time in circuit map test to prevent date-dependent failures

### DIFF
--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 import logging
 import time
 from unittest.mock import MagicMock
@@ -386,7 +387,13 @@ def test_get_circuit_map_url_prefers_2026_detailed_maps() -> None:
 
 
 @pytest.mark.asyncio
-async def test_next_race_sensor_uses_2026_detailed_circuit_map(hass) -> None:
+async def test_next_race_sensor_uses_2026_detailed_circuit_map(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.helpers.dt_util.utcnow",
+        lambda: datetime(2026, 3, 10, tzinfo=UTC),
+    )
     coordinator = _build_coordinator(
         hass,
         {"MRData": {"RaceTable": {"Races": [_build_race(date="2026-03-15")]}}},


### PR DESCRIPTION
## Summary
- The `test_next_race_sensor_uses_2026_detailed_circuit_map` test used a hardcoded race date (`2026-03-15`) without mocking the clock, causing `_get_next_race()` to return `None` once the date plus the 3-hour grace period had passed.
- Added `monkeypatch` to freeze `dt_util.utcnow` to `2026-03-10`, matching the pattern used in other next-race sensor tests.

## Test plan
- [x] Verified the previously failing test now passes locally
- [x] Full test suite passes (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)