### PR TITLE
F1TV authentication

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -78,6 +78,7 @@ from .helpers import (
     fetch_json,
     fetch_text,
     get_next_race,
+    normalize_live_timing_auth_header,
     parse_fia_documents,
 )
 from .live_delay import LiveDelayController, LiveDelayReferenceController
@@ -95,6 +96,7 @@ from .signalr import (
     PUBLIC_LIVE_STREAMS,
     REPLAY_ONLY_STREAMS,
     LiveBus,
+    build_live_subscribe_streams,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -1575,9 +1577,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[LATEST_TRACK_STATUS] = None
     # Create shared LiveBus (single SignalR connection). Live mode defers start to supervisor.
     session = async_get_clientsession(hass)
-    live_timing_auth_header = str(
-        entry.data.get(CONF_LIVE_TIMING_AUTH_HEADER, "") or ""
-    ).strip()
+    live_timing_auth_header = normalize_live_timing_auth_header(
+        entry.data.get(CONF_LIVE_TIMING_AUTH_HEADER, "")
+    )
     if operation_mode != OPERATION_MODE_LIVE or not ENABLE_DEVELOPMENT_MODE_UI:
         live_timing_auth_header = ""
 
@@ -1587,6 +1589,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             capabilities = entry_data.get("signalr_stream_capabilities")
             if isinstance(capabilities, dict):
                 capabilities["auth_enabled"] = False
+                capabilities["active_live_streams"] = frozenset(
+                    build_live_subscribe_streams(include_auth_gated=False)
+                )
+            championship_prediction_coordinator = entry_data.get(
+                "championship_prediction_coordinator"
+            )
+            live_state = entry_data.get("live_state")
+            if (
+                championship_prediction_coordinator is not None
+                and live_state is not None
+                and hasattr(championship_prediction_coordinator, "_handle_live_state")
+            ):
+                with suppress(Exception):
+                    championship_prediction_coordinator._handle_live_state(  # noqa: SLF001
+                        bool(getattr(live_state, "is_live", False)),
+                        getattr(live_state, "reason", None),
+                    )
         entry.async_start_reauth(hass, data=entry.data)
 
     live_bus = LiveBus(
@@ -1906,6 +1925,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "auth_gated_live_streams": frozenset(AUTH_GATED_LIVE_STREAMS),
             "replay_only_streams": frozenset(REPLAY_ONLY_STREAMS),
             "auth_enabled": live_bus.auth_enabled,
+            "active_live_streams": frozenset(
+                build_live_subscribe_streams(include_auth_gated=live_bus.auth_enabled)
+            ),
         },
         "operation_mode": operation_mode,
         "replay_file": replay_source,
@@ -3552,8 +3574,14 @@ class ChampionshipPredictionCoordinator(
         if self._replay_mode:
             _clear_delayed_ingest_state(self)
         replay_available = bool(is_live and self._replay_mode)
-        self.available = replay_available
-        if not replay_available:
+        auth_live_available = bool(
+            is_live
+            and not self._replay_mode
+            and self._bus is not None
+            and self._bus.auth_enabled
+        )
+        self.available = replay_available or auth_live_available
+        if not self.available:
             _clear_delayed_ingest_state(self)
             self._reset_store()
 

--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -31,6 +31,7 @@ from .calibration import LiveDelayCalibrationManager
 from .const import (
     API_URL,
     CONF_LIVE_DELAY_REFERENCE,
+    CONF_LIVE_TIMING_AUTH_HEADER,
     CONF_OPERATION_MODE,
     CONF_REPLAY_FILE,
     CONF_REPLAY_START_REFERENCE,
@@ -1574,7 +1575,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[LATEST_TRACK_STATUS] = None
     # Create shared LiveBus (single SignalR connection). Live mode defers start to supervisor.
     session = async_get_clientsession(hass)
-    live_bus = LiveBus(hass, session, transport_factory=transport_factory)
+    live_timing_auth_header = str(
+        entry.data.get(CONF_LIVE_TIMING_AUTH_HEADER, "") or ""
+    ).strip()
+    if operation_mode != OPERATION_MODE_LIVE or not ENABLE_DEVELOPMENT_MODE_UI:
+        live_timing_auth_header = ""
+
+    def _handle_live_timing_auth_failed() -> None:
+        entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+        if isinstance(entry_data, dict):
+            capabilities = entry_data.get("signalr_stream_capabilities")
+            if isinstance(capabilities, dict):
+                capabilities["auth_enabled"] = False
+        entry.async_start_reauth(hass, data=entry.data)
+
+    live_bus = LiveBus(
+        hass,
+        session,
+        transport_factory=transport_factory,
+        auth_header=live_timing_auth_header,
+        auth_failed_callback=(
+            _handle_live_timing_auth_failed if live_timing_auth_header else None
+        ),
+    )
     live_supervisor: LiveSessionSupervisor | None = None
     event_tracker_source: EventTrackerScheduleSource | None = None
     live_state: LiveAvailabilityTracker
@@ -1882,7 +1905,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "public_live_streams": frozenset(PUBLIC_LIVE_STREAMS),
             "auth_gated_live_streams": frozenset(AUTH_GATED_LIVE_STREAMS),
             "replay_only_streams": frozenset(REPLAY_ONLY_STREAMS),
-            "auth_enabled": False,
+            "auth_enabled": live_bus.auth_enabled,
         },
         "operation_mode": operation_mode,
         "replay_file": replay_source,
@@ -5287,6 +5310,13 @@ class LiveDriversCoordinator(DataUpdateCoordinator):
                 self._unsubs.append(
                     bus.subscribe(
                         "LapHistory", _wrap_delayed_handler(self, self._on_lap_history)
+                    )
+                )
+            with suppress(Exception):
+                self._unsubs.append(
+                    bus.subscribe(
+                        "DriverRaceInfo",
+                        _wrap_delayed_handler(self, self._on_driver_race_info),
                     )
                 )
             with suppress(Exception):

--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -1621,20 +1621,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 capabilities["active_live_streams"] = frozenset(
                     build_live_subscribe_streams(include_auth_gated=False)
                 )
-            championship_prediction_coordinator = entry_data.get(
-                "championship_prediction_coordinator"
-            )
             live_state = entry_data.get("live_state")
-            if (
-                championship_prediction_coordinator is not None
-                and live_state is not None
-                and hasattr(championship_prediction_coordinator, "_handle_live_state")
-            ):
-                with suppress(Exception):
-                    championship_prediction_coordinator._handle_live_state(  # noqa: SLF001
-                        bool(getattr(live_state, "is_live", False)),
-                        getattr(live_state, "reason", None),
-                    )
+            if live_state is not None:
+                for coordinator_key in (
+                    "championship_prediction_coordinator",
+                    "team_radio_coordinator",
+                    "pitstop_coordinator",
+                ):
+                    coordinator = entry_data.get(coordinator_key)
+                    if coordinator is not None and hasattr(
+                        coordinator, "_handle_live_state"
+                    ):
+                        with suppress(Exception):
+                            coordinator._handle_live_state(  # noqa: SLF001
+                                bool(getattr(live_state, "is_live", False)),
+                                getattr(live_state, "reason", None),
+                            )
         entry.async_start_reauth(hass, data=entry.data)
 
     live_bus = LiveBus(
@@ -2815,8 +2817,14 @@ class TeamRadioCoordinator(DataUpdateCoordinator):
         if self._replay_mode:
             _clear_delayed_ingest_state(self)
         replay_available = bool(is_live and self._replay_mode)
-        self.available = replay_available
-        if not replay_available:
+        auth_live_available = bool(
+            is_live
+            and not self._replay_mode
+            and self._bus is not None
+            and getattr(self._bus, "auth_enabled", False)
+        )
+        self.available = replay_available or auth_live_available
+        if not self.available:
             _clear_delayed_ingest_state(self)
             self._state = {"latest": None, "history": []}
             # Notify entities to clear their state
@@ -3053,8 +3061,14 @@ class PitStopCoordinator(_SessionFingerprintMixin, DataUpdateCoordinator):
         if self._replay_mode:
             _clear_delayed_ingest_state(self)
         replay_available = bool(is_live and self._replay_mode)
-        self.available = replay_available
-        if not replay_available:
+        auth_live_available = bool(
+            is_live
+            and not self._replay_mode
+            and self._bus is not None
+            and getattr(self._bus, "auth_enabled", False)
+        )
+        self.available = replay_available or auth_live_available
+        if not self.available:
             _clear_delayed_ingest_state(self)
             self._reset_store()
 

--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -27,6 +27,18 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 import voluptuous as vol
 
+from .auth import (
+    AUTH_REPAIR_STATUSES,
+    AUTH_RUNTIME_STATUS,
+    AUTH_RUNTIME_STATUS_REFRESH_UNSUB,
+    async_cancel_f1tv_auth_status_refresh,
+    async_schedule_f1tv_auth_status_refresh,
+    async_set_runtime_f1tv_auth_status,
+    async_update_f1tv_auth_repair_issue,
+    evaluate_f1tv_auth_header,
+    is_auth_transport_enabled,
+    rejected_f1tv_auth_status,
+)
 from .calibration import LiveDelayCalibrationManager
 from .const import (
     API_URL,
@@ -78,7 +90,6 @@ from .helpers import (
     fetch_json,
     fetch_text,
     get_next_race,
-    normalize_live_timing_auth_header,
     parse_fia_documents,
 )
 from .live_delay import LiveDelayController, LiveDelayReferenceController
@@ -1577,15 +1588,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[LATEST_TRACK_STATUS] = None
     # Create shared LiveBus (single SignalR connection). Live mode defers start to supervisor.
     session = async_get_clientsession(hass)
-    live_timing_auth_header = normalize_live_timing_auth_header(
+    live_timing_auth_status = evaluate_f1tv_auth_header(
         entry.data.get(CONF_LIVE_TIMING_AUTH_HEADER, "")
     )
-    if operation_mode != OPERATION_MODE_LIVE or not ENABLE_DEVELOPMENT_MODE_UI:
+    live_timing_auth_header = live_timing_auth_status.header
+    auth_transport_enabled = is_auth_transport_enabled()
+    auth_can_be_used = (
+        operation_mode == OPERATION_MODE_LIVE
+        and auth_transport_enabled
+        and live_timing_auth_status.status not in AUTH_REPAIR_STATUSES
+    )
+    if not auth_can_be_used:
         live_timing_auth_header = ""
+    else:
+        live_timing_auth_status = evaluate_f1tv_auth_header(
+            live_timing_auth_header,
+            used_for_live_timing=True,
+        )
 
     def _handle_live_timing_auth_failed() -> None:
         entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
         if isinstance(entry_data, dict):
+            current_auth_status = entry_data.get(AUTH_RUNTIME_STATUS)
+            if current_auth_status is None:
+                current_auth_status = live_timing_auth_status
+            rejected_status = rejected_f1tv_auth_status(current_auth_status)
+            async_set_runtime_f1tv_auth_status(hass, entry.entry_id, rejected_status)
+            async_update_f1tv_auth_repair_issue(hass, entry, rejected_status)
             capabilities = entry_data.get("signalr_stream_capabilities")
             if isinstance(capabilities, dict):
                 capabilities["auth_enabled"] = False
@@ -1929,6 +1958,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 build_live_subscribe_streams(include_auth_gated=live_bus.auth_enabled)
             ),
         },
+        AUTH_RUNTIME_STATUS: live_timing_auth_status,
+        AUTH_RUNTIME_STATUS_REFRESH_UNSUB: None,
         "operation_mode": operation_mode,
         "replay_file": replay_source,
         "live_delay_controller": delay_controller,
@@ -1962,6 +1993,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _apply_activity_log_filter_excludes(hass)
     hass_data = hass.data.setdefault(DOMAIN, {}).get(entry.entry_id)
     if isinstance(hass_data, dict):
+        async_update_f1tv_auth_repair_issue(hass, entry, live_timing_auth_status)
+        async_schedule_f1tv_auth_status_refresh(hass, entry)
 
         def _on_component_loaded(event):
             component = str((getattr(event, "data", {}) or {}).get("component") or "")
@@ -5370,10 +5403,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if isinstance(data_root, dict):
             data = data_root.pop(entry.entry_id, None)
         if isinstance(data, dict):
+            auth_status_unsub = data.pop(AUTH_RUNTIME_STATUS_REFRESH_UNSUB, None)
+            if callable(auth_status_unsub):
+                with suppress(Exception):
+                    auth_status_unsub()
             activity_filter_unsub = data.pop("activity_filter_unsub", None)
             if callable(activity_filter_unsub):
                 with suppress(Exception):
                     activity_filter_unsub()
+            async_cancel_f1tv_auth_status_refresh(hass, entry.entry_id)
             for name, obj in list(data.items()):
                 if obj is None:
                     continue

--- a/custom_components/f1_sensor/auth.py
+++ b/custom_components/f1_sensor/auth.py
@@ -1,0 +1,363 @@
+"""Safe F1TV token status helpers."""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
+import json
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.event import async_call_later
+
+from . import const
+from .const import CONF_LIVE_TIMING_AUTH_HEADER, DOMAIN
+from .helpers import normalize_live_timing_auth_header
+
+AUTH_STATUS_NOT_CONFIGURED = "not_configured"
+AUTH_STATUS_VALID = "valid"
+AUTH_STATUS_EXPIRING_SOON = "expiring_soon"
+AUTH_STATUS_EXPIRED = "expired"
+AUTH_STATUS_INVALID = "invalid"
+AUTH_STATUS_REJECTED = "rejected"
+
+AUTH_STATUS_OPTIONS = (
+    AUTH_STATUS_NOT_CONFIGURED,
+    AUTH_STATUS_VALID,
+    AUTH_STATUS_EXPIRING_SOON,
+    AUTH_STATUS_EXPIRED,
+    AUTH_STATUS_INVALID,
+    AUTH_STATUS_REJECTED,
+)
+
+AUTH_EXPIRING_SOON = timedelta(hours=24)
+AUTH_MIN_REPLACEMENT_REMAINING = timedelta(minutes=10)
+AUTH_REPAIR_STATUSES = frozenset(
+    {AUTH_STATUS_EXPIRED, AUTH_STATUS_INVALID, AUTH_STATUS_REJECTED}
+)
+AUTH_REPAIR_TRANSLATION_KEY = "f1tv_token_attention_required"
+
+AUTH_RUNTIME_STATUS = "f1tv_auth_status"
+AUTH_RUNTIME_STATUS_LISTENERS = "f1tv_auth_status_listeners"
+AUTH_RUNTIME_STATUS_REFRESH_UNSUB = "f1tv_auth_status_refresh_unsub"
+
+
+@dataclass(frozen=True)
+class F1TvAuthStatus:
+    """Redacted F1TV token status."""
+
+    status: str
+    configured: bool
+    header: str = ""
+    expires_at: datetime | None = None
+    reason: str | None = None
+    used_for_live_timing: bool = False
+
+    @property
+    def issue_required(self) -> bool:
+        """Return True when Home Assistant should show a repair issue."""
+        return self.configured and self.status in AUTH_REPAIR_STATUSES
+
+    @property
+    def expires_at_iso(self) -> str | None:
+        """Return the token expiry as an ISO-8601 string."""
+        if self.expires_at is None:
+            return None
+        return self.expires_at.astimezone(UTC).isoformat()
+
+    def as_safe_dict(self) -> dict[str, Any]:
+        """Return diagnostics-safe metadata."""
+        return {
+            "status": self.status,
+            "configured": self.configured,
+            "expires_at": self.expires_at_iso,
+            "reason": self.reason,
+            "used_for_live_timing": self.used_for_live_timing,
+        }
+
+
+def is_auth_transport_enabled() -> bool:
+    """Return True when F1TV auth may be used for live timing transport."""
+    return const.ENABLE_DEVELOPMENT_MODE_UI
+
+
+def is_auth_health_visible(status: F1TvAuthStatus | None) -> bool:
+    """Return True when redacted token health may be shown."""
+    return bool(is_auth_transport_enabled() or (status and status.configured))
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _decode_jwt_part(part: str) -> dict[str, Any]:
+    padded = part + "=" * (-len(part) % 4)
+    decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+    value = json.loads(decoded.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("JWT part is not a JSON object")
+    return value
+
+
+def _extract_bearer_token(header: str) -> str:
+    parts = header.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise ValueError("missing_bearer_scheme")
+    return parts[1].strip()
+
+
+def evaluate_f1tv_auth_header(
+    value: object,
+    *,
+    now: datetime | None = None,
+    used_for_live_timing: bool = False,
+) -> F1TvAuthStatus:
+    """Return redacted status for a saved F1TV authorization header."""
+    header = normalize_live_timing_auth_header(value)
+    if not header:
+        return F1TvAuthStatus(
+            status=AUTH_STATUS_NOT_CONFIGURED,
+            configured=False,
+            used_for_live_timing=False,
+        )
+
+    now = (now or _utcnow()).astimezone(UTC)
+
+    try:
+        token = _extract_bearer_token(header)
+        parts = token.split(".")
+        if len(parts) != 3:
+            raise ValueError("malformed_jwt")
+        _decode_jwt_part(parts[0])
+        payload = _decode_jwt_part(parts[1])
+        exp = payload.get("exp")
+        if not isinstance(exp, (int, float)):
+            return F1TvAuthStatus(
+                status=AUTH_STATUS_INVALID,
+                configured=True,
+                header=header,
+                reason="missing_exp",
+            )
+        expires_at = datetime.fromtimestamp(exp, tz=UTC)
+    except Exception as err:
+        return F1TvAuthStatus(
+            status=AUTH_STATUS_INVALID,
+            configured=True,
+            header=header,
+            reason=str(err) or "invalid_jwt",
+        )
+
+    if expires_at <= now:
+        status = AUTH_STATUS_EXPIRED
+        reason = "expired"
+        used_for_live_timing = False
+    elif expires_at - now <= AUTH_EXPIRING_SOON:
+        status = AUTH_STATUS_EXPIRING_SOON
+        reason = "expiring_soon"
+    else:
+        status = AUTH_STATUS_VALID
+        reason = None
+
+    return F1TvAuthStatus(
+        status=status,
+        configured=True,
+        header=header,
+        expires_at=expires_at,
+        reason=reason,
+        used_for_live_timing=used_for_live_timing,
+    )
+
+
+def validate_replacement_auth_header(
+    value: object, *, now: datetime | None = None
+) -> tuple[str | None, str | None, F1TvAuthStatus]:
+    """Validate a user-submitted replacement token.
+
+    Returns ``(normalized_header, error_key, status)``. ``error_key`` is ``None``
+    when the header can be saved.
+    """
+    status = evaluate_f1tv_auth_header(value, now=now)
+    if not status.configured:
+        return None, "auth_header_required", status
+    if status.status == AUTH_STATUS_INVALID:
+        reason = status.reason or "invalid_auth_header"
+        if reason == "missing_exp":
+            return None, "auth_token_missing_exp", status
+        return None, "invalid_auth_header", status
+    if status.status == AUTH_STATUS_EXPIRED:
+        return None, "auth_token_expired", status
+
+    now = (now or _utcnow()).astimezone(UTC)
+    if status.expires_at is None:
+        return None, "auth_token_missing_exp", status
+    if status.expires_at - now <= AUTH_MIN_REPLACEMENT_REMAINING:
+        return None, "auth_token_expiring_soon", status
+    return status.header, None, status
+
+
+def rejected_f1tv_auth_status(status: F1TvAuthStatus) -> F1TvAuthStatus:
+    """Return a rejected status for a token the server refused."""
+    return replace(
+        status,
+        status=AUTH_STATUS_REJECTED,
+        reason="signalr_rejected",
+        used_for_live_timing=False,
+    )
+
+
+def _issue_id(entry_id: str) -> str:
+    return f"f1tv_token_{entry_id}"
+
+
+def f1tv_auth_repair_issue_id(entry_id: str) -> str:
+    """Return the stable repair issue id for a config entry."""
+    return _issue_id(entry_id)
+
+
+@callback
+def async_update_f1tv_auth_repair_issue(
+    hass: HomeAssistant, entry: ConfigEntry, status: F1TvAuthStatus
+) -> None:
+    """Create or clear the redacted F1TV token repair issue."""
+    issue_id = _issue_id(entry.entry_id)
+    if not status.issue_required:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+        return
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        data={
+            "entry_id": entry.entry_id,
+            "status": status.status,
+            "expires_at": status.expires_at_iso,
+        },
+        is_fixable=True,
+        is_persistent=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=AUTH_REPAIR_TRANSLATION_KEY,
+        translation_placeholders={
+            "name": entry.title or entry.data.get("sensor_name", "F1"),
+            "status": status.status,
+            "expires_at": status.expires_at_iso or "unknown",
+        },
+    )
+
+
+def _runtime_data(hass: HomeAssistant, entry_id: str) -> dict[str, Any] | None:
+    root = hass.data.get(DOMAIN)
+    if not isinstance(root, dict):
+        return None
+    data = root.get(entry_id)
+    return data if isinstance(data, dict) else None
+
+
+@callback
+def async_set_runtime_f1tv_auth_status(
+    hass: HomeAssistant, entry_id: str, status: F1TvAuthStatus
+) -> None:
+    """Store runtime auth status and notify listeners."""
+    data = _runtime_data(hass, entry_id)
+    if data is None:
+        return
+    data[AUTH_RUNTIME_STATUS] = status
+    listeners = list(data.get(AUTH_RUNTIME_STATUS_LISTENERS) or [])
+    for listener in listeners:
+        listener(status)
+
+
+@callback
+def async_add_f1tv_auth_status_listener(
+    hass: HomeAssistant,
+    entry_id: str,
+    listener: Callable[[F1TvAuthStatus], None],
+) -> Callable[[], None]:
+    """Listen for token health updates for one entry."""
+    data = _runtime_data(hass, entry_id)
+    if data is None:
+        return lambda: None
+    listeners = data.setdefault(AUTH_RUNTIME_STATUS_LISTENERS, [])
+    listeners.append(listener)
+
+    def _remove() -> None:
+        if listener in listeners:
+            listeners.remove(listener)
+
+    return _remove
+
+
+def _next_refresh_delay(status: F1TvAuthStatus, now: datetime) -> float | None:
+    if status.expires_at is None or status.status in (
+        AUTH_STATUS_NOT_CONFIGURED,
+        AUTH_STATUS_EXPIRED,
+        AUTH_STATUS_INVALID,
+        AUTH_STATUS_REJECTED,
+    ):
+        return None
+
+    target = status.expires_at
+    if status.status == AUTH_STATUS_VALID:
+        target = status.expires_at - AUTH_EXPIRING_SOON
+        if target <= now:
+            target = status.expires_at
+
+    delay = (target - now).total_seconds()
+    if delay <= 0:
+        return 0
+    return delay
+
+
+@callback
+def async_schedule_f1tv_auth_status_refresh(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Schedule the next token status transition without polling."""
+    data = _runtime_data(hass, entry.entry_id)
+    if data is None:
+        return
+
+    if old_unsub := data.pop(AUTH_RUNTIME_STATUS_REFRESH_UNSUB, None):
+        old_unsub()
+
+    current = data.get(AUTH_RUNTIME_STATUS)
+    if not isinstance(current, F1TvAuthStatus):
+        current = evaluate_f1tv_auth_header(
+            entry.data.get(CONF_LIVE_TIMING_AUTH_HEADER)
+        )
+
+    delay = _next_refresh_delay(current, _utcnow())
+    if delay is None:
+        return
+
+    @callback
+    def _refresh(_now: datetime | None = None) -> None:
+        previous = data.get(AUTH_RUNTIME_STATUS)
+        used = bool(
+            isinstance(previous, F1TvAuthStatus) and previous.used_for_live_timing
+        )
+        status = evaluate_f1tv_auth_header(
+            entry.data.get(CONF_LIVE_TIMING_AUTH_HEADER),
+            used_for_live_timing=used,
+        )
+        if status.status in AUTH_REPAIR_STATUSES:
+            status = replace(status, used_for_live_timing=False)
+        async_set_runtime_f1tv_auth_status(hass, entry.entry_id, status)
+        async_update_f1tv_auth_repair_issue(hass, entry, status)
+        async_schedule_f1tv_auth_status_refresh(hass, entry)
+
+    data[AUTH_RUNTIME_STATUS_REFRESH_UNSUB] = async_call_later(hass, delay, _refresh)
+
+
+@callback
+def async_cancel_f1tv_auth_status_refresh(hass: HomeAssistant, entry_id: str) -> None:
+    """Cancel a scheduled token status transition."""
+    data = _runtime_data(hass, entry_id)
+    if data is None:
+        return
+    if old_unsub := data.pop(AUTH_RUNTIME_STATUS_REFRESH_UNSUB, None):
+        old_unsub()

--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -2,11 +2,17 @@ from pathlib import Path
 
 from homeassistant import config_entries
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 import voluptuous as vol
 
 from .const import (
     CONF_ENTITY_NAME_LANGUAGE,
     CONF_ENTITY_NAME_MODE,
+    CONF_LIVE_TIMING_AUTH_HEADER,
     CONF_OPERATION_MODE,
     CONF_RACE_WEEK_START_DAY,
     CONF_RACE_WEEK_SUNDAY_START,
@@ -22,6 +28,12 @@ from .const import (
     RACE_WEEK_START_MONDAY,
     RACE_WEEK_START_SATURDAY,
     RACE_WEEK_START_SUNDAY,
+)
+
+_CONF_CLEAR_LIVE_TIMING_AUTH_HEADER = "clear_live_timing_auth_header"
+
+_AUTH_HEADER_SELECTOR = TextSelector(
+    TextSelectorConfig(type=TextSelectorType.PASSWORD, autocomplete="current-password")
 )
 
 RACE_WEEK_START_OPTIONS = {
@@ -79,6 +91,11 @@ def _build_sensor_options() -> dict:
     return options
 
 
+def _normalize_auth_header(value: object) -> str:
+    """Return a normalized live timing authorization header."""
+    return str(value or "").strip()
+
+
 class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
@@ -107,6 +124,12 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         race_week_start = self._normalize_race_week_start(current)
 
         if user_input is not None:
+            auth_header = _normalize_auth_header(
+                user_input.pop(CONF_LIVE_TIMING_AUTH_HEADER, "")
+            )
+            if ENABLE_DEVELOPMENT_MODE_UI and auth_header:
+                user_input[CONF_LIVE_TIMING_AUTH_HEADER] = auth_header
+
             # Resolve and validate operation mode
             mode = user_input.get(CONF_OPERATION_MODE, DEFAULT_OPERATION_MODE)
             if mode not in (OPERATION_MODE_LIVE, OPERATION_MODE_DEVELOPMENT):
@@ -172,6 +195,9 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_REPLAY_FILE,
                         default=current.get(CONF_REPLAY_FILE, ""),
                     ): cv.string,
+                    vol.Optional(
+                        CONF_LIVE_TIMING_AUTH_HEADER, default=""
+                    ): _AUTH_HEADER_SELECTOR,
                 }
             )
         else:
@@ -192,6 +218,19 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         race_week_start = self._normalize_race_week_start(current)
 
         if user_input is not None:
+            auth_header = _normalize_auth_header(
+                user_input.pop(CONF_LIVE_TIMING_AUTH_HEADER, "")
+            )
+            clear_auth_header = bool(
+                user_input.pop(_CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, False)
+            )
+            if auth_header:
+                if ENABLE_DEVELOPMENT_MODE_UI:
+                    user_input[CONF_LIVE_TIMING_AUTH_HEADER] = auth_header
+            elif clear_auth_header:
+                if ENABLE_DEVELOPMENT_MODE_UI:
+                    user_input[CONF_LIVE_TIMING_AUTH_HEADER] = ""
+
             mode = user_input.get(
                 CONF_OPERATION_MODE,
                 current.get(CONF_OPERATION_MODE, DEFAULT_OPERATION_MODE),
@@ -293,11 +332,60 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     ): cv.string,
                 }
             )
+            if ENABLE_DEVELOPMENT_MODE_UI:
+                schema_fields.update(
+                    {
+                        vol.Optional(
+                            CONF_LIVE_TIMING_AUTH_HEADER, default=""
+                        ): _AUTH_HEADER_SELECTOR,
+                        vol.Optional(
+                            _CONF_CLEAR_LIVE_TIMING_AUTH_HEADER,
+                            default=False,
+                        ): cv.boolean,
+                    }
+                )
 
         data_schema = vol.Schema(schema_fields)
 
         return self.async_show_form(
             step_id="reconfigure",
+            data_schema=data_schema,
+            errors=errors,
+        )
+
+    async def async_step_reauth(self, entry_data=None):
+        """Handle reauthentication for live timing authorization."""
+        if not ENABLE_DEVELOPMENT_MODE_UI:
+            return self.async_abort(reason="reauth_not_supported")
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Handle live timing authorization reauthentication."""
+        if not ENABLE_DEVELOPMENT_MODE_UI:
+            return self.async_abort(reason="reauth_not_supported")
+
+        errors = {}
+
+        if user_input is not None:
+            auth_header = _normalize_auth_header(
+                user_input.get(CONF_LIVE_TIMING_AUTH_HEADER)
+            )
+            if not auth_header:
+                errors[CONF_LIVE_TIMING_AUTH_HEADER] = "auth_header_required"
+            else:
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_LIVE_TIMING_AUTH_HEADER: auth_header},
+                )
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_LIVE_TIMING_AUTH_HEADER): _AUTH_HEADER_SELECTOR,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
             data_schema=data_schema,
             errors=errors,
         )

