### PR TITLE
blue: **Restore session-start CLEAR lights after delay**

### DIFF
--- a/blueprints/f1_track_status.yaml
+++ b/blueprints/f1_track_status.yaml
@@ -807,12 +807,6 @@ variables:
   pre_alert_scene_id: "{{ automation_slug ~ '_pre_alert' }}"
 
   track_state: "{{ states(track_status_entity) | upper }}"
-  defer_wled_clear_restore: >-
-    {{
-      track_state == 'CLEAR'
-      and (snapshot_before_alert_enabled | bool)
-      and clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay']
-    }}
   session_phase: "{{ states(session_status_entity) | lower }}"
   notification_title: "F1 Track Status"
   notification_track_state: "{{ track_state }}"
@@ -887,6 +881,26 @@ variables:
     {% else %}
       {{ (session_scope_now_ok | bool) and trigger_to_phase in valid_session_phases and trigger_from_phase not in active_phases and trigger_to_phase in active_phases }}
     {% endif %}
+
+  clear_restore_scene_entity: >-
+    {% if session_entered_active | bool %}
+      {% if snapshot_pre_race_enabled | bool %}
+        {{ 'scene.' ~ pre_race_scene_id }}
+      {% else %}
+        {{ '' }}
+      {% endif %}
+    {% elif snapshot_before_alert_enabled | bool %}
+      {{ 'scene.' ~ pre_alert_scene_id }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  clear_restore_scene_available: "{{ clear_restore_scene_entity | string | trim | length > 0 }}"
+  defer_wled_clear_restore: >-
+    {{
+      track_state == 'CLEAR'
+      and (clear_restore_scene_available | bool)
+      and clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay']
+    }}
 
   session_left_active: >
     {% if trigger.id != 'session_leave_active' %}
@@ -1141,7 +1155,7 @@ actions:
                       - choose:
                           - conditions:
                               - condition: template
-                                value_template: "{{ clear_behavior_mode_input == 'steady' or (clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay'] and not snapshot_before_alert_enabled) }}"
+                                value_template: "{{ clear_behavior_mode_input == 'steady' or (clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay'] and not (clear_restore_scene_available | bool)) }}"
                             sequence:
                               - choose:
                                   - conditions:
@@ -1167,16 +1181,16 @@ actions:
 
                           - conditions:
                               - condition: template
-                                value_template: "{{ clear_behavior_mode_input == 'restore_immediately' and snapshot_before_alert_enabled }}"
+                                value_template: "{{ clear_behavior_mode_input == 'restore_immediately' and (clear_restore_scene_available | bool) }}"
                             sequence:
                               - continue_on_error: true
                                 action: scene.turn_on
                                 data:
-                                  entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                                  entity_id: "{{ clear_restore_scene_entity | string | trim }}"
 
                           - conditions:
                               - condition: template
-                                value_template: "{{ clear_behavior_mode_input == 'restore_after_delay' and snapshot_before_alert_enabled }}"
+                                value_template: "{{ clear_behavior_mode_input == 'restore_after_delay' and (clear_restore_scene_available | bool) }}"
                             sequence:
                               - choose:
                                   - conditions:
@@ -1223,7 +1237,7 @@ actions:
                               - continue_on_error: true
                                 action: scene.turn_on
                                 data:
-                                  entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                                  entity_id: "{{ clear_restore_scene_entity | string | trim }}"
 
                   - conditions:
                       - condition: template


### PR DESCRIPTION
The Track Status Light blueprint now restores the saved pre-race light state after showing CLEAR at session start when delayed or immediate restore is selected. This keeps the green start indication temporary while preserving the existing restore behavior for mid-session warnings.

Fixes #481

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [X] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [X] The blueprint has been imported and tested in Home Assistant
- [X] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
