### PR TITLE
docs: Update to exprimental testing

### DIFF
--- a/docs/help/experimental-testing.md
+++ b/docs/help/experimental-testing.md
@@ -5,6 +5,7 @@ title: Experimental Testing
 
 Experimental testing is for power users who want to validate F1TV authenticated live timing before it is made available as a normal user-facing feature.
 Use this page when you are testing the development-gated authentication flow, the F1TV Token Helper, token expiry handling, and the fallback to public live timing.
+
 :::danger[Test environment only]
 Do not test F1TV authentication in your production Home Assistant instance.
 Use a separate Home Assistant test instance, development container, VM, or secondary setup where restarts, broken entities, and temporary configuration changes are acceptable.
@@ -15,18 +16,19 @@ Use a separate Home Assistant test instance, development container, VM, or secon
 F1 Sensor works without F1TV authentication by using public live timing streams.
 The experimental authentication flow adds a short-lived F1TV live timing authorization value so the integration can test extra live timing streams during an active Formula 1 session.
 
-The current manual testing flow is:
+The current testing flow uses Home Assistant pairing:
 
-1. Enable the development-gated controls in the integration code
-2. Install or update the test copy of F1 Sensor in Home Assistant
-3. Install the separate [F1TV Token Helper](https://github.com/Nicxe/f1tv-token-helper) repository as a local browser extension
-4. Sign in to Formula 1 in your browser
-5. Copy the `Bearer <JWT>` value from the helper
-6. Paste the value into F1 Sensor
-7. Verify that public live timing still works and that F1TV-only live data is enabled when the token is valid
+1. Enable the development-gated controls in the integration code.
+2. Install or update F1 Sensor `v4.3.0-beta.2` or later in Home Assistant.
+3. Install the separate [F1TV Token Helper](https://github.com/Nicxe/f1tv-token-helper) as a local browser extension while the Chrome Web Store beta is under review.
+4. Start **Connect F1TV access with Token Helper** in Home Assistant.
+5. Open the pairing page from Home Assistant.
+6. Open the helper extension, sign in to Formula 1 if needed, select **Fetch**, then select **Send to Home Assistant**.
+7. Verify that public live timing still works and that F1TV-only live data is enabled when the token is valid.
+
 :::info
 This flow does not ask Home Assistant for your F1TV username or password.
-The token is extracted from your own browser session by the separate helper and pasted manually into the integration.
+The token is extracted from your own browser session by the separate helper and sent only to your own Home Assistant pairing callback.
 :::
 
 ## Current limitations
@@ -39,11 +41,12 @@ The current experimental scope is:
 | Area | Expected behavior |
 | --- | --- |
 | Public live timing | Continues to work without any token |
-| F1TV token | Optional and manually pasted as `Bearer <JWT>` |
+| F1TV token | Optional and sent through Home Assistant pairing |
 | Token lifetime | Short-lived and must be replaced when expired |
 | Token renewal | Not automatic |
 | F1TV password | Never entered into Home Assistant |
-| Helper | Separate local repository and browser extension |
+| Helper | Separate Chrome or Chromium extension |
+| Chrome Web Store | Submitted for unlisted beta review, not available until approved |
 | Auth failure | Downgrades to public live timing |
 | Auth-gated live data | Requires a valid token during live sessions |
 
@@ -71,13 +74,13 @@ If the token is missing, expired, or rejected, auth-gated live data should becom
 
 Before you start, make sure you have:
 
-1. A non-production Home Assistant instance
-2. F1 Sensor `4.3.0-beta.1` or later installed
-3. Access to Home Assistant logs
-4. A Formula 1 account with the required F1TV access for live timing
-5. Chrome or another Chromium-based browser for the helper extension
-6. Node.js 22 or newer for building the helper
-7. The [F1TV Token Helper](https://github.com/Nicxe/f1tv-token-helper) repository cloned or unpacked locally
+1. A non-production Home Assistant instance.
+2. F1 Sensor `v4.3.0-beta.2` or later installed.
+3. Access to Home Assistant logs.
+4. A Formula 1 account with the required F1TV access for live timing.
+5. Chrome or another Chromium-based browser for the helper extension.
+6. Node.js 22 or newer for local helper builds while the Chrome Web Store beta is under review.
+7. The [F1TV Token Helper](https://github.com/Nicxe/f1tv-token-helper) repository cloned or unpacked locally.
 
 The helper can be stored anywhere on your computer.
 In the examples below, replace this path with the folder where you cloned or unpacked the repository:
@@ -97,7 +100,7 @@ Adjust the paths if your test environment uses different locations.
 ## Step 1 - Enable the development gate
 
 F1TV authentication is hidden behind the development UI gate.
-The test build must expose development controls before the auth field appears in setup or reconfigure.
+The test build must expose development controls before the pairing option appears in setup or reconfigure.
 
 Open the integration `const.py` file in the Home Assistant test copy:
 
@@ -112,31 +115,24 @@ ENABLE_DEVELOPMENT_MODE_UI = True
 ```
 
 Save the file and restart Home Assistant.
+
 :::warning
 Released builds should keep this gate disabled.
 For normal users, `ENABLE_DEVELOPMENT_MODE_UI` should be `False` so the experimental auth UI and runtime behavior stay hidden.
 :::
 
-## Step 2 - Confirm the integration exposes auth controls
+## Step 2 - Confirm the integration exposes pairing controls
 
 After Home Assistant restarts:
 
-1. Open **Settings**
-2. Go to **Devices & services**
-3. Open **F1 Sensor**
-4. Select **Reconfigure**
-5. Confirm that the live timing authorization field is visible
+1. Open **Settings**.
+2. Go to **Devices & services**.
+3. Open **F1 Sensor**.
+4. Select **Reconfigure**.
+5. Confirm that **Connect F1TV access with Token Helper** is available.
 
-The field may be named **Live timing authorization value**.
-It expects a value in this exact format:
-
-```text
-Bearer <JWT>
-```
-
-Do not include the `Authorization:` prefix in this field.
-
-Leave the field empty if you want to keep using public live timing only.
+Manual `Bearer <JWT>` paste remains available only as an advanced fallback in development-gated builds.
+The normal test flow should use the helper pairing option.
 
 ## Step 3 - Enable debug logging
 
@@ -154,15 +150,17 @@ logger:
 Restart Home Assistant after changing the logger configuration.
 
 When you collect logs, use **Settings** → **System** → **Logs**, then select **Show raw logs** from the menu.
+
 :::warning
-Never share a raw token, a full `Authorization` header, cookies, or browser session data in an issue, screenshot, log excerpt, or discussion post.
+Never share a raw token, a full `Authorization` header, cookies, nonce values, callback bodies, or browser session data in an issue, screenshot, log excerpt, or discussion post.
 Redact secrets before sharing logs.
 :::
 
 ## Step 4 - Build the F1TV Token Helper
 
-The token helper is a separate local tool.
-It does not write directly to Home Assistant and does not send your token to a project server.
+The token helper is a separate local extension while the Chrome Web Store beta is under review.
+It sends your token only to the Home Assistant callback URL created by the pairing flow and does not send your token to a project server.
+
 Use the [F1TV Token Helper repository](https://github.com/Nicxe/f1tv-token-helper) for the latest setup instructions and source code.
 
 From the helper repository:
@@ -183,50 +181,45 @@ The built extension is created in the `dist/` folder inside your local helper fo
 
 Load the helper as a local unpacked extension:
 
-1. Open Chrome
-2. Go to `chrome://extensions`
-3. Select **Load unpacked**
-4. Select the local `dist/` folder inside your F1TV Token Helper repository
+1. Open Chrome.
+2. Go to `chrome://extensions`.
+3. Enable **Developer mode**.
+4. Select **Load unpacked**.
+5. Select the local `dist/` folder inside your F1TV Token Helper repository.
 
-## Step 6 - Fetch a token
+After the Chrome Web Store beta is approved, install the helper from the store link instead of using **Load unpacked**.
 
-Use the helper from the same browser where you sign in to Formula 1:
-
-1. Sign in to the official Formula 1 site in Chrome
-2. Open the **F1TV Token Helper** extension popup
-3. Select **Fetch**
-4. Confirm that the helper shows a valid token status and expiry
-5. Select **Copy HA value**
-
-The copied value should look like this:
-
-```text
-Bearer <JWT>
-```
-
-The helper may also support downloading a text file containing the full header:
-
-```text
-Authorization: Bearer <JWT>
-```
-
-Use only the `Bearer <JWT>` part in Home Assistant.
-
-## Step 7 - Add the token to F1 Sensor
+## Step 6 - Start pairing from Home Assistant
 
 In Home Assistant:
 
-1. Open **Settings**
-2. Go to **Devices & services**
-3. Open **F1 Sensor**
-4. Select **Reconfigure**
-5. Paste the copied `Bearer <JWT>` value into **Live timing authorization value**
-6. Keep **Operation mode** set to **Live** when testing real live timing
-7. Submit the form
+1. Open **Settings**.
+2. Go to **Devices & services**.
+3. Open **F1 Sensor**.
+4. Select **Reconfigure**.
+5. Select **Connect F1TV access with Token Helper**.
+6. Select **Open website** when Home Assistant shows the external step.
 
-Restart Home Assistant if your test build does not reload the integration automatically.
+Home Assistant opens the [F1TV Token Helper pairing page](/help/f1tv-token-helper).
+Keep that tab open and active before opening the extension.
 
-The integration should store the token as an authorization value and use it only when the development gate allows auth transport.
+Pairing sessions are short-lived.
+If the helper says the pairing expired, return to Home Assistant and start the pairing again.
+
+## Step 7 - Send F1TV access to Home Assistant
+
+Use the helper from the same browser where you sign in to Formula 1:
+
+1. Keep the pairing page as the active tab.
+2. Open the **F1TV Token Helper** extension popup.
+3. If the helper says no token is available, select **Sign in** and sign in to Formula 1.
+4. Return to the helper and select **Fetch**.
+5. When the helper is ready, select **Send to Home Assistant**.
+
+The helper stores only the Home Assistant pairing session temporarily while you sign in.
+It does not store the F1TV token permanently.
+
+Home Assistant should finish the pairing, save the live timing authorization value, and reload the integration.
 
 ## Step 8 - Understand token lifetime
 
@@ -258,153 +251,29 @@ sensor.f1_track_status
 sensor.f1_session_status
 sensor.f1_race_control
 sensor.f1_driver_positions
-sensor.f1_current_tyres
 ```
 
-Public live timing must keep working even when:
+Then confirm that F1TV-only data becomes available only after a valid helper pairing.
 
-1. No token is configured
-2. The token expires
-3. The token is rejected by the live timing server
+## Troubleshooting
 
-This fallback behavior is the most important part of the test.
+### The helper does not show Home Assistant pairing
 
-## Step 10 - Verify auth behavior
+Keep the pairing page as the active tab and open the helper again.
+If that does not work, copy the full browser URL from the pairing page, open **Pairing link** in the helper, paste the URL, and select **Connect**.
 
-With a valid token configured and `ENABLE_DEVELOPMENT_MODE_UI = True`, start live timing during a real session and check for these behaviors:
+### The helper opens but only manual export is available
 
-1. The integration connects to live timing without logging the token
-2. The connection uses the saved `Bearer <JWT>` value internally
-3. Public live entities continue to update
-4. F1TV-only live data becomes available where the current build supports it
-5. The token status entity or diagnostics show only safe metadata, such as status and expiry
+Make sure you are using F1 Sensor `v4.3.0-beta.2` or later and that you started **Connect F1TV access with Token Helper** from Home Assistant.
+Older beta builds did not include the pairing callback flow.
 
-Depending on the test build, useful entities may include:
+### Home Assistant rejects the pairing
 
-```text
-sensor.f1_f1tv_token_status
-sensor.f1_f1tv_token_expires_at
-sensor.f1_championship_prediction_drivers
-sensor.f1_championship_prediction_teams
-sensor.f1_team_radio
-sensor.f1_pitstops
-binary_sensor.f1_formation_start
-```
+Start a new pairing session in Home Assistant.
+The old session may have expired, already been used, or been created before Home Assistant was restarted.
 
-Entity IDs can differ if your installation already has renamed entities.
-Search for the `f1_` suffix or the documented entity name in **Settings** → **Devices & services** → **Entities**.
+### Public live timing stops working
 
-For auth-gated entities, verify three states separately:
-
-1. They are unavailable in public live timing without a valid token
-2. Replay-capable entities can update during Replay Mode
-3. They can update during auth-enabled live timing when Formula 1 provides the streams
-
-## Step 11 - Test token replacement
-
-Tokens are short-lived.
-When Home Assistant reports that the token is expiring soon, expired, invalid, or rejected, generate a new one with the helper and replace the old value.
-
-1. Sign in to Formula 1 again if needed
-2. Open the helper popup
-3. Select **Fetch**
-4. Select **Copy HA value**
-5. Open **F1 Sensor** → **Reconfigure**
-6. Paste the new `Bearer <JWT>` value
-7. Submit the form
-
-The integration should accept a valid replacement token and continue without requiring a full reinstall.
-
-If the token is expired, malformed, missing an expiry, or too close to expiry, the form should reject it with a clear error.
-
-## Step 12 - Test clearing auth
-
-Clearing the token should return the integration to public live timing.
-
-1. Open **F1 Sensor** → **Reconfigure**
-2. Select **Clear live timing authorization value**
-3. Submit the form
-4. Restart or reload the integration if needed
-5. Confirm that public live timing still works
-
-After clearing the token, F1TV-only live data should become unavailable, but normal public live timing should continue.
-
-## Step 13 - Test auth failure handling
-
-Use this only in a disposable test setup.
-The goal is to confirm that broken auth does not break public live timing.
-
-You can test with:
-
-1. An expired token
-2. A malformed `Bearer` value
-3. A valid-looking token that the live timing server rejects
-
-Expected behavior:
-
-| Failure | Expected result |
-| --- | --- |
-| Missing token | Public live timing only |
-| Malformed token | Form error or invalid token status |
-| Expired token | Repair or reauth prompt, public live timing continues |
-| Server rejects token | Downgrade to public live timing and request token refresh |
-
-When auth fails, auth-gated live entities such as Championship Prediction, Team Radio, and Pit Stops should become unavailable or stop receiving F1TV-only updates, while public live timing continues.
-The integration must not retry aggressively, spam repairs, or make the full integration unavailable because auth fails.
-
-## Step 14 - Review diagnostics safely
-
-Diagnostics are useful for testing, but they must not expose secrets.
-
-When you download diagnostics or copy debug information, confirm that the output does not contain:
-
-```text
-Bearer
-Authorization
-subscriptionToken
-login-session
-JWT payload that identifies you
-F1TV email or account identity
-```
-
-Safe diagnostics may include:
-
-```text
-auth_configured: true
-status: valid
-status: expired
-expires_at: 2026-04-23T12:34:56+00:00
-used_for_live_timing: true
-```
-
-If diagnostics expose the token or any browser session value, stop testing and report it privately.
-
-## Good test report format
-
-When reporting experimental auth results, include:
-
-1. F1 Sensor version or branch
-2. Home Assistant version
-3. Whether `ENABLE_DEVELOPMENT_MODE_UI` was `True` or `False`
-4. Whether you used Live mode or Development replay mode
-5. Whether the token was valid, expired, rejected, or cleared
-6. Which entities updated and which stayed unavailable
-7. Relevant redacted log lines
-8. The exact session you tested, such as race, qualifying, sprint, or practice
-
-Do not include the token, full auth header, cookies, screenshots of the helper showing secrets, or unredacted diagnostics.
-
-## What must always remain true
-
-Use this checklist before you mark an auth test as successful:
-
-1. F1 Sensor still works without F1TV authentication
-2. Public live timing still updates without a token
-3. A valid token enables only the supported F1TV-auth test behavior
-4. An expired or rejected token downgrades to public live timing
-5. No token appears in logs, diagnostics, entities, repairs, or issue reports
-6. The helper does not store the token permanently or send it to a project server
-7. Home Assistant never asks for your F1TV password
-
-For broader beta participation, see [BETA-test](/help/beta-tester).
-For replay-based testing without F1TV authentication, see [Replay Mode](/features/replay-mode).
+That is a bug.
+F1TV auth failure should downgrade only the extra F1TV-authenticated streams.
+Public live timing should continue without a token.


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 📋 Blueprint (new or updated blueprint)
- [X] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