--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -29,6 +29,7 @@ from .const import (
     RACE_WEEK_START_SATURDAY,
     RACE_WEEK_START_SUNDAY,
 )
+from .helpers import normalize_live_timing_auth_header
 
 _CONF_CLEAR_LIVE_TIMING_AUTH_HEADER = "clear_live_timing_auth_header"
 
@@ -93,7 +94,7 @@ def _build_sensor_options() -> dict:
 
 def _normalize_auth_header(value: object) -> str:
     """Return a normalized live timing authorization header."""
-    return str(value or "").strip()
+    return normalize_live_timing_auth_header(value)
 
 
 class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -370,17 +371,28 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             auth_header = _normalize_auth_header(
                 user_input.get(CONF_LIVE_TIMING_AUTH_HEADER)
             )
-            if not auth_header:
-                errors[CONF_LIVE_TIMING_AUTH_HEADER] = "auth_header_required"
-            else:
+            clear_auth_header = bool(
+                user_input.get(_CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, False)
+            )
+            if auth_header:
                 return self.async_update_reload_and_abort(
                     self._get_reauth_entry(),
                     data_updates={CONF_LIVE_TIMING_AUTH_HEADER: auth_header},
                 )
+            if clear_auth_header:
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_LIVE_TIMING_AUTH_HEADER: ""},
+                )
+            if not auth_header:
+                errors[CONF_LIVE_TIMING_AUTH_HEADER] = "auth_header_required"
 
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_LIVE_TIMING_AUTH_HEADER): _AUTH_HEADER_SELECTOR,
+                vol.Optional(_CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, default=False): (
+                    cv.boolean
+                ),
             }
         )
 

--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.selector import (
 import voluptuous as vol
 
 from .const import (
+    CONF_CLEAR_LIVE_TIMING_AUTH_HEADER,
     CONF_ENTITY_NAME_LANGUAGE,
     CONF_ENTITY_NAME_MODE,
     CONF_LIVE_TIMING_AUTH_HEADER,
@@ -30,8 +31,6 @@ from .const import (
     RACE_WEEK_START_SUNDAY,
 )
 from .helpers import normalize_live_timing_auth_header
-
-_CONF_CLEAR_LIVE_TIMING_AUTH_HEADER = "clear_live_timing_auth_header"
 
 _AUTH_HEADER_SELECTOR = TextSelector(
     TextSelectorConfig(type=TextSelectorType.PASSWORD, autocomplete="current-password")
@@ -223,7 +222,7 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.pop(CONF_LIVE_TIMING_AUTH_HEADER, "")
             )
             clear_auth_header = bool(
-                user_input.pop(_CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, False)
+                user_input.pop(CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, False)
             )
             if auth_header:
                 if ENABLE_DEVELOPMENT_MODE_UI:
@@ -340,7 +339,7 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                             CONF_LIVE_TIMING_AUTH_HEADER, default=""
                         ): _AUTH_HEADER_SELECTOR,
                         vol.Optional(
-                            _CONF_CLEAR_LIVE_TIMING_AUTH_HEADER,
+                            CONF_CLEAR_LIVE_TIMING_AUTH_HEADER,
                             default=False,
                         ): cv.boolean,
                     }
@@ -372,7 +371,7 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.get(CONF_LIVE_TIMING_AUTH_HEADER)
             )
             clear_auth_header = bool(
-                user_input.get(_CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, False)
+                user_input.get(CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, False)
             )
             if auth_header:
                 return self.async_update_reload_and_abort(
@@ -390,7 +389,7 @@ class F1FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_LIVE_TIMING_AUTH_HEADER): _AUTH_HEADER_SELECTOR,
-                vol.Optional(_CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, default=False): (
+                vol.Optional(CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, default=False): (
                     cv.boolean
                 ),
             }

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -62,7 +62,7 @@ DEFAULT_REPLAY_START_REFERENCE = REPLAY_START_REFERENCE_FORMATION
 # Gate for exposing development mode controls in the UI.
 # Keep this False in released versions to avoid confusing users;
 # flip to True locally when you want to work with replay/development mode.
