### PR TITLE
Add Grid & Laps to Race Results

### DIFF
--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -1233,9 +1233,11 @@ class F1LastRaceSensor(F1BaseEntity, SensorEntity):
         def _clean_result(r):
             return {
                 "number": r.get("number"),
+                "grid": r.get("grid"),
                 "position": r.get("position"),
                 "points": r.get("points"),
                 "status": r.get("status"),
+                "laps": r.get("laps"),
                 "driver": {
                     "permanentNumber": r.get("Driver", {}).get("permanentNumber"),
                     "code": r.get("Driver", {}).get("code"),

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -275,41 +275,41 @@ def _build_race(
 
 
 def _build_last_race(
-        *,
-        season: str = "2026",
-        round_: str = "1",
-        race_name: str = "Australian Grand Prix",
-        circuit_id: str = "albert_park",
-        circuit_name: str = "Albert Park Grand Prix Circuit",
-        locality: str = "Melbourne",
-        country: str = "Australia",
-        date: str = "2026-03-08",
-        time: str = "04:00:00Z",
-        results_per_race: int = 20,
-    ) -> dict:
-        return {
-            "season": season,
-            "round": round_,
-            "raceName": race_name,
-            "url": f"https://example.com/races/{round_}",
-            "date": date,
-            "time": time,
-            "Circuit": {
-                "circuitId": circuit_id,
-                "url": f"https://example.com/circuits/{circuit_id}",
-                "circuitName": circuit_name,
-                "Location": {
-                    "lat": "-37.8497",
-                    "long": "144.968",
-                    "locality": locality,
-                    "country": country,
-                },
+    *,
+    season: str = "2026",
+    round_: str = "1",
+    race_name: str = "Australian Grand Prix",
+    circuit_id: str = "albert_park",
+    circuit_name: str = "Albert Park Grand Prix Circuit",
+    locality: str = "Melbourne",
+    country: str = "Australia",
+    date: str = "2026-03-08",
+    time: str = "04:00:00Z",
+    results_per_race: int = 20,
+) -> dict:
+    return {
+        "season": season,
+        "round": round_,
+        "raceName": race_name,
+        "url": f"https://example.com/races/{round_}",
+        "date": date,
+        "time": time,
+        "Circuit": {
+            "circuitId": circuit_id,
+            "url": f"https://example.com/circuits/{circuit_id}",
+            "circuitName": circuit_name,
+            "Location": {
+                "lat": "-37.8497",
+                "long": "144.968",
+                "locality": locality,
+                "country": country,
             },
-            "Results": [
-                _build_result_entry(driver_idx)
-                for driver_idx in range(1, results_per_race + 1)
-            ]
-        }
+        },
+        "Results": [
+            _build_result_entry(driver_idx)
+            for driver_idx in range(1, results_per_race + 1)
+        ],
+    }
 
 
 def _history_driver(
@@ -1657,6 +1657,7 @@ async def test_driver_list_sensor_handles_22_drivers(hass) -> None:
     assert state is not None
     assert state.state == "22"
     assert len(state.attributes["drivers"]) == 22
+
 
 @pytest.mark.asyncio
 async def test_last_race_sensor_attributes(hass) -> None:

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -1696,9 +1696,9 @@ async def test_last_race_sensor_attributes(hass) -> None:
     state = await _add_sensor_and_get_state(hass, sensor)
 
     results = state.attributes["results"]
-    assert results[0]["position"] == 1
-    assert results[0]["grid"] == 1
-    assert results[0]["laps"] == 60
-    assert results[1]["position"] == 2
-    assert results[1]["grid"] == 2
-    assert results[1]["laps"] == 60
+    assert results[0]["position"] == "1"
+    assert results[0]["grid"] == "1"
+    assert results[0]["laps"] == "60"
+    assert results[1]["position"] == "2"
+    assert results[1]["grid"] == "2"
+    assert results[1]["laps"] == "60"

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -30,6 +30,7 @@ from custom_components.f1_sensor.sensor import (
     F1DriverPointsProgressionSensor,
     F1DriverPositionsSensor,
     F1DriverStandingsSensor,
+    F1LastRaceSensor,
     F1LiveTimingModeSensor,
     F1NextRaceSensor,
     F1PitStopsSensor,
@@ -271,6 +272,44 @@ def _build_race(
         "ThirdPractice": {"date": "2026-03-07", "time": "01:30:00Z"},
         "Qualifying": {"date": "2026-03-07", "time": "05:00:00Z"},
     }
+
+
+def _build_last_race(
+        *,
+        season: str = "2026",
+        round_: str = "1",
+        race_name: str = "Australian Grand Prix",
+        circuit_id: str = "albert_park",
+        circuit_name: str = "Albert Park Grand Prix Circuit",
+        locality: str = "Melbourne",
+        country: str = "Australia",
+        date: str = "2026-03-08",
+        time: str = "04:00:00Z",
+        results_per_race: int = 20,
+    ) -> dict:
+        return {
+            "season": season,
+            "round": round_,
+            "raceName": race_name,
+            "url": f"https://example.com/races/{round_}",
+            "date": date,
+            "time": time,
+            "Circuit": {
+                "circuitId": circuit_id,
+                "url": f"https://example.com/circuits/{circuit_id}",
+                "circuitName": circuit_name,
+                "Location": {
+                    "lat": "-37.8497",
+                    "long": "144.968",
+                    "locality": locality,
+                    "country": country,
+                },
+            },
+            "Results": [
+                _build_result_entry(driver_idx)
+                for driver_idx in range(1, results_per_race + 1)
+            ]
+        }
 
 
 def _history_driver(
@@ -1618,3 +1657,47 @@ async def test_driver_list_sensor_handles_22_drivers(hass) -> None:
     assert state is not None
     assert state.state == "22"
     assert len(state.attributes["drivers"]) == 22
+
+@pytest.mark.asyncio
+async def test_last_race_sensor_attributes(hass) -> None:
+    coordinator = _build_coordinator(
+        hass,
+        {
+            "MRData": {
+                "RaceTable": {
+                    "season": "2026",
+                    "Races": [
+                        _build_last_race(
+                            round_="16",
+                            race_name="Spanish Grand Prix",
+                            circuit_id="madring",
+                            circuit_name="Madring",
+                            locality="Madrid",
+                            country="Spain",
+                            date="2026-09-13",
+                            time="13:00:00Z",
+                            results_per_race=20,
+                        ),
+                    ],
+                }
+            }
+        },
+    )
+    entry_id = "test_entry_last_race"
+    _set_entry_context(hass, entry_id)
+
+    sensor = F1LastRaceSensor(
+        coordinator,
+        f"{entry_id}_last_race",
+        entry_id,
+        "F1",
+    )
+    state = await _add_sensor_and_get_state(hass, sensor)
+
+    results = state.attributes["results"]
+    assert results[0]["position"] == 1
+    assert results[0]["grid"] == 1
+    assert results[0]["laps"] == 60
+    assert results[1]["position"] == 2
+    assert results[1]["grid"] == 2
+    assert results[1]["laps"] == 60

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -105,9 +105,11 @@ def _recorder_shared_attrs(state) -> tuple[dict, int]:
 def _build_result_entry(idx: int) -> dict:
     return {
         "number": str(idx),
+        "grid": str(idx),
         "position": str(idx),
         "points": str(max(0, 26 - idx)),
         "status": "Finished",
+        "laps": str(60),
         "Driver": {
             "driverId": f"driver{idx}",
             "code": f"D{idx:02d}",


### PR DESCRIPTION
## Description

Add starting grid position and number of laps completed to the last race results sensor

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [x] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

- [x] Tested locally with a real Home Assistant instance
- [x] Existing automations and dashboards still work as expected after the change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [x] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [x] No merge conflicts with the target branch