### PR TITLE
Update fi.json

### DIFF
--- a/custom_components/f1_sensor/translations/fi.json
+++ b/custom_components/f1_sensor/translations/fi.json
@@ -1,4 +1,27 @@
 {
+  "device_automation": {
+    "trigger_type": {
+      "race_week_started": "Kilpailuviikko on alkanut",
+      "race_week_ended": "Kilpailuviikko on päättynyt",
+      "safety_car_deployed": "Turva-auto radalla",
+      "safety_car_cleared": "Turva-auto poistunut",
+      "formation_start_ready": "Lämmittelykierroksen aloitus valmis",
+      "overtake_mode_enabled": "Ohitustila käytössä",
+      "overtake_mode_disabled": "Ohitustila pois käytöstä",
+      "session_live": "Sessio alkoi",
+      "track_status_clear": "Radan tila: Selvä",
+      "track_status_yellow": "Radan tila: Keltainen lippu",
+      "track_status_safety_car": "Radan tila: Turva-auto",
+      "track_status_vsc": "Radan tila: Virtuaalinen turva-auto",
+      "track_status_red_flag": "Radan tila: Punainen lippu",
+      "new_race_control_message": "Uusi viesti kilpailun johdolta",
+      "new_fia_document": "Uusi FIA:n dokumentti julkaistu",
+      "investigation_changed": "Tutkinnan tila muuttui",
+      "new_team_radio": "Uusi tiimiradioviesti",
+      "live_timing_online": "Live-ajoitus yhdistetty",
+      "live_timing_offline": "Live-ajoitus katkaistu"
+    }
+  },
   "config": {
     "step": {
       "user": {
@@ -6,13 +29,16 @@
         "data": {
           "sensor_name": "Laitteen nimi",
           "enabled_sensors": "Käytössä olevat anturit",
-          "operation_mode": "Operation mode",
+          "operation_mode": "Toimintatila",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Kilpailuviikon ensimmäinen päivä",
-          "live_timing_auth_header": "Live timing authorization value"
+          "enable_race_control": "Ota käyttöön live F1 API (Race Control/Track/Session)",
+          "race_week_start_day": "Kilpailuviikon ensimmäinen päivä"
         },
         "data_description": {
-          "live_timing_auth_header": "Optional value from the F1TV Token Helper for Formula 1 Live Timing. Paste `Bearer <JWT>`. Do not include `Authorization:`. Leave blank to use public live timing only."
+          "operation_mode": "Valitse Live yhdistääksesi Formula 1 SignalR:ään tai Development toistaaksesi tallennetun tiedoston paikallisesti.",
+          "replay_file": "Absoluuttinen polku tallennettuun SignalR-tiedostoon. Vaaditaan vain Development-tilassa.",
+          "enable_race_control": "Yhdistää Formula 1 Live Timingiin SignalR:n kautta live-päivitysten vastaanottamiseksi. Jos tämä on pois käytöstä, näitä live-antureita ei luoda.",
+          "race_week_start_day": "Valitse alkaako kilpailuviikko lauantaina, sunnuntaina vai maanantaina."
         }
       },
       "reconfigure": {
@@ -20,39 +46,34 @@
         "data": {
           "sensor_name": "Laitteen nimi",
           "enabled_sensors": "Käytössä olevat anturit",
-          "operation_mode": "Operation mode",
+          "operation_mode": "Toimintatila",
           "replay_file": "Replay dump path",
-          "race_week_start_day": "Kilpailuviikon ensimmäinen päivä",
-          "live_timing_auth_header": "Live timing authorization value",
-          "clear_live_timing_auth_header": "Clear live timing authorization value"
+          "enable_race_control": "Ota käyttöön live F1 API",
+          "race_week_start_day": "Kilpailuviikon ensimmäinen päivä"
         },
         "data_description": {
-          "live_timing_auth_header": "Enter a new F1TV Token Helper value to update it. Paste `Bearer <JWT>`. Leave blank to keep the current value.",
-          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
-        }
-      },
-      "reauth_confirm": {
-        "title": "Update F1 live timing authorization",
-        "data": {
-          "live_timing_auth_header": "Live timing authorization value",
-          "clear_live_timing_auth_header": "Clear live timing authorization value"
-        },
-        "data_description": {
-          "live_timing_auth_header": "Enter a new F1TV Token Helper value for Formula 1 Live Timing. Paste `Bearer <JWT>`.",
-          "clear_live_timing_auth_header": "Remove the saved live timing authorization value and continue with public live timing only."
+          "operation_mode": "Valitse Live yhdistääksesi Formula 1 SignalR:ään tai Development toistaaksesi tallennetun tiedoston paikallisesti.",
+          "replay_file": "Absoluuttinen polku tallennettuun SignalR-tiedostoon. Vaaditaan vain Development-tilassa.",
+          "enable_race_control": "Yhdistää Formula 1 Live Timingiin live-päivitysten vastaanottamiseksi. Jos tämä on pois käytöstä, näitä live-antureita ei luoda.",
+          "race_week_start_day": "Valitse alkaako kilpailuviikko lauantaina, sunnuntaina vai maanantaina."
         }
       }
     },
+    "abort": {
+      "reconfigure_successful": "F1-anturin määritys onnistui."
+    },
     "error": {
       "replay_required": "Select a replay dump file when Development mode is enabled.",
-      "replay_missing": "Replay dump file not found or unreadable.",
-      "auth_header_required": "Enter the live timing authorization value or select clear."
+      "replay_missing": "Replay dump file not found or unreadable."
     }
   },
   "entity": {
     "sensor": {
       "next_race": {
         "name": "Seuraava kilpailu"
+      },
+      "track_time": {
+        "name": "Rata-aika"
       },
       "current_season": {
         "name": "Nykyinen kausi"
@@ -66,6 +87,9 @@
       "weather": {
         "name": "Sää"
       },
+      "track_weather": {
+        "name": "Radan sää"
+      },
       "current_session": {
         "name": "Käynnissä oleva sessio"
       },
@@ -76,13 +100,28 @@
         "name": "Kausitulokset"
       },
       "sprint_results": {
-        "name": "Sprinttulokset"
+        "name": "Sprinttitulokset"
       },
       "race_control": {
         "name": "Kisavalvonta"
       },
+      "top_three_p1": {
+        "name": "Kolme parasta (P1)"
+      },
+      "top_three_p2": {
+        "name": "Kolme parasta (P2)"
+      },
+      "top_three_p3": {
+        "name": "Kolme parasta (P3)"
+      },
       "pitstops": {
         "name": "Varikkopysähdykset"
+      },
+      "championship_prediction_drivers": {
+        "name": "Mestaruusennuste (kuljettajat)"
+      },
+      "championship_prediction_teams": {
+        "name": "Mestaruusennuste (tallit)"
       },
       "fia_documents": {
         "name": "FIA-päätökset"
@@ -90,11 +129,103 @@
       "live_timing_mode": {
         "name": "Live timing -tila"
       },
+      "driver_positions": {
+        "name": "Kuljettajien sijoitukset"
+      },
       "track_limits": {
-        "name": "Track limits"
+        "name": "Ratarajat"
       },
       "investigations": {
-        "name": "Investigations & penalties"
+        "name": "Tutkinnat ja rangaistukset"
+      },
+      "straight_mode": {
+        "name": "Straight mode",
+        "state": {
+          "normal_grip": "Normaali pito",
+          "low_grip": "Heikko pito",
+          "disabled": "Pois käytöstä"
+        }
+      },
+      "track_status": {
+        "name": "Radan tila"
+      },
+      "session_status": {
+        "name": "Session tila"
+      },
+      "session_time_remaining": {
+        "name": "Sessiota jäljellä"
+      },
+      "session_time_elapsed": {
+        "name": "Sessiota kulunut"
+      },
+      "race_time_to_three_hour_limit": {
+        "name": "Aikaa 3 tunnin rajaan"
+      },
+      "driver_list": {
+        "name": "Kuljettajalista"
+      },
+      "current_tyres": {
+        "name": "Nykyiset renkaat"
+      },
+      "tyre_statistics": {
+        "name": "Rengastilastot"
+      },
+      "team_radio": {
+        "name": "Tiimiradio"
+      },
+      "race_lap_count": {
+        "name": "Kierrosmäärä"
+      },
+      "driver_points_progression": {
+        "name": "Kuljettajien pisteiden kehitys"
+      },
+      "constructor_points_progression": {
+        "name": "Valmistajien pisteiden kehitys"
+      },
+      "replay_status": {
+        "name": "Replay status"
+      }
+    },
+    "button": {
+      "delay_calibration_match": {
+        "name": "Kohdista live-viiveeseen"
+      },
+      "replay_load": {
+        "name": "Lataa sessio"
+      },
+      "replay_play": {
+        "name": "Toista"
+      },
+      "replay_pause": {
+        "name": "Keskeytä"
+      },
+      "replay_back_30": {
+        "name": "30 sekuntia taaksepäin"
+      },
+      "replay_forward_30": {
+        "name": "30 sekuntia eteenpäin"
+      },
+      "replay_stop": {
+        "name": "Lopeta"
+      },
+      "replay_refresh": {
+        "name": "Päivitä sessiot"
+      },
+      "jolpica_ua_test": {
+        "name": "Jolpica user-agent test"
+      }
+    },
+    "switch": {
+      "delay_calibration": {
+        "name": "Viiveen kalibrointi"
+      },
+      "no_spoiler_mode": {
+        "name": "Ei spoilereita -tila"
+      }
+    },
+    "number": {
+      "live_delay": {
+        "name": "Live-viive"
       }
     },
     "media_player": {
@@ -127,12 +258,15 @@
         "name": "Turva-auto"
       },
       "formation_start": {
-        "name": "Formation start"
+        "name": "Lämmittelykierroksen alku"
+      },
+      "overtake_mode": {
+        "name": "Ohitustila"
       }
     },
-    "switch": {
-      "no_spoiler_mode": {
-        "name": "Ei spoilereita -tila"
+    "calendar": {
+      "season_calendar": {
+        "name": "Kausikalenteri"
       }
     }
   }


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->
Almost complete finnish translation.

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [x] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [x] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