-ENABLE_DEVELOPMENT_MODE_UI = True
+ENABLE_DEVELOPMENT_MODE_UI = False
 
 LATEST_TRACK_STATUS = "f1_latest_track_status"
 

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -22,6 +22,7 @@ REPLAY_CACHE_RETENTION_DAYS = (
 
 CONF_OPERATION_MODE = "operation_mode"
 CONF_REPLAY_FILE = "replay_file"
+CONF_LIVE_TIMING_AUTH_HEADER = "live_timing_auth_header"
 CONF_RACE_WEEK_SUNDAY_START = "race_week_sunday_start"
 CONF_RACE_WEEK_START_DAY = "race_week_start_day"
 RACE_WEEK_START_MONDAY = "monday"

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -23,6 +23,7 @@ REPLAY_CACHE_RETENTION_DAYS = (
 CONF_OPERATION_MODE = "operation_mode"
 CONF_REPLAY_FILE = "replay_file"
 CONF_LIVE_TIMING_AUTH_HEADER = "live_timing_auth_header"
+CONF_CLEAR_LIVE_TIMING_AUTH_HEADER = "clear_live_timing_auth_header"
 CONF_RACE_WEEK_SUNDAY_START = "race_week_sunday_start"
 CONF_RACE_WEEK_START_DAY = "race_week_start_day"
 RACE_WEEK_START_MONDAY = "monday"
@@ -62,7 +63,7 @@ DEFAULT_REPLAY_START_REFERENCE = REPLAY_START_REFERENCE_FORMATION
 # Gate for exposing development mode controls in the UI.
 # Keep this False in released versions to avoid confusing users;
 # flip to True locally when you want to work with replay/development mode.
-ENABLE_DEVELOPMENT_MODE_UI = False
+ENABLE_DEVELOPMENT_MODE_UI = True
 
 LATEST_TRACK_STATUS = "f1_latest_track_status"
 

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -62,8 +62,9 @@ DEFAULT_REPLAY_START_REFERENCE = REPLAY_START_REFERENCE_FORMATION
 
 # Gate for exposing development mode controls in the UI.
 # Keep this False in released versions to avoid confusing users;
-# flip to True locally when you want to work with replay/development mode.
-ENABLE_DEVELOPMENT_MODE_UI = True
+# flip to True locally when you want to work with development mode.
+# Read more here : https://nicxe.github.io/f1_sensor/help/beta-tester and https://nicxe.github.io/f1_sensor/help/experimental-testing
+ENABLE_DEVELOPMENT_MODE_UI = False
 
 LATEST_TRACK_STATUS = "f1_latest_track_status"
 

--- a/custom_components/f1_sensor/diagnostics.py
+++ b/custom_components/f1_sensor/diagnostics.py
@@ -1,0 +1,133 @@
+"""Diagnostics support for F1 Sensor."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_LIVE_TIMING_AUTH_HEADER,
+    CONF_OPERATION_MODE,
+    DOMAIN,
+    ENABLE_DEVELOPMENT_MODE_UI,
+)
+from .helpers import normalize_live_timing_auth_header
+
+TO_REDACT = {
+    CONF_LIVE_TIMING_AUTH_HEADER,
+    "Authorization",
+    "authorization",
+    "cookie",
+    "cookies",
+    "login-session",
+    "nonce",
+    "callback_body",
+}
+_TRACKED_STREAMS = (
+    "SessionStatus",
+    "TrackStatus",
+    "TopThree",
+    "TimingAppData",
+    "ChampionshipPrediction",
+    "DriverRaceInfo",
+    "CarData.z",
+)
+
+
+def _sorted_strings(value: object) -> list[str] | None:
+    if not isinstance(value, (set, frozenset, tuple, list)):
+        return None
+    return sorted(str(item) for item in value)
+
+
+def _serialize_signalr_stream_capabilities(
+    capabilities: object, *, include_auth: bool
+) -> dict[str, Any]:
+    if not isinstance(capabilities, dict):
+        return {}
+
+    serialized: dict[str, Any] = {}
+    if include_auth:
+        serialized["auth_enabled"] = bool(capabilities.get("auth_enabled"))
+
+    public_streams = _sorted_strings(capabilities.get("public_live_streams")) or []
+    if public_streams:
+        serialized["public_live_streams"] = public_streams
+
+    replay_only_streams = _sorted_strings(capabilities.get("replay_only_streams")) or []
+    if replay_only_streams:
+        serialized["replay_only_streams"] = replay_only_streams
+
+    if include_auth:
+        if values := _sorted_strings(capabilities.get("auth_gated_live_streams")):
+            serialized["auth_gated_live_streams"] = values
+
+    for key in ("active_live_streams",):
+        if values := _sorted_strings(capabilities.get(key)):
+            if not include_auth:
+                allowed = set(public_streams) | set(replay_only_streams)
+                values = [stream for stream in values if stream in allowed]
+                if not values:
+                    continue
+            serialized[key] = values
+    return serialized
+
+
+def _serialize_live_timing_runtime(live_bus: object) -> dict[str, Any]:
+    runtime: dict[str, Any] = {}
+
+    with suppress(Exception):
+        runtime["heartbeat_age_s"] = live_bus.last_heartbeat_age()
+    with suppress(Exception):
+        runtime["activity_age_s"] = live_bus.last_stream_activity_age()
+    with suppress(Exception):
+        runtime["streams"] = live_bus.stream_diagnostics(_TRACKED_STREAMS)
+
+    return runtime
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for one config entry."""
+    entry_runtime = hass.data.get(DOMAIN, {}).get(entry.entry_id, {}) or {}
+    include_auth = ENABLE_DEVELOPMENT_MODE_UI
+    capabilities = _serialize_signalr_stream_capabilities(
+        entry_runtime.get("signalr_stream_capabilities"),
+        include_auth=include_auth,
+    )
+    runtime: dict[str, Any] = {
+        "operation_mode": entry_runtime.get(
+            "operation_mode", entry.data.get(CONF_OPERATION_MODE)
+        ),
+        "signalr_stream_capabilities": capabilities,
+    }
+
+    if include_auth:
+        runtime["auth_configured"] = bool(
+            normalize_live_timing_auth_header(
+                entry.data.get(CONF_LIVE_TIMING_AUTH_HEADER, "")
+            )
+        )
+        runtime["auth_enabled"] = bool(capabilities.get("auth_enabled"))
+
+    live_bus = entry_runtime.get("live_bus")
+    if live_bus is not None:
+        runtime["live_timing"] = _serialize_live_timing_runtime(live_bus)
+
+    payload: dict[str, Any] = {
+        "entry": {
+            "entry_id": entry.entry_id,
+            "title": entry.title,
+            "data": dict(entry.data),
+            "options": dict(entry.options),
+        },
+        "runtime": runtime,
+    }
+
+    return async_redact_data(payload, TO_REDACT)

--- a/custom_components/f1_sensor/diagnostics.py
+++ b/custom_components/f1_sensor/diagnostics.py
@@ -40,6 +40,8 @@ _TRACKED_STREAMS = (
     "ChampionshipPrediction",
     "DriverRaceInfo",
     "CarData.z",
+    "TeamRadio",
+    "PitStopSeries",
 )
 
 

--- a/custom_components/f1_sensor/diagnostics.py
+++ b/custom_components/f1_sensor/diagnostics.py
@@ -9,13 +9,18 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .auth import (
+    AUTH_RUNTIME_STATUS,
+    F1TvAuthStatus,
+    evaluate_f1tv_auth_header,
+    is_auth_health_visible,
+    is_auth_transport_enabled,
+)
 from .const import (
     CONF_LIVE_TIMING_AUTH_HEADER,
     CONF_OPERATION_MODE,
     DOMAIN,
-    ENABLE_DEVELOPMENT_MODE_UI,
 )
-from .helpers import normalize_live_timing_auth_header
 
 TO_REDACT = {
     CONF_LIVE_TIMING_AUTH_HEADER,
@@ -96,10 +101,17 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for one config entry."""
     entry_runtime = hass.data.get(DOMAIN, {}).get(entry.entry_id, {}) or {}
-    include_auth = ENABLE_DEVELOPMENT_MODE_UI
+    runtime_auth_status = entry_runtime.get(AUTH_RUNTIME_STATUS)
+    auth_status = (
+        runtime_auth_status
+        if isinstance(runtime_auth_status, F1TvAuthStatus)
+        else evaluate_f1tv_auth_header(entry.data.get(CONF_LIVE_TIMING_AUTH_HEADER, ""))
+    )
+    include_auth_transport = is_auth_transport_enabled()
+    include_auth_health = is_auth_health_visible(auth_status)
     capabilities = _serialize_signalr_stream_capabilities(
         entry_runtime.get("signalr_stream_capabilities"),
-        include_auth=include_auth,
+        include_auth=include_auth_transport,
     )
     runtime: dict[str, Any] = {
         "operation_mode": entry_runtime.get(
@@ -108,12 +120,10 @@ async def async_get_config_entry_diagnostics(
         "signalr_stream_capabilities": capabilities,
     }
 
-    if include_auth:
-        runtime["auth_configured"] = bool(
-            normalize_live_timing_auth_header(
-                entry.data.get(CONF_LIVE_TIMING_AUTH_HEADER, "")
-            )
-        )
+    if include_auth_health:
+        runtime["auth_configured"] = auth_status.configured
+        runtime["f1tv_token"] = auth_status.as_safe_dict()
+    if include_auth_transport:
         runtime["auth_enabled"] = bool(capabilities.get("auth_enabled"))
 
     live_bus = entry_runtime.get("live_bus")

--- a/custom_components/f1_sensor/entity.py
+++ b/custom_components/f1_sensor/entity.py
@@ -224,6 +224,38 @@ def is_replay_only_stream_active(
     return bool(is_live and reason in _REPLAY_ONLY_ACTIVE_REASONS)
 
 
+def is_auth_gated_stream_active(
+    hass: HomeAssistant | None, entry_id: str | None, stream: str | None
+) -> bool:
+    """Return True when an auth-gated live stream should expose live data."""
+    if hass is None or not entry_id or not stream:
+        return False
+
+    reg = hass.data.get(DOMAIN, {}).get(entry_id, {}) or {}
+    if (
+        reg.get(CONF_OPERATION_MODE, DEFAULT_OPERATION_MODE)
+        == OPERATION_MODE_DEVELOPMENT
+    ):
+        return False
+
+    live_state = reg.get("live_state")
+    if live_state is None or not bool(getattr(live_state, "is_live", False)):
+        return False
+
+    if getattr(live_state, "reason", None) in _REPLAY_ONLY_ACTIVE_REASONS:
+        return False
+
+    capabilities = reg.get("signalr_stream_capabilities")
+    if not isinstance(capabilities, dict) or not bool(capabilities.get("auth_enabled")):
+        return False
+
+    auth_gated_streams = capabilities.get("auth_gated_live_streams")
+    if not isinstance(auth_gated_streams, (set, frozenset, tuple, list)):
+        return False
+
+    return stream in auth_gated_streams
+
+
 class F1BaseEntity(CoordinatorEntity):
     """Common base entity for F1 sensors."""
 

--- a/custom_components/f1_sensor/helpers.py
+++ b/custom_components/f1_sensor/helpers.py
@@ -44,6 +44,25 @@ _JOLPICA_UA_TEXT_HIT_LOGGED: set[str] = set()
 _ENTITY_NAME_ACRONYMS = {"f1": "F1", "fia": "FIA"}
 
 
+def normalize_live_timing_auth_header(value: object) -> str:
+    """Normalize a user-provided live timing Authorization value.
+
+    The stored value is the Authorization header value itself, typically
+    ``Bearer <JWT>``. Legacy inputs that include an ``Authorization:`` prefix are
+    accepted and normalized to the header value only.
+    """
+    normalized = str(value or "").strip()
+    if not normalized:
+        return ""
+
+    if match := re.match(
+        r"^authorization\s*:\s*(?P<header>.+)$", normalized, flags=re.IGNORECASE
+    ):
+        normalized = match.group("header").strip()
+
+    return normalized
+
+
 def _record_jolpica_miss(hass, key: str) -> None:
     """Dev-only: count Jolpica network MISS calls for periodic summary logging."""
     if not ENABLE_DEVELOPMENT_MODE_UI:

--- a/custom_components/f1_sensor/repairs.py
+++ b/custom_components/f1_sensor/repairs.py
@@ -1,0 +1,102 @@
+"""Repairs support for F1 Sensor."""
+
+from __future__ import annotations
+
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+import voluptuous as vol
+
+from .auth import (
+    async_update_f1tv_auth_repair_issue,
+    evaluate_f1tv_auth_header,
+    f1tv_auth_repair_issue_id,
+    validate_replacement_auth_header,
+)
+from .const import (
+    CONF_CLEAR_LIVE_TIMING_AUTH_HEADER,
+    CONF_LIVE_TIMING_AUTH_HEADER,
+)
+
+_AUTH_HEADER_SELECTOR = TextSelector(
+    TextSelectorConfig(type=TextSelectorType.PASSWORD, autocomplete="current-password")
+)
+
+
+class F1TvTokenRepairFlow(RepairsFlow):
+    """Repair flow for expired or invalid F1TV token access."""
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize the repair flow."""
+        self._entry = entry
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Handle the first step."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, object] | None = None
+    ) -> FlowResult:
+        """Handle token replacement or removal."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            if bool(user_input.get(CONF_CLEAR_LIVE_TIMING_AUTH_HEADER, False)):
+                await self._async_save_auth_header("")
+                return self.async_create_entry(title="", data={})
+
+            auth_header, error, _status = validate_replacement_auth_header(
+                user_input.get(CONF_LIVE_TIMING_AUTH_HEADER)
+            )
+            if error is None and auth_header is not None:
+                await self._async_save_auth_header(auth_header)
+                return self.async_create_entry(title="", data={})
+            errors[CONF_LIVE_TIMING_AUTH_HEADER] = error or "invalid_auth_header"
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_LIVE_TIMING_AUTH_HEADER): _AUTH_HEADER_SELECTOR,
+                    vol.Optional(
+                        CONF_CLEAR_LIVE_TIMING_AUTH_HEADER,
+                        default=False,
+                    ): cv.boolean,
+                }
+            ),
+            errors=errors,
+            description_placeholders={"name": self._entry.title or "F1"},
+        )
+
+    async def _async_save_auth_header(self, auth_header: str) -> None:
+        data = dict(self._entry.data)
+        data[CONF_LIVE_TIMING_AUTH_HEADER] = auth_header
+        self.hass.config_entries.async_update_entry(self._entry, data=data)
+        async_update_f1tv_auth_repair_issue(
+            self.hass,
+            self._entry,
+            evaluate_f1tv_auth_header(auth_header),
+        )
+        await self.hass.config_entries.async_reload(self._entry.entry_id)
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create a repair flow."""
+    if data and (entry_id := data.get("entry_id")):
+        entry = hass.config_entries.async_get_entry(str(entry_id))
+        if entry is not None and issue_id == f1tv_auth_repair_issue_id(entry.entry_id):
+            return F1TvTokenRepairFlow(entry)
+    return ConfirmRepairFlow()

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -41,6 +41,7 @@ from .entity import (
     F1AuxEntity,
     F1BaseEntity,
     default_object_id,
+    is_auth_gated_stream_active,
     is_replay_only_stream_active,
     set_suggested_object_id,
 )
@@ -592,9 +593,7 @@ class _CoordinatorStreamSensorBase(F1BaseEntity, SensorEntity):
         raise NotImplementedError
 
 
-class _ChampionshipPredictionBase(
-    _ReplayOnlyStreamMixin, F1BaseEntity, RestoreEntity, SensorEntity
-):
+class _ChampionshipPredictionBase(F1BaseEntity, RestoreEntity, SensorEntity):
     """Base for championship prediction sensors with shared restore logic."""
 
     _device_category = "championship"
@@ -631,6 +630,13 @@ class _ChampionshipPredictionBase(
     def _extract_current(self) -> dict | None:
         data = self.coordinator.data
         return data if isinstance(data, dict) else None
+
+    def _is_stream_active(self) -> bool:
+        hass = getattr(self, "hass", None)
+        entry_id = getattr(self, "_entry_id", None)
+        return is_replay_only_stream_active(hass, entry_id) or (
+            is_auth_gated_stream_active(hass, entry_id, "ChampionshipPrediction")
+        )
 
     def _handle_coordinator_update(self) -> None:
         payload = self._extract_current()

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -25,6 +25,13 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 
+from .auth import (
+    AUTH_RUNTIME_STATUS,
+    AUTH_STATUS_OPTIONS,
+    F1TvAuthStatus,
+    async_add_f1tv_auth_status_listener,
+    is_auth_health_visible,
+)
 from .const import (
     CONF_OPERATION_MODE,
     DEFAULT_OPERATION_MODE,
@@ -331,6 +338,18 @@ async def async_setup_entry(
             set_suggested_object_id(sensor, default_object_id(key))
             sensors.append(sensor)
 
+    auth_status = data.get(AUTH_RUNTIME_STATUS)
+    if isinstance(auth_status, F1TvAuthStatus) and is_auth_health_visible(auth_status):
+        status_sensor = F1TvTokenStatusSensor(hass, entry.entry_id, base)
+        set_suggested_object_id(status_sensor, default_object_id("f1tv_token_status"))
+        sensors.append(status_sensor)
+
+        expires_sensor = F1TvTokenExpiresAtSensor(hass, entry.entry_id, base)
+        set_suggested_object_id(
+            expires_sensor, default_object_id("f1tv_token_expires_at")
+        )
+        sensors.append(expires_sensor)
+
     # Replay status sensor
     replay_controller = data.get("replay_controller")
     if replay_controller is not None:
@@ -346,6 +365,83 @@ async def async_setup_entry(
     async_add_entities(sensors, True)
 
 
+class _F1TvTokenSensorBase(F1AuxEntity, SensorEntity):
+    """Base for redacted F1TV token health sensors."""
+
+    _device_category = "system"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, hass: HomeAssistant, entry_id: str, device_name: str) -> None:
+        super().__init__(
+            unique_id=f"{entry_id}_{self._attr_translation_key}",
+            entry_id=entry_id,
+            device_name=device_name,
+        )
+        self.hass = hass
+        self._entry_id = entry_id
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_add_f1tv_auth_status_listener(
+                self.hass,
+                self._entry_id,
+                lambda *_: self._safe_write_ha_state(),
+            )
+        )
+
+    def _status(self) -> F1TvAuthStatus | None:
+        data = self.hass.data.get(DOMAIN, {}).get(self._entry_id, {}) or {}
+        status = data.get(AUTH_RUNTIME_STATUS)
+        return status if isinstance(status, F1TvAuthStatus) else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object | None]:
+        status = self._status()
+        if status is None:
+            return {
+                "auth_configured": False,
+                "used_for_live_timing": False,
+                "expires_at": None,
+                "reason": None,
+            }
+        return {
+            "auth_configured": status.configured,
+            "used_for_live_timing": status.used_for_live_timing,
+            "expires_at": status.expires_at_iso,
+            "reason": status.reason,
+        }
+
+
+class F1TvTokenStatusSensor(_F1TvTokenSensorBase):
+    """Diagnostic sensor exposing redacted F1TV token status."""
+
+    _attr_translation_key = "f1tv_token_status"
+    _attr_icon = "mdi:key-alert"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = list(AUTH_STATUS_OPTIONS)
+
+    @property
+    def native_value(self) -> str:
+        status = self._status()
+        return status.status if status is not None else "not_configured"
+
+
+class F1TvTokenExpiresAtSensor(_F1TvTokenSensorBase):
+    """Diagnostic timestamp for the saved F1TV token expiry."""
+
+    _attr_translation_key = "f1tv_token_expires_at"
+    _attr_icon = "mdi:calendar-clock"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    @property
+    def native_value(self) -> datetime.datetime | None:
+        status = self._status()
+        if status is None:
+            return None
+        return status.expires_at
+
+
 class F1LiveTimingModeSensor(F1AuxEntity, SensorEntity):
     """Diagnostic mode sensor for the live timing transport (idle/live/replay)."""
 
@@ -356,12 +452,14 @@ class F1LiveTimingModeSensor(F1AuxEntity, SensorEntity):
     _attr_options = ["idle", "live", "replay"]
 
     _attr_translation_key = "live_timing_mode"
-    _tracked_streams = (
+    _fallback_tracked_streams = (
         "SessionStatus",
         "TrackStatus",
         "TopThree",
         "TimingAppData",
         "ChampionshipPrediction",
+        "DriverRaceInfo",
+        "CarData.z",
     )
 
     def __init__(self, hass: HomeAssistant, entry_id: str, device_name: str) -> None:
@@ -374,6 +472,27 @@ class F1LiveTimingModeSensor(F1AuxEntity, SensorEntity):
         self.hass = hass
         self._entry_id = entry_id
         self._unsub_live_state = None
+
+    @staticmethod
+    def _stream_names(value: object) -> tuple[str, ...]:
+        if not isinstance(value, (set, frozenset, tuple, list)):
+            return ()
+        streams: list[str] = []
+        for stream in value:
+            if stream is None:
+                continue
+            name = str(stream).strip()
+            if name:
+                streams.append(name)
+        return tuple(sorted(streams))
+
+    def _diagnostic_streams(self, reg: dict) -> tuple[str, ...]:
+        capabilities = reg.get("signalr_stream_capabilities")
+        if isinstance(capabilities, dict):
+            active_streams = self._stream_names(capabilities.get("active_live_streams"))
+            if active_streams:
+                return active_streams
+        return self._fallback_tracked_streams
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -438,18 +557,19 @@ class F1LiveTimingModeSensor(F1AuxEntity, SensorEntity):
         except Exception:
             hb_age = activity_age = None
 
+        diagnostic_streams = self._diagnostic_streams(reg)
         stream_diagnostics = {
             stream: {
                 "frame_count": 0,
                 "last_seen_age_s": None,
                 "last_payload_keys": None,
             }
-            for stream in self._tracked_streams
+            for stream in diagnostic_streams
         }
         try:
             if live_bus is not None and hasattr(live_bus, "stream_diagnostics"):
                 stream_diagnostics.update(
-                    live_bus.stream_diagnostics(self._tracked_streams)
+                    live_bus.stream_diagnostics(diagnostic_streams)
                 )
         except Exception:
             stream_diagnostics = {
@@ -458,7 +578,7 @@ class F1LiveTimingModeSensor(F1AuxEntity, SensorEntity):
                     "last_seen_age_s": None,
                     "last_payload_keys": None,
                 }
-                for stream in self._tracked_streams
+                for stream in diagnostic_streams
             }
 
         attrs = {

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -95,10 +95,15 @@ WMO_CODE_TO_MDI = {
 }
 
 
-class _ReplayOnlyStreamMixin:
+class _ReplayOrAuthGatedStreamMixin:
+    _auth_gated_stream: str | None = None
+
     def _is_stream_active(self) -> bool:
-        return is_replay_only_stream_active(
-            getattr(self, "hass", None), getattr(self, "_entry_id", None)
+        hass = getattr(self, "hass", None)
+        entry_id = getattr(self, "_entry_id", None)
+        return is_replay_only_stream_active(hass, entry_id) or (
+            self._auth_gated_stream is not None
+            and is_auth_gated_stream_active(hass, entry_id, self._auth_gated_stream)
         )
 
 
@@ -4842,7 +4847,7 @@ class F1InvestigationsSensor(F1BaseEntity, RestoreEntity, SensorEntity):
 
 
 class F1TeamRadioSensor(
-    _ReplayOnlyStreamMixin, F1BaseEntity, RestoreEntity, SensorEntity
+    _ReplayOrAuthGatedStreamMixin, F1BaseEntity, RestoreEntity, SensorEntity
 ):
     """Sensor exposing the latest Team Radio clip.
 
@@ -4854,6 +4859,7 @@ class F1TeamRadioSensor(
     _history_limit = 20
 
     _attr_translation_key = "team_radio"
+    _auth_gated_stream = "TeamRadio"
 
     def __init__(self, coordinator, unique_id, entry_id, device_name):
         super().__init__(coordinator, unique_id, entry_id, device_name)
@@ -5038,7 +5044,7 @@ class F1TeamRadioSensor(
 
 
 class F1PitStopsSensor(
-    _ReplayOnlyStreamMixin, F1BaseEntity, RestoreEntity, SensorEntity
+    _ReplayOrAuthGatedStreamMixin, F1BaseEntity, RestoreEntity, SensorEntity
 ):
     """Live pit stops for all cars (aggregated).
 
@@ -5050,6 +5056,7 @@ class F1PitStopsSensor(
     _unrecorded_attributes = frozenset({"cars"})
 
     _attr_translation_key = "pitstops"
+    _auth_gated_stream = "PitStopSeries"
 
     def __init__(self, coordinator, unique_id, entry_id, device_name):
         super().__init__(coordinator, unique_id, entry_id, device_name)

--- a/custom_components/f1_sensor/signalr.py
+++ b/custom_components/f1_sensor/signalr.py
@@ -12,6 +12,8 @@ from typing import Any, Protocol
 from aiohttp import ClientResponseError, ClientSession, WSMsgType
 from homeassistant.core import HomeAssistant
 
+from .helpers import normalize_live_timing_auth_header
+
 _LOGGER = logging.getLogger(__name__)
 
 StreamPayload = Any
@@ -47,7 +49,6 @@ PUBLIC_LIVE_STREAMS = (
 AUTH_GATED_LIVE_STREAMS = (
     "CarData.z",
     "DriverRaceInfo",
-    "Position.z",
     "ChampionshipPrediction",
 )
 
@@ -104,7 +105,7 @@ class SignalRAuthenticationError(Exception):
 
 
 def _normalize_auth_header(auth_header: str | None) -> str | None:
-    value = str(auth_header or "").strip()
+    value = normalize_live_timing_auth_header(auth_header)
     return value or None
 
 

--- a/custom_components/f1_sensor/signalr.py
+++ b/custom_components/f1_sensor/signalr.py
@@ -9,7 +9,7 @@ import logging
 import time
 from typing import Any, Protocol
 
-from aiohttp import ClientSession, WSMsgType
+from aiohttp import ClientResponseError, ClientSession, WSMsgType
 from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,6 +56,8 @@ REPLAY_ONLY_STREAMS = (
     "PitStopSeries",
 )
 
+AUTH_FAILURE_STATUSES = frozenset({401, 403})
+
 
 def build_live_subscribe_streams(
     *, include_auth_gated: bool = False
@@ -67,14 +69,21 @@ def build_live_subscribe_streams(
     return tuple(streams)
 
 
+def build_subscribe_message(*, include_auth_gated: bool = False) -> dict[str, Any]:
+    """Return a SignalR legacy subscribe message for the selected capability set."""
+    return {
+        "H": "Streaming",
+        "M": "Subscribe",
+        "A": [
+            list(build_live_subscribe_streams(include_auth_gated=include_auth_gated))
+        ],
+        "I": 1,
+    }
+
+
 NO_AUTH_LIVE_STREAMS = build_live_subscribe_streams()
 
-SUBSCRIBE_MSG = {
-    "H": "Streaming",
-    "M": "Subscribe",
-    "A": [list(NO_AUTH_LIVE_STREAMS)],
-    "I": 1,
-}
+SUBSCRIBE_MSG = build_subscribe_message()
 
 DEBUG_SUMMARY_STREAMS = (
     "SessionStatus",
@@ -90,12 +99,69 @@ class LiveTransport(Protocol):
     async def close(self) -> None: ...
 
 
+class SignalRAuthenticationError(Exception):
+    """Raised when F1 Live Timing rejects the configured authorization."""
+
+
+def _normalize_auth_header(auth_header: str | None) -> str | None:
+    value = str(auth_header or "").strip()
+    return value or None
+
+
+def _authorization_headers(auth_header: str | None) -> dict[str, str]:
+    if not auth_header:
+        return {}
+    return {"Authorization": auth_header}
+
+
+def _is_authentication_error(err: Exception) -> bool:
+    if isinstance(err, ClientResponseError):
+        return err.status in AUTH_FAILURE_STATUSES
+    text = str(err).lower()
+    return any(
+        marker in text
+        for marker in (
+            "401",
+            "403",
+            "unauthorized",
+            "forbidden",
+            "auth",
+            "credential",
+        )
+    )
+
+
+def _is_authentication_close_error(error: object) -> bool:
+    text = str(error or "").lower()
+    return any(
+        marker in text
+        for marker in (
+            "401",
+            "403",
+            "unauthorized",
+            "forbidden",
+            "auth",
+            "credential",
+        )
+    )
+
+
 class SignalRLegacyClient:
     """Minimal legacy SignalR client for Formula 1 live timing."""
 
-    def __init__(self, hass: HomeAssistant, session: ClientSession) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        session: ClientSession,
+        *,
+        auth_header: str | None = None,
+    ) -> None:
         self._hass = hass
         self._session = session
+        self._auth_header = _normalize_auth_header(auth_header)
+        self._subscribe_msg = build_subscribe_message(
+            include_auth_gated=self._auth_header is not None
+        )
         self._ws = None
         self._t0 = dt.datetime.now(dt.UTC)
         self._startup_cutoff = None
@@ -104,7 +170,11 @@ class SignalRLegacyClient:
     async def connect(self) -> None:
         _LOGGER.debug("Connecting to F1 SignalR service")
         params = {"clientProtocol": "1.5", "connectionData": HUB_DATA}
-        async with self._session.get(NEGOTIATE_URL, params=params) as resp:
+        async with self._session.get(
+            NEGOTIATE_URL,
+            params=params,
+            headers=_authorization_headers(self._auth_header),
+        ) as resp:
             resp.raise_for_status()
             data = await resp.json()
             token = data.get("ConnectionToken")
@@ -116,6 +186,7 @@ class SignalRLegacyClient:
         }
         if cookie:
             headers["Cookie"] = cookie
+        headers.update(_authorization_headers(self._auth_header))
 
         params = {
             "transport": "webSockets",
@@ -126,7 +197,7 @@ class SignalRLegacyClient:
         self._ws = await self._session.ws_connect(
             CONNECT_URL, params=params, headers=headers
         )
-        await self._ws.send_json(SUBSCRIBE_MSG)
+        await self._ws.send_json(self._subscribe_msg)
         # Renew the subscription every 5 minutes so Azure SignalR
         # inte stänger grupp‑anslutningen (20 min timeout).
         if self._heartbeat_task is None or self._heartbeat_task.done():
@@ -136,7 +207,7 @@ class SignalRLegacyClient:
         _LOGGER.debug("SignalR connection established")
         _LOGGER.debug(
             "Subscribed to %s",
-            ", ".join(SUBSCRIBE_MSG["A"][0]),
+            ", ".join(self._subscribe_msg["A"][0]),
         )
 
     async def ensure_connection(self) -> None:
@@ -150,7 +221,13 @@ class SignalRLegacyClient:
             try:
                 await self.connect()
                 return
+            except SignalRAuthenticationError:
+                raise
             except Exception as err:  # noqa: BLE001
+                if self._auth_header and _is_authentication_error(err):
+                    raise SignalRAuthenticationError(
+                        "F1 SignalR authorization was rejected"
+                    ) from err
                 _LOGGER.warning(
                     "SignalR reconnect failed (%s). Retrying in %s s …", err, delay
                 )
@@ -170,6 +247,14 @@ class SignalRLegacyClient:
                     payload = None
                 if payload is None:
                     continue
+                if (
+                    isinstance(payload, dict)
+                    and isinstance(payload.get("E"), str)
+                    and _is_authentication_close_error(payload.get("E"))
+                ):
+                    raise SignalRAuthenticationError(
+                        "F1 SignalR authorization was rejected"
+                    )
                 # Per-message payload logging suppressed to reduce verbosity
 
                 if "M" in payload:
@@ -196,7 +281,7 @@ class SignalRLegacyClient:
                 if self._ws is None or self._ws.closed:
                     break
                 try:
-                    await self._ws.send_json(SUBSCRIBE_MSG)
+                    await self._ws.send_json(self._subscribe_msg)
                     _LOGGER.debug("Heartbeat: subscriptions renewed")
                 except Exception as exc:  # pylint: disable=broad-except
                     _LOGGER.warning("Heartbeat failed: %s", exc)
@@ -221,9 +306,19 @@ class SignalRCoreClient:
     into legacy-format dicts so LiveBus._run() needs no changes.
     """
 
-    def __init__(self, hass: HomeAssistant, session: ClientSession) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        session: ClientSession,
+        *,
+        auth_header: str | None = None,
+    ) -> None:
         self._hass = hass
         self._session = session
+        self._auth_header = _normalize_auth_header(auth_header)
+        self._subscribe_msg = build_subscribe_message(
+            include_auth_gated=self._auth_header is not None
+        )
         self._ws = None
         self._cookie: str | None = None
 
@@ -234,7 +329,9 @@ class SignalRCoreClient:
         # Step 1: OPTIONS to obtain AWSALBCORS load-balancer cookie
         try:
             async with self._session.options(
-                CORE_NEGOTIATE_URL, params=negotiate_params
+                CORE_NEGOTIATE_URL,
+                params=negotiate_params,
+                headers=_authorization_headers(self._auth_header),
             ) as resp:
                 cookie_header = resp.headers.get("Set-Cookie", "")
                 for part in cookie_header.split(","):
@@ -246,7 +343,7 @@ class SignalRCoreClient:
             _LOGGER.debug("OPTIONS request failed, continuing without cookie")
 
         # Step 2: POST negotiate to obtain connectionToken
-        headers = {}
+        headers = _authorization_headers(self._auth_header)
         if self._cookie:
             headers["Cookie"] = f"AWSALBCORS={self._cookie}"
         async with self._session.post(
@@ -257,7 +354,7 @@ class SignalRCoreClient:
             token = data.get("connectionToken") or data.get("ConnectionToken", "")
 
         # Step 3: WebSocket connect
-        ws_headers = {}
+        ws_headers = _authorization_headers(self._auth_header)
         if self._cookie:
             ws_headers["Cookie"] = f"AWSALBCORS={self._cookie}"
         self._ws = await self._session.ws_connect(
@@ -274,6 +371,12 @@ class SignalRCoreClient:
             if hs_data:
                 hs_json = json.loads(hs_data)
                 if "error" in hs_json:
+                    if self._auth_header and _is_authentication_close_error(
+                        hs_json["error"]
+                    ):
+                        raise SignalRAuthenticationError(
+                            "F1 SignalR Core authorization was rejected"
+                        )
                     raise ConnectionError(
                         f"SignalR Core handshake error: {hs_json['error']}"
                     )
@@ -284,7 +387,7 @@ class SignalRCoreClient:
         subscribe = {
             "type": 1,
             "target": "Subscribe",
-            "arguments": SUBSCRIBE_MSG["A"],
+            "arguments": self._subscribe_msg["A"],
             "invocationId": "0",
         }
         await self._ws.send_str(json.dumps(subscribe) + RECORD_SEP)
@@ -300,7 +403,13 @@ class SignalRCoreClient:
             try:
                 await self.connect()
                 return
+            except SignalRAuthenticationError:
+                raise
             except Exception as err:  # noqa: BLE001
+                if self._auth_header and _is_authentication_error(err):
+                    raise SignalRAuthenticationError(
+                        "F1 SignalR Core authorization was rejected"
+                    ) from err
                 _LOGGER.warning(
                     "SignalR Core reconnect failed (%s). Retrying in %s s …",
                     err,
@@ -344,6 +453,10 @@ class SignalRCoreClient:
                     elif msg_type == 7:
                         # Close
                         error = payload.get("error", "")
+                        if self._auth_header and _is_authentication_close_error(error):
+                            raise SignalRAuthenticationError(
+                                "F1 SignalR Core authorization was rejected"
+                            )
                         _LOGGER.warning(
                             "SignalR Core server closed connection: %s", error
                         )
@@ -369,10 +482,16 @@ class LiveBus:
         session: ClientSession,
         *,
         transport_factory: Callable[[], LiveTransport] | None = None,
+        auth_header: str | None = None,
+        auth_failed_callback: Callable[[], None] | None = None,
     ) -> None:
         self._hass = hass
         self._session = session
         self._transport_factory = transport_factory
+        self._auth_header = _normalize_auth_header(auth_header)
+        self._auth_enabled = self._auth_header is not None
+        self._auth_failed_callback = auth_failed_callback
+        self._auth_failed_reported = False
         self._client: LiveTransport | None = None
         self._task: asyncio.Task | None = None
         self._subs: dict[str, list[Callable[[StreamPayload], None]]] = {}
@@ -391,6 +510,11 @@ class LiveBus:
         self._heartbeat_guard: asyncio.Task | None = None
         self._heartbeat_timeout = 45.0
         self._heartbeat_check_interval = 5.0
+
+    @property
+    def auth_enabled(self) -> bool:
+        """Return whether the live connection is currently using auth."""
+        return self._auth_enabled
 
     def subscribe(
         self, stream: str, callback: Callable[[StreamPayload], None]
@@ -477,6 +601,22 @@ class LiveBus:
                                         # Dispatch if there are subscribers now
                                         if key in self._subs:
                                             self._dispatch(key, value)
+                except SignalRAuthenticationError:
+                    if self._auth_enabled:
+                        self._auth_enabled = False
+                        _LOGGER.warning(
+                            "Live timing authorization was rejected; falling back to public live timing"
+                        )
+                        if (
+                            self._auth_failed_callback is not None
+                            and not self._auth_failed_reported
+                        ):
+                            self._auth_failed_reported = True
+                            self._auth_failed_callback()
+                        continue
+                    _LOGGER.warning("LiveBus authorization error")
+                    if self._running:
+                        await asyncio.sleep(2)
                 except Exception as err:  # pragma: no cover - network errors
                     # Log replay-related errors at DEBUG since they're expected during replay stop
                     err_str = str(err)
@@ -579,8 +719,16 @@ class LiveBus:
         from .const import SIGNALR_USE_CORE
 
         if SIGNALR_USE_CORE:
-            return SignalRCoreClient(self._hass, self._session)
-        return SignalRLegacyClient(self._hass, self._session)
+            return SignalRCoreClient(
+                self._hass,
+                self._session,
+                auth_header=self._auth_header if self._auth_enabled else None,
+            )
+        return SignalRLegacyClient(
+            self._hass,
+            self._session,
+            auth_header=self._auth_header if self._auth_enabled else None,
+        )
 
     async def _monitor_heartbeat(self) -> None:
         with suppress(asyncio.CancelledError):

--- a/custom_components/f1_sensor/signalr.py
+++ b/custom_components/f1_sensor/signalr.py
@@ -26,10 +26,9 @@ CORE_NEGOTIATE_URL = "https://livetiming.formula1.com/signalrcore/negotiate"
 CORE_CONNECT_URL = "wss://livetiming.formula1.com/signalrcore"
 RECORD_SEP = "\x1e"
 
-# Capability matrix for the current no-auth SignalR Core implementation.
-# Public live streams are subscribed during normal live sessions.
-# Auth-gated and replay-only streams stay defined here so future auth support
-# can extend the runtime contract without changing entity registration.
+# Capability matrix for the current SignalR live implementation.
+# Public live streams are always subscribed during live sessions. Auth-gated
+# streams are added only when Live Timing authentication is configured.
 PUBLIC_LIVE_STREAMS = (
     "RaceControlMessages",
     "TrackStatus",
@@ -50,12 +49,11 @@ AUTH_GATED_LIVE_STREAMS = (
     "CarData.z",
     "DriverRaceInfo",
     "ChampionshipPrediction",
-)
-
-REPLAY_ONLY_STREAMS = (
     "TeamRadio",
     "PitStopSeries",
 )
+
+REPLAY_ONLY_STREAMS: tuple[str, ...] = ()
 
 AUTH_FAILURE_STATUSES = frozenset({401, 403})
 

--- a/custom_components/f1_sensor/tests/fixtures/f1_track_status.yaml
+++ b/custom_components/f1_sensor/tests/fixtures/f1_track_status.yaml
@@ -807,12 +807,6 @@ variables:
   pre_alert_scene_id: "{{ automation_slug ~ '_pre_alert' }}"
 
   track_state: "{{ states(track_status_entity) | upper }}"
-  defer_wled_clear_restore: >-
-    {{
-      track_state == 'CLEAR'
-      and (snapshot_before_alert_enabled | bool)
-      and clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay']
-    }}
   session_phase: "{{ states(session_status_entity) | lower }}"
   notification_title: "F1 Track Status"
   notification_track_state: "{{ track_state }}"
@@ -887,6 +881,26 @@ variables:
     {% else %}
       {{ (session_scope_now_ok | bool) and trigger_to_phase in valid_session_phases and trigger_from_phase not in active_phases and trigger_to_phase in active_phases }}
     {% endif %}
+
+  clear_restore_scene_entity: >-
+    {% if session_entered_active | bool %}
+      {% if snapshot_pre_race_enabled | bool %}
+        {{ 'scene.' ~ pre_race_scene_id }}
+      {% else %}
+        {{ '' }}
+      {% endif %}
+    {% elif snapshot_before_alert_enabled | bool %}
+      {{ 'scene.' ~ pre_alert_scene_id }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
+  clear_restore_scene_available: "{{ clear_restore_scene_entity | string | trim | length > 0 }}"
+  defer_wled_clear_restore: >-
+    {{
+      track_state == 'CLEAR'
+      and (clear_restore_scene_available | bool)
+      and clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay']
+    }}
 
   session_left_active: >
     {% if trigger.id != 'session_leave_active' %}
@@ -1141,7 +1155,7 @@ actions:
                       - choose:
                           - conditions:
                               - condition: template
-                                value_template: "{{ clear_behavior_mode_input == 'steady' or (clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay'] and not snapshot_before_alert_enabled) }}"
+                                value_template: "{{ clear_behavior_mode_input == 'steady' or (clear_behavior_mode_input in ['restore_immediately', 'restore_after_delay'] and not (clear_restore_scene_available | bool)) }}"
                             sequence:
                               - choose:
                                   - conditions:
@@ -1167,16 +1181,16 @@ actions:
 
                           - conditions:
                               - condition: template
-                                value_template: "{{ clear_behavior_mode_input == 'restore_immediately' and snapshot_before_alert_enabled }}"
+                                value_template: "{{ clear_behavior_mode_input == 'restore_immediately' and (clear_restore_scene_available | bool) }}"
                             sequence:
                               - continue_on_error: true
                                 action: scene.turn_on
                                 data:
-                                  entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                                  entity_id: "{{ clear_restore_scene_entity | string | trim }}"
 
                           - conditions:
                               - condition: template
-                                value_template: "{{ clear_behavior_mode_input == 'restore_after_delay' and snapshot_before_alert_enabled }}"
+                                value_template: "{{ clear_behavior_mode_input == 'restore_after_delay' and (clear_restore_scene_available | bool) }}"
                             sequence:
                               - choose:
                                   - conditions:
@@ -1223,7 +1237,7 @@ actions:
                               - continue_on_error: true
                                 action: scene.turn_on
                                 data:
-                                  entity_id: "{{ 'scene.' ~ pre_alert_scene_id }}"
+                                  entity_id: "{{ clear_restore_scene_entity | string | trim }}"
 
                   - conditions:
                       - condition: template

--- a/custom_components/f1_sensor/tests/test_auth.py
+++ b/custom_components/f1_sensor/tests/test_auth.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime, timedelta
+import json
+
+import pytest
+
+from custom_components.f1_sensor.auth import (
+    evaluate_f1tv_auth_header,
+    validate_replacement_auth_header,
+)
+
+
+def _part(value: dict) -> str:
+    raw = json.dumps(value, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _jwt(payload: dict) -> str:
+    return ".".join(
+        (
+            _part({"alg": "RS256", "typ": "JWT"}),
+            _part(payload),
+            "signature",
+        )
+    )
+
+
+def test_evaluate_f1tv_auth_header_accepts_authorization_prefix() -> None:
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+    token = _jwt({"exp": int((now + timedelta(days=2)).timestamp())})
+
+    status = evaluate_f1tv_auth_header(f" Authorization: Bearer {token} ", now=now)
+
+    assert status.status == "valid"
+    assert status.configured is True
+    assert status.header == f"Bearer {token}"
+    assert status.expires_at == now + timedelta(days=2)
+    assert status.as_safe_dict() == {
+        "status": "valid",
+        "configured": True,
+        "expires_at": "2026-05-03T00:00:00+00:00",
+        "reason": None,
+        "used_for_live_timing": False,
+    }
+
+
+def test_evaluate_f1tv_auth_header_marks_expiring_soon() -> None:
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+    token = _jwt({"exp": int((now + timedelta(hours=23)).timestamp())})
+
+    status = evaluate_f1tv_auth_header(f"Bearer {token}", now=now)
+
+    assert status.status == "expiring_soon"
+    assert status.reason == "expiring_soon"
+
+
+def test_evaluate_f1tv_auth_header_marks_expired() -> None:
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+    token = _jwt({"exp": int((now - timedelta(seconds=1)).timestamp())})
+
+    status = evaluate_f1tv_auth_header(f"Bearer {token}", now=now)
+
+    assert status.status == "expired"
+    assert status.reason == "expired"
+
+
+@pytest.mark.parametrize(
+    ("value", "reason"),
+    [
+        ("Bearer not-a-jwt", "malformed_jwt"),
+        ("raw-token", "missing_bearer_scheme"),
+    ],
+)
+def test_evaluate_f1tv_auth_header_marks_malformed_values_invalid(
+    value: str, reason: str
+) -> None:
+    status = evaluate_f1tv_auth_header(value)
+
+    assert status.status == "invalid"
+    assert status.configured is True
+    assert reason in status.reason
+
+
+def test_evaluate_f1tv_auth_header_requires_exp() -> None:
+    status = evaluate_f1tv_auth_header(f"Bearer {_jwt({'iat': 1})}")
+
+    assert status.status == "invalid"
+    assert status.reason == "missing_exp"
+
+
+def test_validate_replacement_auth_header_rejects_near_expiry_token() -> None:
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+    token = _jwt({"exp": int((now + timedelta(minutes=9)).timestamp())})
+
+    header, error, status = validate_replacement_auth_header(f"Bearer {token}", now=now)
+
+    assert header is None
+    assert error == "auth_token_expiring_soon"
+    assert status.status == "expiring_soon"
+
+
+def test_validate_replacement_auth_header_accepts_usable_token() -> None:
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+    token = _jwt({"exp": int((now + timedelta(hours=1)).timestamp())})
+
+    header, error, status = validate_replacement_auth_header(
+        f"Authorization: Bearer {token}", now=now
+    )
+
+    assert header == f"Bearer {token}"
+    assert error is None
+    assert status.status == "expiring_soon"

--- a/custom_components/f1_sensor/tests/test_auth_repairs.py
+++ b/custom_components/f1_sensor/tests/test_auth_repairs.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime, timedelta
+import json
+from unittest.mock import AsyncMock
+
+from homeassistant.helpers import issue_registry as ir
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.f1_sensor import repairs
+from custom_components.f1_sensor.auth import (
+    async_update_f1tv_auth_repair_issue,
+    evaluate_f1tv_auth_header,
+    f1tv_auth_repair_issue_id,
+)
+from custom_components.f1_sensor.const import (
+    CONF_CLEAR_LIVE_TIMING_AUTH_HEADER,
+    CONF_LIVE_TIMING_AUTH_HEADER,
+    DOMAIN,
+)
+
+
+def _part(value: dict) -> str:
+    raw = json.dumps(value, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _jwt(exp: datetime) -> str:
+    return ".".join(
+        (
+            _part({"alg": "RS256", "typ": "JWT"}),
+            _part({"exp": int(exp.timestamp())}),
+            "signature",
+        )
+    )
+
+
+async def test_repair_flow_replaces_expired_token(hass) -> None:
+    old_token = _jwt(datetime.now(UTC) - timedelta(hours=1))
+    new_token = _jwt(datetime.now(UTC) + timedelta(days=2))
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="F1",
+        data={CONF_LIVE_TIMING_AUTH_HEADER: f"Bearer {old_token}"},
+    )
+    entry.add_to_hass(hass)
+    status = evaluate_f1tv_auth_header(entry.data[CONF_LIVE_TIMING_AUTH_HEADER])
+    async_update_f1tv_auth_repair_issue(hass, entry, status)
+    hass.config_entries.async_reload = AsyncMock(return_value=True)
+
+    flow = await repairs.async_create_fix_flow(
+        hass,
+        f1tv_auth_repair_issue_id(entry.entry_id),
+        {"entry_id": entry.entry_id},
+    )
+    flow.hass = hass
+
+    result = await flow.async_step_confirm(
+        {CONF_LIVE_TIMING_AUTH_HEADER: f"Authorization: Bearer {new_token}"}
+    )
+
+    assert result["type"] == "create_entry"
+    assert entry.data[CONF_LIVE_TIMING_AUTH_HEADER] == f"Bearer {new_token}"
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    assert (
+        ir.async_get(hass).async_get_issue(
+            DOMAIN, f1tv_auth_repair_issue_id(entry.entry_id)
+        )
+        is None
+    )
+
+
+async def test_repair_flow_can_clear_token(hass) -> None:
+    old_token = _jwt(datetime.now(UTC) - timedelta(hours=1))
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="F1",
+        data={CONF_LIVE_TIMING_AUTH_HEADER: f"Bearer {old_token}"},
+    )
+    entry.add_to_hass(hass)
+    async_update_f1tv_auth_repair_issue(
+        hass,
+        entry,
+        evaluate_f1tv_auth_header(entry.data[CONF_LIVE_TIMING_AUTH_HEADER]),
+    )
+    hass.config_entries.async_reload = AsyncMock(return_value=True)
+
+    flow = await repairs.async_create_fix_flow(
+        hass,
+        f1tv_auth_repair_issue_id(entry.entry_id),
+        {"entry_id": entry.entry_id},
+    )
+    flow.hass = hass
+
+    result = await flow.async_step_confirm(
+        {
+            CONF_LIVE_TIMING_AUTH_HEADER: "",
+            CONF_CLEAR_LIVE_TIMING_AUTH_HEADER: True,
+        }
+    )
+
+    assert result["type"] == "create_entry"
+    assert entry.data[CONF_LIVE_TIMING_AUTH_HEADER] == ""
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    assert (
+        ir.async_get(hass).async_get_issue(
+            DOMAIN, f1tv_auth_repair_issue_id(entry.entry_id)
+        )
+        is None
+    )
+
+
+async def test_repair_flow_rejects_invalid_replacement(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="F1",
+        data={CONF_LIVE_TIMING_AUTH_HEADER: "Bearer old.invalid.token"},
+    )
+    entry.add_to_hass(hass)
+    hass.config_entries.async_reload = AsyncMock(return_value=True)
+
+    flow = await repairs.async_create_fix_flow(
+        hass,
+        f1tv_auth_repair_issue_id(entry.entry_id),
+        {"entry_id": entry.entry_id},
+    )
+    flow.hass = hass
+
+    result = await flow.async_step_confirm(
+        {CONF_LIVE_TIMING_AUTH_HEADER: "Bearer not-a-jwt"}
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"][CONF_LIVE_TIMING_AUTH_HEADER] == "invalid_auth_header"
+    hass.config_entries.async_reload.assert_not_called()

--- a/custom_components/f1_sensor/tests/test_config_flow_entity_naming.py
+++ b/custom_components/f1_sensor/tests/test_config_flow_entity_naming.py
@@ -76,7 +76,7 @@ async def test_user_flow_stores_trimmed_live_timing_auth_header(
             "enabled_sensors": ["next_race"],
             "enable_race_control": False,
             CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
-            CONF_LIVE_TIMING_AUTH_HEADER: "  Bearer test-token  ",
+            CONF_LIVE_TIMING_AUTH_HEADER: "  Authorization: Bearer test-token  ",
         },
     )
 
@@ -213,11 +213,42 @@ async def test_reauth_updates_auth_header(hass, monkeypatch) -> None:
     flow.context = {"source": "reauth", "entry_id": entry.entry_id}
 
     result = await flow.async_step_reauth_confirm(
-        {CONF_LIVE_TIMING_AUTH_HEADER: "  Bearer new-token  "}
+        {CONF_LIVE_TIMING_AUTH_HEADER: "  Authorization: Bearer new-token  "}
     )
 
     assert result["type"] == "abort"
     assert entry.data[CONF_LIVE_TIMING_AUTH_HEADER] == "Bearer new-token"
+
+
+async def test_reauth_can_clear_auth_header(hass, monkeypatch) -> None:
+    monkeypatch.setattr(config_flow_module, "ENABLE_DEVELOPMENT_MODE_UI", True)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            CONF_OPERATION_MODE: DEFAULT_OPERATION_MODE,
+            CONF_REPLAY_FILE: "",
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer old-token",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = F1FlowHandler()
+    flow.hass = hass
+    flow.context = {"source": "reauth", "entry_id": entry.entry_id}
+
+    result = await flow.async_step_reauth_confirm(
+        {
+            CONF_LIVE_TIMING_AUTH_HEADER: "",
+            "clear_live_timing_auth_header": True,
+        }
+    )
+
+    assert result["type"] == "abort"
+    assert entry.data[CONF_LIVE_TIMING_AUTH_HEADER] == ""
 
 
 async def test_reauth_requires_auth_header(hass, monkeypatch) -> None:

--- a/custom_components/f1_sensor/tests/test_config_flow_entity_naming.py
+++ b/custom_components/f1_sensor/tests/test_config_flow_entity_naming.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
 
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.f1_sensor import config_flow as config_flow_module
 from custom_components.f1_sensor.config_flow import F1FlowHandler
 from custom_components.f1_sensor.const import (
     CONF_ENTITY_NAME_LANGUAGE,
     CONF_ENTITY_NAME_MODE,
+    CONF_LIVE_TIMING_AUTH_HEADER,
+    CONF_OPERATION_MODE,
     CONF_RACE_WEEK_START_DAY,
+    CONF_REPLAY_FILE,
+    DEFAULT_OPERATION_MODE,
+    DOMAIN,
     ENTITY_NAME_MODE_LOCALIZED,
     RACE_WEEK_START_MONDAY,
 )
+
+
+def _schema_key_names(result: dict) -> set[str]:
+    """Return the string field names from a config flow form schema."""
+    return {str(key.schema) for key in result["data_schema"].schema}
 
 
 async def test_user_flow_stores_entity_name_metadata(hass) -> None:
@@ -29,3 +42,228 @@ async def test_user_flow_stores_entity_name_metadata(hass) -> None:
     assert result["type"] == "create_entry"
     assert result["data"][CONF_ENTITY_NAME_MODE] == ENTITY_NAME_MODE_LOCALIZED
     assert result["data"][CONF_ENTITY_NAME_LANGUAGE] == "sv"
+
+
+async def test_user_flow_hides_auth_header_when_development_ui_disabled(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(config_flow_module, "ENABLE_DEVELOPMENT_MODE_UI", False)
+
+    flow = F1FlowHandler()
+    flow.hass = hass
+    flow.context = {"source": "user"}
+
+    result = await flow.async_step_user()
+
+    assert result["type"] == "form"
+    keys = _schema_key_names(result)
+    assert CONF_LIVE_TIMING_AUTH_HEADER not in keys
+    assert "clear_live_timing_auth_header" not in keys
+
+
+async def test_user_flow_stores_trimmed_live_timing_auth_header(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(config_flow_module, "ENABLE_DEVELOPMENT_MODE_UI", True)
+
+    flow = F1FlowHandler()
+    flow.hass = hass
+    flow.context = {"source": "user"}
+
+    result = await flow.async_step_user(
+        {
+            "sensor_name": "RaceHub",
+            "enabled_sensors": ["next_race"],
+            "enable_race_control": False,
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+            CONF_LIVE_TIMING_AUTH_HEADER: "  Bearer test-token  ",
+        },
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_LIVE_TIMING_AUTH_HEADER] == "Bearer test-token"
+
+
+async def test_reconfigure_hides_auth_header_when_development_ui_disabled(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(config_flow_module, "ENABLE_DEVELOPMENT_MODE_UI", False)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            "disabled_sensors": [],
+            CONF_OPERATION_MODE: DEFAULT_OPERATION_MODE,
+            CONF_REPLAY_FILE: "",
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer existing-token",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = F1FlowHandler()
+    flow.hass = hass
+    flow.context = {"source": "reconfigure", "entry_id": entry.entry_id}
+
+    result = await flow.async_step_reconfigure()
+
+    assert result["type"] == "form"
+    keys = _schema_key_names(result)
+    assert CONF_LIVE_TIMING_AUTH_HEADER not in keys
+    assert "clear_live_timing_auth_header" not in keys
+
+
+async def test_reconfigure_blank_auth_header_keeps_existing_value(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(config_flow_module, "ENABLE_DEVELOPMENT_MODE_UI", True)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            "disabled_sensors": [],
+            CONF_OPERATION_MODE: DEFAULT_OPERATION_MODE,
+            CONF_REPLAY_FILE: "",
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer existing-token",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = F1FlowHandler()
+    flow.hass = hass
+    flow.context = {"source": "reconfigure", "entry_id": entry.entry_id}
+
+    result = await flow.async_step_reconfigure(
+        {
+            "sensor_name": "F1",
+            "enabled_sensors": ["next_race"],
+            "enable_race_control": False,
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+            CONF_OPERATION_MODE: DEFAULT_OPERATION_MODE,
+            CONF_REPLAY_FILE: "",
+            CONF_LIVE_TIMING_AUTH_HEADER: "",
+            "clear_live_timing_auth_header": False,
+        },
+    )
+
+    assert result["type"] == "abort"
+    assert entry.data[CONF_LIVE_TIMING_AUTH_HEADER] == "Bearer existing-token"
+
+
+async def test_reconfigure_can_clear_auth_header(hass, monkeypatch) -> None:
+    monkeypatch.setattr(config_flow_module, "ENABLE_DEVELOPMENT_MODE_UI", True)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            "disabled_sensors": [],
+            CONF_OPERATION_MODE: DEFAULT_OPERATION_MODE,
+            CONF_REPLAY_FILE: "",
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer existing-token",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = F1FlowHandler()
+    flow.hass = hass
+    flow.context = {"source": "reconfigure", "entry_id": entry.entry_id}
+
+    result = await flow.async_step_reconfigure(
+        {
+            "sensor_name": "F1",
+            "enabled_sensors": ["next_race"],
+            "enable_race_control": False,
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+            CONF_OPERATION_MODE: DEFAULT_OPERATION_MODE,
+            CONF_REPLAY_FILE: "",
+            CONF_LIVE_TIMING_AUTH_HEADER: "",
+            "clear_live_timing_auth_header": True,
+        },
+    )
+
+    assert result["type"] == "abort"
+    assert entry.data[CONF_LIVE_TIMING_AUTH_HEADER] == ""
+
+
+async def test_reauth_updates_auth_header(hass, monkeypatch) -> None:
+    monkeypatch.setattr(config_flow_module, "ENABLE_DEVELOPMENT_MODE_UI", True)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            CONF_OPERATION_MODE: DEFAULT_OPERATION_MODE,
+            CONF_REPLAY_FILE: "",
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer old-token",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = F1FlowHandler()
+    flow.hass = hass
+    flow.context = {"source": "reauth", "entry_id": entry.entry_id}
+
+    result = await flow.async_step_reauth_confirm(
+        {CONF_LIVE_TIMING_AUTH_HEADER: "  Bearer new-token  "}
+    )
+
+    assert result["type"] == "abort"
+    assert entry.data[CONF_LIVE_TIMING_AUTH_HEADER] == "Bearer new-token"
+
+
+async def test_reauth_requires_auth_header(hass, monkeypatch) -> None:
+    monkeypatch.setattr(config_flow_module, "ENABLE_DEVELOPMENT_MODE_UI", True)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            CONF_OPERATION_MODE: DEFAULT_OPERATION_MODE,
+            CONF_REPLAY_FILE: "",
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = F1FlowHandler()
+    flow.hass = hass
+    flow.context = {"source": "reauth", "entry_id": entry.entry_id}
+
+    result = await flow.async_step_reauth_confirm({CONF_LIVE_TIMING_AUTH_HEADER: ""})
+
+    assert result["type"] == "form"
+    assert result["errors"][CONF_LIVE_TIMING_AUTH_HEADER] == "auth_header_required"
+
+
+async def test_reauth_is_hidden_when_development_ui_disabled(hass, monkeypatch) -> None:
+    monkeypatch.setattr(config_flow_module, "ENABLE_DEVELOPMENT_MODE_UI", False)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            CONF_OPERATION_MODE: DEFAULT_OPERATION_MODE,
+            CONF_REPLAY_FILE: "",
+            CONF_RACE_WEEK_START_DAY: RACE_WEEK_START_MONDAY,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = F1FlowHandler()
+    flow.hass = hass
+    flow.context = {"source": "reauth", "entry_id": entry.entry_id}
+
+    result = await flow.async_step_reauth()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_not_supported"

--- a/custom_components/f1_sensor/tests/test_diagnostics.py
+++ b/custom_components/f1_sensor/tests/test_diagnostics.py
@@ -1,0 +1,127 @@
+"""Diagnostics tests for F1 Sensor."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.f1_sensor import diagnostics as diagnostics_module
+from custom_components.f1_sensor.const import (
+    CONF_LIVE_TIMING_AUTH_HEADER,
+    CONF_OPERATION_MODE,
+    DOMAIN,
+    OPERATION_MODE_LIVE,
+)
+
+
+async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(diagnostics_module, "ENABLE_DEVELOPMENT_MODE_UI", True)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="F1",
+        data={
+            CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
+            CONF_LIVE_TIMING_AUTH_HEADER: "Authorization: Bearer secret-token",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    live_bus = MagicMock()
+    live_bus.last_heartbeat_age.return_value = 5.0
+    live_bus.last_stream_activity_age.return_value = 2.0
+    live_bus.stream_diagnostics.return_value = {
+        "ChampionshipPrediction": {
+            "frame_count": 3,
+            "last_seen_age_s": 1.0,
+            "last_payload_keys": ["Drivers", "Teams"],
+        }
+    }
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "operation_mode": OPERATION_MODE_LIVE,
+        "live_bus": live_bus,
+        "signalr_stream_capabilities": {
+            "public_live_streams": frozenset({"SessionStatus", "TrackStatus"}),
+            "auth_gated_live_streams": frozenset(
+                {"CarData.z", "ChampionshipPrediction"}
+            ),
+            "replay_only_streams": frozenset({"TeamRadio"}),
+            "active_live_streams": frozenset(
+                {"SessionStatus", "TrackStatus", "ChampionshipPrediction"}
+            ),
+            "auth_enabled": True,
+        },
+    }
+
+    payload = await diagnostics_module.async_get_config_entry_diagnostics(hass, entry)
+
+    assert payload["entry"]["data"][CONF_LIVE_TIMING_AUTH_HEADER] == "**REDACTED**"
+    assert payload["runtime"]["auth_configured"] is True
+    assert payload["runtime"]["auth_enabled"] is True
+    assert payload["runtime"]["signalr_stream_capabilities"] == {
+        "auth_enabled": True,
+        "public_live_streams": ["SessionStatus", "TrackStatus"],
+        "auth_gated_live_streams": ["CarData.z", "ChampionshipPrediction"],
+        "replay_only_streams": ["TeamRadio"],
+        "active_live_streams": [
+            "ChampionshipPrediction",
+            "SessionStatus",
+            "TrackStatus",
+        ],
+    }
+    assert payload["runtime"]["live_timing"]["heartbeat_age_s"] == 5.0
+    assert payload["runtime"]["live_timing"]["activity_age_s"] == 2.0
+    assert payload["runtime"]["live_timing"]["streams"]["ChampionshipPrediction"] == {
+        "frame_count": 3,
+        "last_seen_age_s": 1.0,
+        "last_payload_keys": ["Drivers", "Teams"],
+    }
+    assert "secret-token" not in str(payload)
+
+
+async def test_diagnostics_hides_auth_state_when_development_ui_disabled(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(diagnostics_module, "ENABLE_DEVELOPMENT_MODE_UI", False)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="F1",
+        data={
+            CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
+            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer secret-token",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "operation_mode": OPERATION_MODE_LIVE,
+        "signalr_stream_capabilities": {
+            "public_live_streams": frozenset({"SessionStatus", "TrackStatus"}),
+            "auth_gated_live_streams": frozenset(
+                {"CarData.z", "ChampionshipPrediction"}
+            ),
+            "replay_only_streams": frozenset({"TeamRadio"}),
+            "active_live_streams": frozenset(
+                {"SessionStatus", "ChampionshipPrediction"}
+            ),
+            "auth_enabled": True,
+        },
+    }
+
+    payload = await diagnostics_module.async_get_config_entry_diagnostics(hass, entry)
+
+    runtime = payload["runtime"]
+    capabilities = runtime["signalr_stream_capabilities"]
+    assert "auth_configured" not in runtime
+    assert "auth_enabled" not in runtime
+    assert "auth_enabled" not in capabilities
+    assert "auth_gated_live_streams" not in capabilities
+    assert capabilities == {
+        "public_live_streams": ["SessionStatus", "TrackStatus"],
+        "replay_only_streams": ["TeamRadio"],
+        "active_live_streams": ["SessionStatus"],
+    }
+    assert payload["entry"]["data"][CONF_LIVE_TIMING_AUTH_HEADER] == "**REDACTED**"
+    assert "secret-token" not in str(payload)

--- a/custom_components/f1_sensor/tests/test_diagnostics.py
+++ b/custom_components/f1_sensor/tests/test_diagnostics.py
@@ -7,6 +7,10 @@ from unittest.mock import MagicMock
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.f1_sensor import diagnostics as diagnostics_module
+from custom_components.f1_sensor.auth import (
+    AUTH_RUNTIME_STATUS,
+    evaluate_f1tv_auth_header,
+)
 from custom_components.f1_sensor.const import (
     CONF_LIVE_TIMING_AUTH_HEADER,
     CONF_OPERATION_MODE,
@@ -18,7 +22,9 @@ from custom_components.f1_sensor.const import (
 async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
     hass, monkeypatch
 ) -> None:
-    monkeypatch.setattr(diagnostics_module, "ENABLE_DEVELOPMENT_MODE_UI", True)
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.const.ENABLE_DEVELOPMENT_MODE_UI", True
+    )
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="F1",
@@ -53,12 +59,15 @@ async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
             ),
             "auth_enabled": True,
         },
+        AUTH_RUNTIME_STATUS: evaluate_f1tv_auth_header("Bearer secret-token"),
     }
 
     payload = await diagnostics_module.async_get_config_entry_diagnostics(hass, entry)
 
     assert payload["entry"]["data"][CONF_LIVE_TIMING_AUTH_HEADER] == "**REDACTED**"
     assert payload["runtime"]["auth_configured"] is True
+    assert payload["runtime"]["f1tv_token"]["status"] == "invalid"
+    assert payload["runtime"]["f1tv_token"]["used_for_live_timing"] is False
     assert payload["runtime"]["auth_enabled"] is True
     assert payload["runtime"]["signalr_stream_capabilities"] == {
         "auth_enabled": True,
@@ -84,7 +93,9 @@ async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
 async def test_diagnostics_hides_auth_state_when_development_ui_disabled(
     hass, monkeypatch
 ) -> None:
-    monkeypatch.setattr(diagnostics_module, "ENABLE_DEVELOPMENT_MODE_UI", False)
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.const.ENABLE_DEVELOPMENT_MODE_UI", False
+    )
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="F1",
@@ -114,7 +125,10 @@ async def test_diagnostics_hides_auth_state_when_development_ui_disabled(
 
     runtime = payload["runtime"]
     capabilities = runtime["signalr_stream_capabilities"]
-    assert "auth_configured" not in runtime
+    assert runtime["auth_configured"] is True
+    assert runtime["f1tv_token"]["status"] == "invalid"
+    assert runtime["f1tv_token"]["configured"] is True
+    assert runtime["f1tv_token"]["used_for_live_timing"] is False
     assert "auth_enabled" not in runtime
     assert "auth_enabled" not in capabilities
     assert "auth_gated_live_streams" not in capabilities

--- a/custom_components/f1_sensor/tests/test_diagnostics.py
+++ b/custom_components/f1_sensor/tests/test_diagnostics.py
@@ -51,11 +51,22 @@ async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
         "signalr_stream_capabilities": {
             "public_live_streams": frozenset({"SessionStatus", "TrackStatus"}),
             "auth_gated_live_streams": frozenset(
-                {"CarData.z", "ChampionshipPrediction"}
+                {
+                    "CarData.z",
+                    "ChampionshipPrediction",
+                    "TeamRadio",
+                    "PitStopSeries",
+                }
             ),
-            "replay_only_streams": frozenset({"TeamRadio"}),
+            "replay_only_streams": frozenset(),
             "active_live_streams": frozenset(
-                {"SessionStatus", "TrackStatus", "ChampionshipPrediction"}
+                {
+                    "SessionStatus",
+                    "TrackStatus",
+                    "ChampionshipPrediction",
+                    "TeamRadio",
+                    "PitStopSeries",
+                }
             ),
             "auth_enabled": True,
         },
@@ -72,11 +83,17 @@ async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
     assert payload["runtime"]["signalr_stream_capabilities"] == {
         "auth_enabled": True,
         "public_live_streams": ["SessionStatus", "TrackStatus"],
-        "auth_gated_live_streams": ["CarData.z", "ChampionshipPrediction"],
-        "replay_only_streams": ["TeamRadio"],
+        "auth_gated_live_streams": [
+            "CarData.z",
+            "ChampionshipPrediction",
+            "PitStopSeries",
+            "TeamRadio",
+        ],
         "active_live_streams": [
             "ChampionshipPrediction",
+            "PitStopSeries",
             "SessionStatus",
+            "TeamRadio",
             "TrackStatus",
         ],
     }
@@ -111,11 +128,16 @@ async def test_diagnostics_hides_auth_state_when_development_ui_disabled(
         "signalr_stream_capabilities": {
             "public_live_streams": frozenset({"SessionStatus", "TrackStatus"}),
             "auth_gated_live_streams": frozenset(
-                {"CarData.z", "ChampionshipPrediction"}
+                {
+                    "CarData.z",
+                    "ChampionshipPrediction",
+                    "TeamRadio",
+                    "PitStopSeries",
+                }
             ),
-            "replay_only_streams": frozenset({"TeamRadio"}),
+            "replay_only_streams": frozenset(),
             "active_live_streams": frozenset(
-                {"SessionStatus", "ChampionshipPrediction"}
+                {"SessionStatus", "ChampionshipPrediction", "TeamRadio"}
             ),
             "auth_enabled": True,
         },
@@ -134,7 +156,6 @@ async def test_diagnostics_hides_auth_state_when_development_ui_disabled(
     assert "auth_gated_live_streams" not in capabilities
     assert capabilities == {
         "public_live_streams": ["SessionStatus", "TrackStatus"],
-        "replay_only_streams": ["TeamRadio"],
         "active_live_streams": ["SessionStatus"],
     }
     assert payload["entry"]["data"][CONF_LIVE_TIMING_AUTH_HEADER] == "**REDACTED**"

--- a/custom_components/f1_sensor/tests/test_entity_naming.py
+++ b/custom_components/f1_sensor/tests/test_entity_naming.py
@@ -18,6 +18,10 @@ from custom_components.f1_sensor import (
     sensor as sensor_platform,
     switch as switch_platform,
 )
+from custom_components.f1_sensor.auth import (
+    AUTH_RUNTIME_STATUS,
+    evaluate_f1tv_auth_header,
+)
 from custom_components.f1_sensor.const import (
     CONF_ENTITY_NAME_LANGUAGE,
     CONF_ENTITY_NAME_MODE,
@@ -94,6 +98,42 @@ async def test_sensor_setup_entry_uses_translation_key_for_track_status(hass) ->
     assert entity.unique_id == f"{entry.entry_id}_track_status"
     assert entity._attr_translation_key == "track_status"
     assert entity._attr_suggested_object_id == "f1_track_status"
+
+
+@pytest.mark.asyncio
+async def test_sensor_setup_entry_does_not_add_token_sensors_without_saved_token(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.const.ENABLE_DEVELOPMENT_MODE_UI", False
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "RaceHub",
+            "disabled_sensors": sorted(SUPPORTED_SENSOR_KEYS - {"track_status"}),
+        },
+    )
+    entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "race_coordinator": Mock(),
+        "driver_coordinator": Mock(),
+        "constructor_coordinator": Mock(),
+        "last_race_coordinator": Mock(),
+        "season_results_coordinator": Mock(),
+        "sprint_results_coordinator": Mock(),
+        "track_status_coordinator": Mock(),
+        AUTH_RUNTIME_STATUS: evaluate_f1tv_auth_header(""),
+    }
+
+    async_add_entities = Mock()
+    await sensor_platform.async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    assert [entity.unique_id for entity in entities] == [
+        f"{entry.entry_id}_track_status"
+    ]
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_live_mode_restore.py
+++ b/custom_components/f1_sensor/tests/test_live_mode_restore.py
@@ -593,26 +593,6 @@ async def test_formation_start_is_unavailable_during_live_sessions(hass) -> None
             "3",
             {"cars": {}, "last_update": "2026-03-08T04:00:00+00:00"},
         ),
-        (
-            lambda coordinator, entry_id: F1ChampionshipPredictionDriversSensor(
-                coordinator,
-                f"{entry_id}_championship_prediction_drivers",
-                entry_id,
-                "F1",
-            ),
-            "NOR",
-            {"drivers": {}, "predicted_driver_p1": None, "last_update": None},
-        ),
-        (
-            lambda coordinator, entry_id: F1ChampionshipPredictionTeamsSensor(
-                coordinator,
-                f"{entry_id}_championship_prediction_teams",
-                entry_id,
-                "F1",
-            ),
-            "McLaren",
-            {"teams": {}, "predicted_team_p1": None, "last_update": None},
-        ),
     ],
 )
 @pytest.mark.asyncio
@@ -636,6 +616,159 @@ async def test_replay_only_sensors_stay_unavailable_during_live_sessions(
     state = await _add_entity_and_get_state(hass, "sensor", entity)
 
     assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("factory", "restored_state", "attributes"),
+    [
+        (
+            lambda coordinator, entry_id: F1ChampionshipPredictionDriversSensor(
+                coordinator,
+                f"{entry_id}_championship_prediction_drivers",
+                entry_id,
+                "F1",
+            ),
+            "NOR",
+            {"drivers": {}, "predicted_driver_p1": None, "last_update": None},
+        ),
+        (
+            lambda coordinator, entry_id: F1ChampionshipPredictionTeamsSensor(
+                coordinator,
+                f"{entry_id}_championship_prediction_teams",
+                entry_id,
+                "F1",
+            ),
+            "McLaren",
+            {"teams": {}, "predicted_team_p1": None, "last_update": None},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_championship_prediction_sensors_stay_unavailable_in_public_live(
+    hass, factory, restored_state, attributes
+) -> None:
+    entry_id = "test_entry"
+    hass.data.setdefault(DOMAIN, {})[entry_id] = {
+        CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
+        "live_state": _LiveState(True, "live-Race"),
+        "live_bus": _LiveBus(0.0),
+        "signalr_stream_capabilities": {
+            "auth_enabled": False,
+            "auth_gated_live_streams": frozenset({"ChampionshipPrediction"}),
+        },
+    }
+    coordinator = _build_coordinator(hass, None)
+    coordinator.available = False
+    entity = factory(coordinator, entry_id)
+    entity.async_get_last_state = AsyncMock(
+        return_value=State(f"sensor.{entity.unique_id}", restored_state, attributes)
+    )
+
+    state = await _add_entity_and_get_state(hass, "sensor", entity)
+
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("factory", "restored_state", "attributes"),
+    [
+        (
+            lambda coordinator, entry_id: F1ChampionshipPredictionDriversSensor(
+                coordinator,
+                f"{entry_id}_championship_prediction_drivers",
+                entry_id,
+                "F1",
+            ),
+            "NOR",
+            {"drivers": {}, "predicted_driver_p1": None, "last_update": None},
+        ),
+        (
+            lambda coordinator, entry_id: F1ChampionshipPredictionTeamsSensor(
+                coordinator,
+                f"{entry_id}_championship_prediction_teams",
+                entry_id,
+                "F1",
+            ),
+            "McLaren",
+            {"teams": {}, "predicted_team_p1": None, "last_update": None},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_championship_prediction_sensors_restore_during_replay(
+    hass, factory, restored_state, attributes
+) -> None:
+    entry_id = "test_entry"
+    hass.data.setdefault(DOMAIN, {})[entry_id] = {
+        CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
+        "live_state": _LiveState(True, "replay-mode"),
+        "live_bus": _LiveBus(0.0),
+        "signalr_stream_capabilities": {
+            "auth_enabled": False,
+            "auth_gated_live_streams": frozenset({"ChampionshipPrediction"}),
+        },
+    }
+    coordinator = _build_coordinator(hass, None)
+    coordinator.available = True
+    entity = factory(coordinator, entry_id)
+    entity.async_get_last_state = AsyncMock(
+        return_value=State(f"sensor.{entity.unique_id}", restored_state, attributes)
+    )
+
+    state = await _add_entity_and_get_state(hass, "sensor", entity)
+
+    assert state.state == restored_state
+
+
+@pytest.mark.parametrize(
+    ("factory", "restored_state", "attributes"),
+    [
+        (
+            lambda coordinator, entry_id: F1ChampionshipPredictionDriversSensor(
+                coordinator,
+                f"{entry_id}_championship_prediction_drivers",
+                entry_id,
+                "F1",
+            ),
+            "NOR",
+            {"drivers": {}, "predicted_driver_p1": None, "last_update": None},
+        ),
+        (
+            lambda coordinator, entry_id: F1ChampionshipPredictionTeamsSensor(
+                coordinator,
+                f"{entry_id}_championship_prediction_teams",
+                entry_id,
+                "F1",
+            ),
+            "McLaren",
+            {"teams": {}, "predicted_team_p1": None, "last_update": None},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_championship_prediction_sensors_restore_during_auth_live(
+    hass, factory, restored_state, attributes
+) -> None:
+    entry_id = "test_entry"
+    hass.data.setdefault(DOMAIN, {})[entry_id] = {
+        CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
+        "live_state": _LiveState(True, "live-Race"),
+        "live_bus": _LiveBus(0.0),
+        "signalr_stream_capabilities": {
+            "auth_enabled": True,
+            "auth_gated_live_streams": frozenset({"ChampionshipPrediction"}),
+        },
+    }
+    coordinator = _build_coordinator(hass, None)
+    coordinator.available = True
+    entity = factory(coordinator, entry_id)
+    entity.async_get_last_state = AsyncMock(
+        return_value=State(f"sensor.{entity.unique_id}", restored_state, attributes)
+    )
+
+    state = await _add_entity_and_get_state(hass, "sensor", entity)
+
+    assert state.state == restored_state
 
 
 @pytest.mark.parametrize("reason", ["live-Race", "replay"])

--- a/custom_components/f1_sensor/tests/test_live_mode_restore.py
+++ b/custom_components/f1_sensor/tests/test_live_mode_restore.py
@@ -596,7 +596,7 @@ async def test_formation_start_is_unavailable_during_live_sessions(hass) -> None
     ],
 )
 @pytest.mark.asyncio
-async def test_replay_only_sensors_stay_unavailable_during_live_sessions(
+async def test_replay_capable_sensors_stay_unavailable_during_public_live(
     hass, factory, restored_state, attributes
 ) -> None:
     entry_id = "test_entry"
@@ -616,6 +616,53 @@ async def test_replay_only_sensors_stay_unavailable_during_live_sessions(
     state = await _add_entity_and_get_state(hass, "sensor", entity)
 
     assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("factory", "restored_state", "attributes", "stream"),
+    [
+        (
+            lambda coordinator, entry_id: F1TeamRadioSensor(
+                coordinator, f"{entry_id}_team_radio", entry_id, "F1"
+            ),
+            "2026-03-08T04:00:00+00:00",
+            {"history": []},
+            "TeamRadio",
+        ),
+        (
+            lambda coordinator, entry_id: F1PitStopsSensor(
+                coordinator, f"{entry_id}_pitstops", entry_id, "F1"
+            ),
+            "3",
+            {"cars": {}, "last_update": "2026-03-08T04:00:00+00:00"},
+            "PitStopSeries",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_replay_capable_sensors_restore_during_auth_live(
+    hass, factory, restored_state, attributes, stream
+) -> None:
+    entry_id = "test_entry"
+    hass.data.setdefault(DOMAIN, {})[entry_id] = {
+        CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
+        "live_state": _LiveState(True, "live-Race"),
+        "live_bus": _LiveBus(0.0),
+        "signalr_stream_capabilities": {
+            "auth_enabled": True,
+            "auth_gated_live_streams": frozenset({stream}),
+        },
+    }
+    coordinator = _build_coordinator(hass, None)
+    coordinator.available = True
+    entity = factory(coordinator, entry_id)
+    entity.async_get_last_state = AsyncMock(
+        return_value=State(f"sensor.{entity.unique_id}", restored_state, attributes)
+    )
+
+    state = await _add_entity_and_get_state(hass, "sensor", entity)
+
+    assert state.state == restored_state
 
 
 @pytest.mark.parametrize(

--- a/custom_components/f1_sensor/tests/test_replay_only_coordinators.py
+++ b/custom_components/f1_sensor/tests/test_replay_only_coordinators.py
@@ -20,7 +20,6 @@ class _StubBus:
     [
         (TeamRadioCoordinator, {}),
         (PitStopCoordinator, {}),
-        (ChampionshipPredictionCoordinator, {}),
     ],
 )
 @pytest.mark.asyncio
@@ -43,6 +42,44 @@ async def test_replay_only_coordinators_are_available_only_during_replay(
     await hass.async_block_till_done()
     assert coordinator.available is False
 
+    live_state.set_state(True, "replay")
+    await hass.async_block_till_done()
+    assert coordinator.available is True
+
+    live_state.set_state(False, "replay-stopped")
+    await hass.async_block_till_done()
+    assert coordinator.available is False
+
+
+@pytest.mark.asyncio
+async def test_championship_prediction_coordinator_is_available_for_auth_live_or_replay(
+    hass,
+) -> None:
+    live_state = LiveAvailabilityTracker()
+    bus = _StubBus()
+    bus.auth_enabled = False
+    coordinator = ChampionshipPredictionCoordinator(
+        hass,
+        session_coord=object(),
+        bus=bus,
+        live_state=live_state,
+    )
+    await hass.async_block_till_done()
+
+    assert coordinator.available is False
+
+    live_state.set_state(True, "live-Race")
+    await hass.async_block_till_done()
+    assert coordinator.available is False
+
+    bus.auth_enabled = True
+    live_state.set_state(False, "idle")
+    await hass.async_block_till_done()
+    live_state.set_state(True, "live-Race")
+    await hass.async_block_till_done()
+    assert coordinator.available is True
+
+    bus.auth_enabled = False
     live_state.set_state(True, "replay")
     await hass.async_block_till_done()
     assert coordinator.available is True

--- a/custom_components/f1_sensor/tests/test_replay_only_coordinators.py
+++ b/custom_components/f1_sensor/tests/test_replay_only_coordinators.py
@@ -11,6 +11,8 @@ from custom_components.f1_sensor.live_window import LiveAvailabilityTracker
 
 
 class _StubBus:
+    auth_enabled = False
+
     def subscribe(self, _stream, _callback):
         return lambda: None
 
@@ -23,14 +25,15 @@ class _StubBus:
     ],
 )
 @pytest.mark.asyncio
-async def test_replay_only_coordinators_are_available_only_during_replay(
+async def test_replay_capable_coordinators_are_available_for_auth_live_or_replay(
     hass, coordinator_cls, extra_kwargs
 ) -> None:
     live_state = LiveAvailabilityTracker()
+    bus = _StubBus()
     coordinator = coordinator_cls(
         hass,
         session_coord=object(),
-        bus=_StubBus(),
+        bus=bus,
         live_state=live_state,
         **extra_kwargs,
     )
@@ -42,6 +45,16 @@ async def test_replay_only_coordinators_are_available_only_during_replay(
     await hass.async_block_till_done()
     assert coordinator.available is False
 
+    bus.auth_enabled = True
+    live_state.set_state(False, "idle")
+    await hass.async_block_till_done()
+    live_state.set_state(True, "live-Race")
+    await hass.async_block_till_done()
+    assert coordinator.available is True
+
+    bus.auth_enabled = False
+    live_state.set_state(False, "idle")
+    await hass.async_block_till_done()
     live_state.set_state(True, "replay")
     await hass.async_block_till_done()
     assert coordinator.available is True

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+import base64
+from datetime import UTC, datetime, timedelta
+import json
 import logging
 import time
 from unittest.mock import MagicMock
@@ -16,6 +18,10 @@ from homeassistant.util.json import json_loads
 import pytest
 
 from custom_components.f1_sensor import F1NextRaceHistoryCoordinator
+from custom_components.f1_sensor.auth import (
+    AUTH_RUNTIME_STATUS,
+    evaluate_f1tv_auth_header,
+)
 from custom_components.f1_sensor.const import (
     CONF_OPERATION_MODE,
     DOMAIN,
@@ -36,6 +42,8 @@ from custom_components.f1_sensor.sensor import (
     F1SeasonResultsSensor,
     F1SprintResultsSensor,
     F1TopThreePositionSensor,
+    F1TvTokenExpiresAtSensor,
+    F1TvTokenStatusSensor,
     F1WeatherSensor,
 )
 from custom_components.f1_sensor.signalr import LiveBus
@@ -68,6 +76,20 @@ def _build_coordinator(hass, data: dict) -> DataUpdateCoordinator:
     coordinator.data = data
     coordinator.available = True
     return coordinator
+
+
+def _jwt(exp: datetime) -> str:
+    def _part(value: dict) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    return ".".join(
+        (
+            _part({"alg": "RS256", "typ": "JWT"}),
+            _part({"exp": int(exp.timestamp())}),
+            "signature",
+        )
+    )
 
 
 def _set_entry_context(hass, entry_id: str, *, stream_active: bool = False) -> None:
@@ -1312,14 +1334,49 @@ async def test_live_timing_mode_sensor_exposes_stream_diagnostics(hass) -> None:
             "last_seen_age_s": 0.5,
             "last_payload_keys": ["Status", "Message"],
         },
+        "CarData.z": {
+            "frame_count": 12,
+            "last_seen_age_s": 0.2,
+            "last_payload_keys": ["Entries"],
+        },
     }
     hass.data[DOMAIN][entry_id]["live_bus"] = bus
+    hass.data[DOMAIN][entry_id]["signalr_stream_capabilities"] = {
+        "active_live_streams": frozenset(
+            {
+                "SessionStatus",
+                "TrackStatus",
+                "ChampionshipPrediction",
+                "DriverRaceInfo",
+                "CarData.z",
+            }
+        )
+    }
 
     sensor = F1LiveTimingModeSensor(hass, entry_id, "F1")
     state = await _add_sensor_and_get_state(hass, sensor)
 
+    bus.stream_diagnostics.assert_any_call(
+        (
+            "CarData.z",
+            "ChampionshipPrediction",
+            "DriverRaceInfo",
+            "SessionStatus",
+            "TrackStatus",
+        )
+    )
     assert state.attributes["heartbeat_age_s"] == 5.0
     assert state.attributes["activity_age_s"] == 2.0
+    assert state.attributes["streams"]["CarData.z"] == {
+        "frame_count": 12,
+        "last_seen_age_s": 0.2,
+        "last_payload_keys": ["Entries"],
+    }
+    assert state.attributes["streams"]["DriverRaceInfo"] == {
+        "frame_count": 0,
+        "last_seen_age_s": None,
+        "last_payload_keys": None,
+    }
     assert state.attributes["streams"]["SessionStatus"] == {
         "frame_count": 3,
         "last_seen_age_s": 1.0,
@@ -1336,6 +1393,44 @@ async def test_live_timing_mode_sensor_exposes_stream_diagnostics(hass) -> None:
         "last_payload_keys": None,
     }
     assert "TyreStintSeries" not in state.attributes["streams"]
+
+
+@pytest.mark.asyncio
+async def test_f1tv_token_status_sensor_exposes_safe_metadata(hass) -> None:
+    entry_id = "test_entry_f1tv_token_status"
+    expires_at = (datetime.now(UTC) + timedelta(days=2)).replace(microsecond=0)
+    _set_entry_context(hass, entry_id, stream_active=False)
+    hass.data[DOMAIN][entry_id][AUTH_RUNTIME_STATUS] = evaluate_f1tv_auth_header(
+        f"Bearer {_jwt(expires_at)}",
+        used_for_live_timing=False,
+    )
+
+    sensor = F1TvTokenStatusSensor(hass, entry_id, "F1")
+    state = await _add_sensor_and_get_state(hass, sensor)
+
+    assert state.state == "valid"
+    assert state.attributes["auth_configured"] is True
+    assert state.attributes["used_for_live_timing"] is False
+    assert state.attributes["expires_at"] == expires_at.isoformat()
+    assert state.attributes["reason"] is None
+    assert "Bearer" not in str(state.attributes)
+
+
+@pytest.mark.asyncio
+async def test_f1tv_token_expires_at_sensor_exposes_timestamp(hass) -> None:
+    entry_id = "test_entry_f1tv_token_expires_at"
+    expires_at = (datetime.now(UTC) + timedelta(hours=2)).replace(microsecond=0)
+    _set_entry_context(hass, entry_id, stream_active=False)
+    hass.data[DOMAIN][entry_id][AUTH_RUNTIME_STATUS] = evaluate_f1tv_auth_header(
+        f"Bearer {_jwt(expires_at)}"
+    )
+
+    sensor = F1TvTokenExpiresAtSensor(hass, entry_id, "F1")
+    state = await _add_sensor_and_get_state(hass, sensor)
+
+    assert state.state == expires_at.isoformat()
+    assert state.attributes["auth_configured"] is True
+    assert state.attributes["expires_at"] == expires_at.isoformat()
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_setup.py
+++ b/custom_components/f1_sensor/tests/test_setup.py
@@ -522,7 +522,7 @@ async def test_async_setup_entry_live_mode_exposes_auth_capability(
             "enable_race_control": False,
             CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
             CONF_REPLAY_FILE: "",
-            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer test-token",
+            CONF_LIVE_TIMING_AUTH_HEADER: "Authorization: Bearer test-token",
         },
     )
     entry.add_to_hass(hass)

--- a/custom_components/f1_sensor/tests/test_setup.py
+++ b/custom_components/f1_sensor/tests/test_setup.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import ExitStack
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.exceptions import ConfigEntryNotReady
 import pytest
@@ -23,6 +23,7 @@ from custom_components.f1_sensor import (
     async_unload_entry,
 )
 from custom_components.f1_sensor.const import (
+    CONF_LIVE_TIMING_AUTH_HEADER,
     CONF_OPERATION_MODE,
     CONF_REPLAY_FILE,
     DOMAIN,
@@ -35,9 +36,25 @@ from custom_components.f1_sensor.live_window import LiveAvailabilityTracker
 
 
 class FakeLiveBus:
-    def __init__(self, _hass, _session, transport_factory=None) -> None:
+    last_instance = None
+
+    def __init__(
+        self,
+        _hass,
+        _session,
+        transport_factory=None,
+        auth_header=None,
+        auth_failed_callback=None,
+    ) -> None:
         self._transport_factory = transport_factory
+        self.auth_header = auth_header
+        self.auth_failed_callback = auth_failed_callback
         self.started = False
+        FakeLiveBus.last_instance = self
+
+    @property
+    def auth_enabled(self) -> bool:
+        return bool(self.auth_header)
 
     async def start(self) -> None:
         self.started = True
@@ -491,6 +508,136 @@ async def test_async_setup_entry_live_mode_wires_event_tracker_fallback(hass) ->
     assert result is True
     assert FakeLiveSupervisor.last_instance is not None
     assert FakeLiveSupervisor.last_instance.fallback_source is sentinel_source
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_live_mode_exposes_auth_capability(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr("custom_components.f1_sensor.ENABLE_DEVELOPMENT_MODE_UI", True)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
+            CONF_REPLAY_FILE: "",
+            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer test-token",
+        },
+    )
+    entry.add_to_hass(hass)
+    FakeLiveBus.last_instance = None
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.build_user_agent",
+                AsyncMock(return_value="ua"),
+            )
+        )
+        stack.enter_context(patch("custom_components.f1_sensor.LiveBus", FakeLiveBus))
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.LiveSessionCoordinator",
+                DummyCoordinator,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.ReplayController",
+                FakeReplayController,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.EventTrackerScheduleSource",
+                lambda *_args, **_kwargs: object(),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.LiveSessionSupervisor",
+                FakeLiveSupervisor,
+            )
+        )
+        for cm in _coordinator_patches():
+            stack.enter_context(cm)
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=None)
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    assert FakeLiveBus.last_instance is not None
+    assert FakeLiveBus.last_instance.auth_header == "Bearer test-token"
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    assert entry_data["signalr_stream_capabilities"]["auth_enabled"] is True
+    entry.async_start_reauth = MagicMock()
+
+    FakeLiveBus.last_instance.auth_failed_callback()
+
+    assert entry_data["signalr_stream_capabilities"]["auth_enabled"] is False
+    entry.async_start_reauth.assert_called_once_with(hass, data=entry.data)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_ignores_auth_when_development_ui_disabled(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr("custom_components.f1_sensor.ENABLE_DEVELOPMENT_MODE_UI", False)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
+            CONF_REPLAY_FILE: "",
+            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer test-token",
+        },
+    )
+    entry.add_to_hass(hass)
+    FakeLiveBus.last_instance = None
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.build_user_agent",
+                AsyncMock(return_value="ua"),
+            )
+        )
+        stack.enter_context(patch("custom_components.f1_sensor.LiveBus", FakeLiveBus))
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.LiveSessionCoordinator",
+                DummyCoordinator,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.ReplayController",
+                FakeReplayController,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.EventTrackerScheduleSource",
+                lambda *_args, **_kwargs: object(),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.LiveSessionSupervisor",
+                FakeLiveSupervisor,
+            )
+        )
+        for cm in _coordinator_patches():
+            stack.enter_context(cm)
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=None)
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    assert FakeLiveBus.last_instance is not None
+    assert FakeLiveBus.last_instance.auth_header == ""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    assert entry_data["signalr_stream_capabilities"]["auth_enabled"] is False
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_setup.py
+++ b/custom_components/f1_sensor/tests/test_setup.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import base64
 from contextlib import ExitStack
+from datetime import UTC, datetime, timedelta
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import issue_registry as ir
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -22,6 +26,7 @@ from custom_components.f1_sensor import (
     async_setup_entry,
     async_unload_entry,
 )
+from custom_components.f1_sensor.auth import f1tv_auth_repair_issue_id
 from custom_components.f1_sensor.const import (
     CONF_LIVE_TIMING_AUTH_HEADER,
     CONF_OPERATION_MODE,
@@ -64,6 +69,25 @@ class FakeLiveBus:
 
     def subscribe(self, _stream, _callback):
         return lambda: None
+
+
+def _jwt(exp: datetime) -> str:
+    def _part(value: dict) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    return ".".join(
+        (
+            _part({"alg": "RS256", "typ": "JWT"}),
+            _part(
+                {
+                    "iat": int(datetime.now(UTC).timestamp()),
+                    "exp": int(exp.timestamp()),
+                }
+            ),
+            "signature",
+        )
+    )
 
 
 class DummyCoordinator:
@@ -514,7 +538,10 @@ async def test_async_setup_entry_live_mode_wires_event_tracker_fallback(hass) ->
 async def test_async_setup_entry_live_mode_exposes_auth_capability(
     hass, monkeypatch
 ) -> None:
-    monkeypatch.setattr("custom_components.f1_sensor.ENABLE_DEVELOPMENT_MODE_UI", True)
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.const.ENABLE_DEVELOPMENT_MODE_UI", True
+    )
+    token = _jwt(datetime.now(UTC) + timedelta(days=2))
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -522,7 +549,7 @@ async def test_async_setup_entry_live_mode_exposes_auth_capability(
             "enable_race_control": False,
             CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
             CONF_REPLAY_FILE: "",
-            CONF_LIVE_TIMING_AUTH_HEADER: "Authorization: Bearer test-token",
+            CONF_LIVE_TIMING_AUTH_HEADER: f"Authorization: Bearer {token}",
         },
     )
     entry.add_to_hass(hass)
@@ -567,14 +594,17 @@ async def test_async_setup_entry_live_mode_exposes_auth_capability(
 
     assert result is True
     assert FakeLiveBus.last_instance is not None
-    assert FakeLiveBus.last_instance.auth_header == "Bearer test-token"
+    assert FakeLiveBus.last_instance.auth_header == f"Bearer {token}"
     entry_data = hass.data[DOMAIN][entry.entry_id]
     assert entry_data["signalr_stream_capabilities"]["auth_enabled"] is True
+    assert entry_data["f1tv_auth_status"].status == "valid"
+    assert entry_data["f1tv_auth_status"].used_for_live_timing is True
     entry.async_start_reauth = MagicMock()
 
     FakeLiveBus.last_instance.auth_failed_callback()
 
     assert entry_data["signalr_stream_capabilities"]["auth_enabled"] is False
+    assert entry_data["f1tv_auth_status"].status == "rejected"
     entry.async_start_reauth.assert_called_once_with(hass, data=entry.data)
 
 
@@ -582,7 +612,10 @@ async def test_async_setup_entry_live_mode_exposes_auth_capability(
 async def test_async_setup_entry_ignores_auth_when_development_ui_disabled(
     hass, monkeypatch
 ) -> None:
-    monkeypatch.setattr("custom_components.f1_sensor.ENABLE_DEVELOPMENT_MODE_UI", False)
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.const.ENABLE_DEVELOPMENT_MODE_UI", False
+    )
+    token = _jwt(datetime.now(UTC) + timedelta(days=2))
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -590,7 +623,7 @@ async def test_async_setup_entry_ignores_auth_when_development_ui_disabled(
             "enable_race_control": False,
             CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
             CONF_REPLAY_FILE: "",
-            CONF_LIVE_TIMING_AUTH_HEADER: "Bearer test-token",
+            CONF_LIVE_TIMING_AUTH_HEADER: f"Bearer {token}",
         },
     )
     entry.add_to_hass(hass)
@@ -638,6 +671,81 @@ async def test_async_setup_entry_ignores_auth_when_development_ui_disabled(
     assert FakeLiveBus.last_instance.auth_header == ""
     entry_data = hass.data[DOMAIN][entry.entry_id]
     assert entry_data["signalr_stream_capabilities"]["auth_enabled"] is False
+    assert entry_data["f1tv_auth_status"].status == "valid"
+    assert entry_data["f1tv_auth_status"].used_for_live_timing is False
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_warns_for_expired_auth_without_transport(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.const.ENABLE_DEVELOPMENT_MODE_UI", False
+    )
+    token = _jwt(datetime.now(UTC) - timedelta(hours=1))
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1",
+            "enable_race_control": False,
+            CONF_OPERATION_MODE: OPERATION_MODE_LIVE,
+            CONF_REPLAY_FILE: "",
+            CONF_LIVE_TIMING_AUTH_HEADER: f"Bearer {token}",
+        },
+    )
+    entry.add_to_hass(hass)
+    FakeLiveBus.last_instance = None
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.build_user_agent",
+                AsyncMock(return_value="ua"),
+            )
+        )
+        stack.enter_context(patch("custom_components.f1_sensor.LiveBus", FakeLiveBus))
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.LiveSessionCoordinator",
+                DummyCoordinator,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.ReplayController",
+                FakeReplayController,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.EventTrackerScheduleSource",
+                lambda *_args, **_kwargs: object(),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.LiveSessionSupervisor",
+                FakeLiveSupervisor,
+            )
+        )
+        for cm in _coordinator_patches():
+            stack.enter_context(cm)
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=None)
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    assert FakeLiveBus.last_instance is not None
+    assert FakeLiveBus.last_instance.auth_header == ""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    assert entry_data["signalr_stream_capabilities"]["auth_enabled"] is False
+    assert entry_data["f1tv_auth_status"].status == "expired"
+
+    issue = ir.async_get(hass).async_get_issue(
+        DOMAIN, f1tv_auth_repair_issue_id(entry.entry_id)
+    )
+    assert issue is not None
+    assert issue.is_fixable is True
+    assert issue.severity is ir.IssueSeverity.WARNING
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_signalr_core.py
+++ b/custom_components/f1_sensor/tests/test_signalr_core.py
@@ -382,7 +382,6 @@ def test_no_auth_live_stream_contract_excludes_gated_and_replay_only_streams():
     assert AUTH_GATED_LIVE_STREAMS == (
         "CarData.z",
         "DriverRaceInfo",
-        "Position.z",
         "ChampionshipPrediction",
     )
     assert REPLAY_ONLY_STREAMS == (

--- a/custom_components/f1_sensor/tests/test_signalr_core.py
+++ b/custom_components/f1_sensor/tests/test_signalr_core.py
@@ -19,9 +19,11 @@ from custom_components.f1_sensor.signalr import (
     REPLAY_ONLY_STREAMS,
     SUBSCRIBE_MSG,
     LiveBus,
+    SignalRAuthenticationError,
     SignalRCoreClient,
     SignalRLegacyClient,
     build_live_subscribe_streams,
+    build_subscribe_message,
 )
 
 # ---------------------------------------------------------------------------
@@ -47,6 +49,9 @@ class FakeWebSocket:
 
     async def send_str(self, data: str) -> None:
         self._sent.append(data)
+
+    async def send_json(self, data: dict) -> None:
+        self._sent.append(json.dumps(data))
 
     async def receive(self) -> FakeWSMessage:
         if self._messages:
@@ -236,6 +241,113 @@ async def test_subscribe_format():
     assert subscribe_sent.endswith(RECORD_SEP)
 
 
+@pytest.mark.asyncio
+async def test_core_auth_header_enables_auth_gated_streams():
+    """Core client sends the configured Authorization header and gated streams."""
+    client = SignalRCoreClient(MagicMock(), MagicMock(), auth_header="Bearer secret")
+
+    options_resp = AsyncMock()
+    options_resp.headers = {}
+    options_resp.__aenter__ = AsyncMock(return_value=options_resp)
+    options_resp.__aexit__ = AsyncMock(return_value=False)
+
+    post_resp = AsyncMock()
+    post_resp.raise_for_status = MagicMock()
+    post_resp.json = AsyncMock(return_value={"connectionToken": "t"})
+    post_resp.__aenter__ = AsyncMock(return_value=post_resp)
+    post_resp.__aexit__ = AsyncMock(return_value=False)
+
+    handshake_msg = FakeWSMessage(WSMsgType.TEXT, "{}" + RECORD_SEP)
+    ws = FakeWebSocket([handshake_msg])
+
+    client._session.options = MagicMock(return_value=options_resp)
+    client._session.post = MagicMock(return_value=post_resp)
+    client._session.ws_connect = AsyncMock(return_value=ws)
+
+    await client.connect()
+
+    assert client._session.options.call_args.kwargs["headers"]["Authorization"] == (
+        "Bearer secret"
+    )
+    assert client._session.post.call_args.kwargs["headers"]["Authorization"] == (
+        "Bearer secret"
+    )
+    assert client._session.ws_connect.call_args.kwargs["headers"]["Authorization"] == (
+        "Bearer secret"
+    )
+    subscribe_sent = ws._sent[1]
+    sub_json = json.loads(subscribe_sent.replace(RECORD_SEP, ""))
+    assert sub_json["arguments"] == [[*PUBLIC_LIVE_STREAMS, *AUTH_GATED_LIVE_STREAMS]]
+    assert set(sub_json["arguments"][0]).isdisjoint(REPLAY_ONLY_STREAMS)
+
+
+@pytest.mark.asyncio
+async def test_core_auth_handshake_error_raises_without_leaking_token():
+    """Auth failures raise the typed error without including the configured token."""
+    client = SignalRCoreClient(MagicMock(), MagicMock(), auth_header="Bearer secret")
+
+    options_resp = AsyncMock()
+    options_resp.headers = {}
+    options_resp.__aenter__ = AsyncMock(return_value=options_resp)
+    options_resp.__aexit__ = AsyncMock(return_value=False)
+
+    post_resp = AsyncMock()
+    post_resp.raise_for_status = MagicMock()
+    post_resp.json = AsyncMock(return_value={"connectionToken": "t"})
+    post_resp.__aenter__ = AsyncMock(return_value=post_resp)
+    post_resp.__aexit__ = AsyncMock(return_value=False)
+
+    handshake_msg = FakeWSMessage(
+        WSMsgType.TEXT,
+        json.dumps({"error": "Unauthorized"}) + RECORD_SEP,
+    )
+    ws = FakeWebSocket([handshake_msg])
+
+    client._session.options = MagicMock(return_value=options_resp)
+    client._session.post = MagicMock(return_value=post_resp)
+    client._session.ws_connect = AsyncMock(return_value=ws)
+
+    with pytest.raises(SignalRAuthenticationError) as exc:
+        await client.connect()
+
+    assert "secret" not in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_legacy_auth_header_enables_auth_gated_streams():
+    """Legacy client also sends Authorization and subscribes to gated streams."""
+    client = SignalRLegacyClient(MagicMock(), MagicMock(), auth_header="Bearer secret")
+
+    get_resp = AsyncMock()
+    get_resp.headers = {"Set-Cookie": "lb-cookie=1"}
+    get_resp.raise_for_status = MagicMock()
+    get_resp.json = AsyncMock(return_value={"ConnectionToken": "legacy-token"})
+    get_resp.__aenter__ = AsyncMock(return_value=get_resp)
+    get_resp.__aexit__ = AsyncMock(return_value=False)
+
+    ws = FakeWebSocket()
+    client._session.get = MagicMock(return_value=get_resp)
+    client._session.ws_connect = AsyncMock(return_value=ws)
+    task = MagicMock()
+    task.done.return_value = True
+
+    def _create_task(coro):
+        coro.close()
+        return task
+
+    with patch("asyncio.create_task", side_effect=_create_task):
+        await client.connect()
+
+    assert client._session.get.call_args.kwargs["headers"]["Authorization"] == (
+        "Bearer secret"
+    )
+    ws_headers = client._session.ws_connect.call_args.kwargs["headers"]
+    assert ws_headers["Authorization"] == "Bearer secret"
+    subscribe_json = json.loads(ws._sent[0])
+    assert subscribe_json == build_subscribe_message(include_auth_gated=True)
+    assert set(subscribe_json["A"][0]).isdisjoint(REPLAY_ONLY_STREAMS)
+
+
 def test_no_auth_live_stream_contract():
     """No-auth subscriptions must stay aligned with the explicit public stream contract."""
     assert PUBLIC_LIVE_STREAMS == (
@@ -287,6 +399,55 @@ def test_live_bus_can_select_legacy_transport(monkeypatch):
     client = bus._create_client()
 
     assert isinstance(client, SignalRLegacyClient)
+
+
+@pytest.mark.asyncio
+async def test_live_bus_falls_back_to_no_auth_after_auth_failure():
+    """Rejected auth disables auth and lets the next connection use public streams."""
+
+    class AuthFailTransport:
+        async def ensure_connection(self) -> None:
+            raise SignalRAuthenticationError("auth rejected")
+
+        async def messages(self):
+            if False:
+                yield {}
+
+        async def close(self) -> None:
+            return None
+
+    class StopTransport:
+        def __init__(self, bus: LiveBus) -> None:
+            self._bus = bus
+
+        async def ensure_connection(self) -> None:
+            return None
+
+        async def messages(self):
+            self._bus._running = False  # noqa: SLF001 - stop private test loop
+            if False:
+                yield {}
+
+        async def close(self) -> None:
+            return None
+
+    hass = MagicMock()
+    auth_failed = MagicMock()
+    bus = LiveBus(
+        hass,
+        MagicMock(),
+        auth_header="Bearer secret",
+        auth_failed_callback=auth_failed,
+    )
+    bus._running = True  # noqa: SLF001 - exercise private fallback loop directly
+    create_client = MagicMock(side_effect=[AuthFailTransport(), StopTransport(bus)])
+    bus._create_client = create_client  # noqa: SLF001 - control transport sequence
+
+    await bus._run()  # noqa: SLF001 - exercise private fallback loop directly
+
+    assert bus.auth_enabled is False
+    auth_failed.assert_called_once_with()
+    assert create_client.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_signalr_core.py
+++ b/custom_components/f1_sensor/tests/test_signalr_core.py
@@ -383,11 +383,10 @@ def test_no_auth_live_stream_contract_excludes_gated_and_replay_only_streams():
         "CarData.z",
         "DriverRaceInfo",
         "ChampionshipPrediction",
-    )
-    assert REPLAY_ONLY_STREAMS == (
         "TeamRadio",
         "PitStopSeries",
     )
+    assert REPLAY_ONLY_STREAMS == ()
 
 
 def test_live_bus_can_select_legacy_transport(monkeypatch):

--- a/custom_components/f1_sensor/tests/test_track_status_blueprint.py
+++ b/custom_components/f1_sensor/tests/test_track_status_blueprint.py
@@ -157,6 +157,60 @@ async def test_blueprint_syncs_track_light_when_session_enters_active(
 
 
 @pytest.mark.asyncio
+async def test_blueprint_restores_pre_race_scene_after_start_clear_delay(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_services(hass)
+    await _set_states(
+        hass,
+        {
+            "light.test_track_status": "off",
+            "sensor.test_track_status": "CLEAR",
+            "sensor.test_session_status": "pre",
+        },
+    )
+
+    assert await _setup_blueprint_automation(
+        hass,
+        extra_inputs={
+            "snapshot_pre_race": True,
+            "snapshot_before_alert": True,
+            "clear_behavior_mode": "restore_after_delay",
+            "clear_restore_delay_s": 0,
+        },
+    )
+    calls.clear()
+
+    await _set_states(hass, {"sensor.test_session_status": "live"})
+
+    assert calls == [
+        (
+            "scene.create",
+            {
+                "scene_id": "automation_track_status_blueprint_test_pre_race",
+                "snapshot_entities": ["light.test_track_status"],
+            },
+        ),
+        (
+            "light.turn_on",
+            {
+                "entity_id": ["light.test_track_status"],
+                "brightness_pct": 100,
+                "rgb_color": [11, 22, 33],
+                "transition": 0,
+            },
+        ),
+        (
+            "scene.turn_on",
+            {
+                "entity_id": "scene.automation_track_status_blueprint_test_pre_race",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_blueprint_ignores_internal_session_updates_without_track_change(
     hass: HomeAssistant,
 ) -> None:

--- a/custom_components/f1_sensor/translations/da.json
+++ b/custom_components/f1_sensor/translations/da.json
@@ -8,7 +8,11 @@
           "enabled_sensors": "Aktiverede sensorer",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Første dag i løbsugen"
+          "race_week_start_day": "Første dag i løbsugen",
+          "live_timing_auth_header": "Live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -18,13 +22,31 @@
           "enabled_sensors": "Aktiverede sensorer",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Første dag i løbsugen"
+          "race_week_start_day": "Første dag i løbsugen",
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Update F1 live timing authorization",
+        "data": {
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
     },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable."
+      "replay_missing": "Replay dump file not found or unreadable.",
+      "auth_header_required": "Enter the live timing authorization value or select clear."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/de.json
+++ b/custom_components/f1_sensor/translations/de.json
@@ -8,7 +8,11 @@
           "enabled_sensors": "Aktivierte Sensoren",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Erster Tag der Rennwoche"
+          "race_week_start_day": "Erster Tag der Rennwoche",
+          "live_timing_auth_header": "Live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -18,13 +22,31 @@
           "enabled_sensors": "Aktivierte Sensoren",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Erster Tag der Rennwoche"
+          "race_week_start_day": "Erster Tag der Rennwoche",
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Update F1 live timing authorization",
+        "data": {
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
     },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable."
+      "replay_missing": "Replay dump file not found or unreadable.",
+      "auth_header_required": "Enter the live timing authorization value or select clear."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -33,14 +33,14 @@
           "replay_file": "Replay dump path",
           "enable_race_control": "Enable live F1 API (Race Control/Track/Session)",
           "race_week_start_day": "First day of race week",
-          "live_timing_auth_header": "Live timing authorization header"
+          "live_timing_auth_header": "Live timing authorization value"
         },
         "data_description": {
           "operation_mode": "Choose Live to connect to Formula 1 SignalR, or Development to replay a saved dump locally.",
           "replay_file": "Absolute path to a recorded SignalR dump file. Only required in Development mode.",
           "enable_race_control": "Connects to Formula 1 Live Timing via SignalR to receive live updates. If disabled, these live sensors are not created.",
           "race_week_start_day": "Choose whether Race week starts on Saturday, Sunday, or Monday.",
-          "live_timing_auth_header": "Optional full Authorization header for Formula 1 Live Timing. Leave blank to use public live timing only."
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -52,25 +52,27 @@
           "replay_file": "Replay dump path",
           "enable_race_control": "Enable live F1 API",
           "race_week_start_day": "First day of race week",
-          "live_timing_auth_header": "Live timing authorization header",
-          "clear_live_timing_auth_header": "Clear live timing authorization header"
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
         },
         "data_description": {
           "operation_mode": "Choose Live to connect to Formula 1 SignalR, or Development to replay a saved dump locally.",
           "replay_file": "Absolute path to a recorded SignalR dump file. Only required in Development mode.",
           "enable_race_control": "Connects to Formula 1 Live Timing to receive live updates. If disabled, these live sensors are not created.",
           "race_week_start_day": "Choose whether Race week starts on Saturday, Sunday, or Monday.",
-          "live_timing_auth_header": "Enter a new full Authorization header to update it. Leave blank to keep the current value.",
-          "clear_live_timing_auth_header": "Remove the saved live timing authorization header and continue with public live timing only."
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       },
       "reauth_confirm": {
         "title": "Update F1 live timing authorization",
         "data": {
-          "live_timing_auth_header": "Live timing authorization header"
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
         },
         "data_description": {
-          "live_timing_auth_header": "Enter the full Authorization header for Formula 1 Live Timing."
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
     },
@@ -80,7 +82,7 @@
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
       "replay_missing": "Replay dump file not found or unreadable.",
-      "auth_header_required": "Enter the full live timing authorization header."
+      "auth_header_required": "Enter the live timing authorization value or select clear."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -32,13 +32,15 @@
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
           "enable_race_control": "Enable live F1 API (Race Control/Track/Session)",
-          "race_week_start_day": "First day of race week"
+          "race_week_start_day": "First day of race week",
+          "live_timing_auth_header": "Live timing authorization header"
         },
         "data_description": {
           "operation_mode": "Choose Live to connect to Formula 1 SignalR, or Development to replay a saved dump locally.",
           "replay_file": "Absolute path to a recorded SignalR dump file. Only required in Development mode.",
           "enable_race_control": "Connects to Formula 1 Live Timing via SignalR to receive live updates. If disabled, these live sensors are not created.",
-          "race_week_start_day": "Choose whether Race week starts on Saturday, Sunday, or Monday."
+          "race_week_start_day": "Choose whether Race week starts on Saturday, Sunday, or Monday.",
+          "live_timing_auth_header": "Optional full Authorization header for Formula 1 Live Timing. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -49,13 +51,26 @@
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
           "enable_race_control": "Enable live F1 API",
-          "race_week_start_day": "First day of race week"
+          "race_week_start_day": "First day of race week",
+          "live_timing_auth_header": "Live timing authorization header",
+          "clear_live_timing_auth_header": "Clear live timing authorization header"
         },
         "data_description": {
           "operation_mode": "Choose Live to connect to Formula 1 SignalR, or Development to replay a saved dump locally.",
           "replay_file": "Absolute path to a recorded SignalR dump file. Only required in Development mode.",
           "enable_race_control": "Connects to Formula 1 Live Timing to receive live updates. If disabled, these live sensors are not created.",
-          "race_week_start_day": "Choose whether Race week starts on Saturday, Sunday, or Monday."
+          "race_week_start_day": "Choose whether Race week starts on Saturday, Sunday, or Monday.",
+          "live_timing_auth_header": "Enter a new full Authorization header to update it. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization header and continue with public live timing only."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Update F1 live timing authorization",
+        "data": {
+          "live_timing_auth_header": "Live timing authorization header"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter the full Authorization header for Formula 1 Live Timing."
         }
       }
     },
@@ -64,7 +79,8 @@
     },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable."
+      "replay_missing": "Replay dump file not found or unreadable.",
+      "auth_header_required": "Enter the full live timing authorization header."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -82,7 +82,32 @@
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
       "replay_missing": "Replay dump file not found or unreadable.",
-      "auth_header_required": "Enter the live timing authorization value or select clear."
+      "auth_header_required": "Enter the live timing authorization value or select clear.",
+      "invalid_auth_header": "Enter a valid `Bearer <JWT>` value.",
+      "auth_token_missing_exp": "The token does not include an expiry time.",
+      "auth_token_expired": "The token has expired.",
+      "auth_token_expiring_soon": "The token expires too soon. Generate a new token and try again."
+    }
+  },
+  "issues": {
+    "f1tv_token_attention_required": {
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "data": {
+              "live_timing_auth_header": "Live timing authorization value",
+              "clear_live_timing_auth_header": "Clear live timing authorization value"
+            },
+            "data_description": {
+              "live_timing_auth_header": "Paste a new `Bearer <JWT>` value from the F1TV Token Helper.",
+              "clear_live_timing_auth_header": "Remove the saved F1TV token and continue with public live timing only."
+            },
+            "description": "The saved F1TV token for {name} needs attention. Public live timing continues to work, but F1TV-only live data will not be used until the token is replaced.",
+            "title": "Update F1TV live timing token"
+          }
+        }
+      },
+      "title": "F1TV live timing token needs attention"
     }
   },
   "entity": {
@@ -146,6 +171,20 @@
       },
       "live_timing_mode": {
         "name": "Live timing mode"
+      },
+      "f1tv_token_status": {
+        "name": "F1TV token status",
+        "state": {
+          "not_configured": "Not configured",
+          "valid": "Valid",
+          "expiring_soon": "Expiring soon",
+          "expired": "Expired",
+          "invalid": "Invalid",
+          "rejected": "Rejected"
+        }
+      },
+      "f1tv_token_expires_at": {
+        "name": "F1TV token expires at"
       },
       "driver_positions": {
         "name": "Driver positions"

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -40,7 +40,7 @@
           "replay_file": "Absolute path to a recorded SignalR dump file. Only required in Development mode.",
           "enable_race_control": "Connects to Formula 1 Live Timing via SignalR to receive live updates. If disabled, these live sensors are not created.",
           "race_week_start_day": "Choose whether Race week starts on Saturday, Sunday, or Monday.",
-          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste the full Bearer token. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -60,7 +60,7 @@
           "replay_file": "Absolute path to a recorded SignalR dump file. Only required in Development mode.",
           "enable_race_control": "Connects to Formula 1 Live Timing to receive live updates. If disabled, these live sensors are not created.",
           "race_week_start_day": "Choose whether Race week starts on Saturday, Sunday, or Monday.",
-          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste the full Bearer token. Leave blank to keep the current value.",
           "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       },
@@ -71,7 +71,7 @@
           "clear_live_timing_auth_header": "Clear live timing authorization value"
         },
         "data_description": {
-          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste the full Bearer token.",
           "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
@@ -83,7 +83,7 @@
       "replay_required": "Select a replay dump file when Development mode is enabled.",
       "replay_missing": "Replay dump file not found or unreadable.",
       "auth_header_required": "Enter the live timing authorization value or select clear.",
-      "invalid_auth_header": "Enter a valid `Bearer <JWT>` value.",
+      "invalid_auth_header": "Enter a valid Bearer token value.",
       "auth_token_missing_exp": "The token does not include an expiry time.",
       "auth_token_expired": "The token has expired.",
       "auth_token_expiring_soon": "The token expires too soon. Generate a new token and try again."
@@ -99,7 +99,7 @@
               "clear_live_timing_auth_header": "Clear live timing authorization value"
             },
             "data_description": {
-              "live_timing_auth_header": "Paste a new `Bearer <JWT>` value from the F1TV Token Helper.",
+              "live_timing_auth_header": "Paste a new Bearer token value from the F1TV Token Helper.",
               "clear_live_timing_auth_header": "Remove the saved F1TV token and continue with public live timing only."
             },
             "description": "The saved F1TV token for {name} needs attention. Public live timing continues to work, but F1TV-only live data will not be used until the token is replaced.",

--- a/custom_components/f1_sensor/translations/fi.json
+++ b/custom_components/f1_sensor/translations/fi.json
@@ -8,7 +8,11 @@
           "enabled_sensors": "Käytössä olevat anturit",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Kilpailuviikon ensimmäinen päivä"
+          "race_week_start_day": "Kilpailuviikon ensimmäinen päivä",
+          "live_timing_auth_header": "Live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -18,13 +22,31 @@
           "enabled_sensors": "Käytössä olevat anturit",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Kilpailuviikon ensimmäinen päivä"
+          "race_week_start_day": "Kilpailuviikon ensimmäinen päivä",
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Update F1 live timing authorization",
+        "data": {
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
     },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable."
+      "replay_missing": "Replay dump file not found or unreadable.",
+      "auth_header_required": "Enter the live timing authorization value or select clear."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/fr.json
+++ b/custom_components/f1_sensor/translations/fr.json
@@ -8,7 +8,11 @@
           "enabled_sensors": "Capteurs activés",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Premier jour de la semaine de course"
+          "race_week_start_day": "Premier jour de la semaine de course",
+          "live_timing_auth_header": "Live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -18,13 +22,31 @@
           "enabled_sensors": "Capteurs activés",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Premier jour de la semaine de course"
+          "race_week_start_day": "Premier jour de la semaine de course",
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Update F1 live timing authorization",
+        "data": {
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
     },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable."
+      "replay_missing": "Replay dump file not found or unreadable.",
+      "auth_header_required": "Enter the live timing authorization value or select clear."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/it.json
+++ b/custom_components/f1_sensor/translations/it.json
@@ -8,7 +8,11 @@
           "enabled_sensors": "Sensori abilitati",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Primo giorno della settimana di gara"
+          "race_week_start_day": "Primo giorno della settimana di gara",
+          "live_timing_auth_header": "Live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -18,13 +22,31 @@
           "enabled_sensors": "Sensori abilitati",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Primo giorno della settimana di gara"
+          "race_week_start_day": "Primo giorno della settimana di gara",
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Update F1 live timing authorization",
+        "data": {
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
     },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable."
+      "replay_missing": "Replay dump file not found or unreadable.",
+      "auth_header_required": "Enter the live timing authorization value or select clear."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/nl.json
+++ b/custom_components/f1_sensor/translations/nl.json
@@ -8,7 +8,11 @@
           "enabled_sensors": "Ingeschakelde sensoren",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Eerste dag van de raceweek"
+          "race_week_start_day": "Eerste dag van de raceweek",
+          "live_timing_auth_header": "Live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -18,13 +22,31 @@
           "enabled_sensors": "Ingeschakelde sensoren",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Eerste dag van de raceweek"
+          "race_week_start_day": "Eerste dag van de raceweek",
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Update F1 live timing authorization",
+        "data": {
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
     },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable."
+      "replay_missing": "Replay dump file not found or unreadable.",
+      "auth_header_required": "Enter the live timing authorization value or select clear."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/no.json
+++ b/custom_components/f1_sensor/translations/no.json
@@ -8,7 +8,11 @@
           "enabled_sensors": "Aktiverte sensorer",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Første dag i raceuken"
+          "race_week_start_day": "Første dag i raceuken",
+          "live_timing_auth_header": "Live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -18,13 +22,31 @@
           "enabled_sensors": "Aktiverte sensorer",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Første dag i raceuken"
+          "race_week_start_day": "Første dag i raceuken",
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Update F1 live timing authorization",
+        "data": {
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
     },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable."
+      "replay_missing": "Replay dump file not found or unreadable.",
+      "auth_header_required": "Enter the live timing authorization value or select clear."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/pt.json
+++ b/custom_components/f1_sensor/translations/pt.json
@@ -8,7 +8,11 @@
           "enabled_sensors": "Sensores habilitados",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Primeiro dia da semana de corrida"
+          "race_week_start_day": "Primeiro dia da semana de corrida",
+          "live_timing_auth_header": "Live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
         }
       },
       "reconfigure": {
@@ -18,13 +22,31 @@
           "enabled_sensors": "Sensores habilitados",
           "operation_mode": "Operation mode",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Primeiro dia da semana de corrida"
+          "race_week_start_day": "Primeiro dia da semana de corrida",
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Update F1 live timing authorization",
+        "data": {
+          "live_timing_auth_header": "Live timing authorization value",
+          "clear_live_timing_auth_header": "Clear live timing authorization value"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
         }
       }
     },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable."
+      "replay_missing": "Replay dump file not found or unreadable.",
+      "auth_header_required": "Enter the live timing authorization value or select clear."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/sv.json
+++ b/custom_components/f1_sensor/translations/sv.json
@@ -32,13 +32,15 @@
           "operation_mode": "Driftläge",
           "replay_file": "Sökväg till replay-dump",
           "enable_race_control": "Aktivera live F1 API (Race Control/Track/Session)",
-          "race_week_start_day": "Första dagen i tävlingsveckan"
+          "race_week_start_day": "Första dagen i tävlingsveckan",
+          "live_timing_auth_header": "Live timing-auktoriseringsvärde"
         },
         "data_description": {
           "operation_mode": "Välj Live för att ansluta till Formula 1 SignalR, eller Utveckling för att spela upp en sparad dump lokalt.",
           "replay_file": "Absolut sökväg till en inspelad SignalR-dumpfil. Krävs endast i utvecklingsläge.",
           "enable_race_control": "Ansluter till Formula 1 Live Timing via SignalR för att ta emot liveuppdateringar. Om avaktiverad skapas inte dessa livesensorer.",
-          "race_week_start_day": "Välj om tävlingsveckan börjar på lördag, söndag eller måndag."
+          "race_week_start_day": "Välj om tävlingsveckan börjar på lördag, söndag eller måndag.",
+          "live_timing_auth_header": "Valfritt värde från F1TV Token Helper för Formula 1 Live Timing. Klistra in `Bearer <JWT>`. Ta inte med `Authorization:`. Lämna tomt för att bara använda publik live timing."
         }
       },
       "reconfigure": {
@@ -49,19 +51,35 @@
           "operation_mode": "Driftläge",
           "replay_file": "Sökväg till replay-dump",
           "enable_race_control": "Aktivera live F1 API",
-          "race_week_start_day": "Första dagen i tävlingsveckan"
+          "race_week_start_day": "Första dagen i tävlingsveckan",
+          "live_timing_auth_header": "Live timing-auktoriseringsvärde",
+          "clear_live_timing_auth_header": "Rensa live timing-auktoriseringsvärde"
         },
         "data_description": {
           "operation_mode": "Välj Live för att ansluta till Formula 1 SignalR, eller Utveckling för att spela upp en sparad dump lokalt.",
           "replay_file": "Absolut sökväg till en inspelad SignalR-dumpfil. Krävs endast i utvecklingsläge.",
           "enable_race_control": "Ansluter till Formula 1 Live Timing för att ta emot liveuppdateringar. Om avaktiverad skapas inte dessa livesensorer.",
-          "race_week_start_day": "Välj om tävlingsveckan börjar på lördag, söndag eller måndag."
+          "race_week_start_day": "Välj om tävlingsveckan börjar på lördag, söndag eller måndag.",
+          "live_timing_auth_header": "Ange ett nytt värde från F1TV Token Helper för att uppdatera det. Klistra in `Bearer <JWT>`. Lämna tomt för att behålla nuvarande värde.",
+          "clear_live_timing_auth_header": "Ta bort det sparade live timing-auktoriseringsvärdet och fortsätt med endast publik live timing."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Uppdatera F1 live timing-auktorisering",
+        "data": {
+          "live_timing_auth_header": "Live timing-auktoriseringsvärde",
+          "clear_live_timing_auth_header": "Rensa live timing-auktoriseringsvärde"
+        },
+        "data_description": {
+          "live_timing_auth_header": "Ange ett nytt värde från F1TV Token Helper för Formula 1 Live Timing. Klistra in `Bearer <JWT>`.",
+          "clear_live_timing_auth_header": "Ta bort det sparade live timing-auktoriseringsvärdet och fortsätt med endast publik live timing."
         }
       }
     },
     "error": {
       "replay_required": "Välj en replay-dumpfil när utvecklingsläge är aktiverat.",
-      "replay_missing": "Replay-dumpfilen hittades inte eller är oläsbar."
+      "replay_missing": "Replay-dumpfilen hittades inte eller är oläsbar.",
+      "auth_header_required": "Ange live timing-auktoriseringsvärdet eller välj att rensa det."
     }
   },
   "entity": {

--- a/custom_components/f1_sensor/translations/sv.json
+++ b/custom_components/f1_sensor/translations/sv.json
@@ -79,7 +79,32 @@
     "error": {
       "replay_required": "Välj en replay-dumpfil när utvecklingsläge är aktiverat.",
       "replay_missing": "Replay-dumpfilen hittades inte eller är oläsbar.",
-      "auth_header_required": "Ange live timing-auktoriseringsvärdet eller välj att rensa det."
+      "auth_header_required": "Ange live timing-auktoriseringsvärdet eller välj att rensa det.",
+      "invalid_auth_header": "Ange ett giltigt `Bearer <JWT>`-värde.",
+      "auth_token_missing_exp": "Token saknar utgångstid.",
+      "auth_token_expired": "Token har gått ut.",
+      "auth_token_expiring_soon": "Token går ut för snart. Skapa en ny token och försök igen."
+    }
+  },
+  "issues": {
+    "f1tv_token_attention_required": {
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "data": {
+              "live_timing_auth_header": "Live timing-auktoriseringsvärde",
+              "clear_live_timing_auth_header": "Rensa live timing-auktoriseringsvärde"
+            },
+            "data_description": {
+              "live_timing_auth_header": "Klistra in ett nytt `Bearer <JWT>`-värde från F1TV Token Helper.",
+              "clear_live_timing_auth_header": "Ta bort den sparade F1TV-token och fortsätt med endast publik live timing."
+            },
+            "description": "Den sparade F1TV-token för {name} behöver åtgärdas. Publik live timing fortsätter att fungera, men F1TV-only live-data används inte förrän token har bytts ut.",
+            "title": "Uppdatera F1TV live timing-token"
+          }
+        }
+      },
+      "title": "F1TV live timing-token behöver åtgärdas"
     }
   },
   "entity": {
@@ -143,6 +168,20 @@
       },
       "live_timing_mode": {
         "name": "Live timing-läge"
+      },
+      "f1tv_token_status": {
+        "name": "F1TV token-status",
+        "state": {
+          "not_configured": "Inte konfigurerad",
+          "valid": "Giltig",
+          "expiring_soon": "Går snart ut",
+          "expired": "Utgången",
+          "invalid": "Ogiltig",
+          "rejected": "Avvisad"
+        }
+      },
+      "f1tv_token_expires_at": {
+        "name": "F1TV-token går ut"
       },
       "driver_positions": {
         "name": "Förarpositioner"


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->
Experimental Testing of F1TV authentication

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [X] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [X] Tested locally with a real Home Assistant instance
- [X] Existing automations and dashboards still work as expected after the change

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [X] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [X] Tests have been added or updated and pass locally — if applicable
- [X] Translations updated if new UI strings were added — if applicable
- [X] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
