### PR TITLE
docs: Update to F1TV Auth

### DIFF
--- a/docs/help/beta-tester.md
+++ b/docs/help/beta-tester.md
@@ -1,229 +1,131 @@
 ---
 id: beta-tester
-title: BETA-test
+title: Beta Testing
 ---
 
-Do you want to help shape the future of this integration?
-By becoming a beta tester, you play an active role in improving functionality, stability, and overall user experience.
+Beta testing lets you try new F1 Sensor behavior before it is part of a stable release.
+Use this page if you want to test beta versions, report problems clearly, or help validate fixes.
+
 :::danger[Important recommendations]
-
-Beta versions are not guaranteed to be stable. For that reason:
-* Do not install beta versions in your production Home Assistant instance
-* Use a separate test environment, development instance, or secondary Home Assistant setup
-* Expect breaking changes, incomplete features, and temporary limitations
-
-If something breaks, that is part of the process, and also where your contribution is most valuable.
+Beta versions are not guaranteed to be stable.
+Do not install beta versions in your production Home Assistant instance.
+Use a separate test environment, development instance, or secondary Home Assistant setup where restarts and temporary issues are acceptable.
 :::
-
 
 ## What it means to be a beta tester
 
-#### As a beta tester, you help by:
-* Testing new features before they are officially released
-* Identifying bugs, regressions, or unexpected behavior
-* Providing feedback and improvement suggestions
-* Creating clear and well described GitHub issues
-* Following up on reported issues and re testing fixes when needed
+As a beta tester, you help by:
 
-Your input directly influences how the integration evolves.
+1. Testing new features before they are officially released.
+2. Identifying bugs, regressions, or unexpected behavior.
+3. Providing feedback and improvement suggestions.
+4. Creating clear and well-described GitHub issues.
+5. Following up on reported issues and retesting fixes when needed.
 
+You do not need to be a developer, but it helps if you have basic Home Assistant knowledge, can read logs, and can describe problems with enough context to reproduce them.
 
-### What we expect from beta testers
+## Install a beta version
 
-You do not need to be a developer, but it helps if you:
-* Have basic knowledge of Home Assistant and custom integrations
-* Are comfortable reading logs and enabling debug logging
-* Can describe problems clearly and provide relevant context
-* Are willing to test specific scenarios or edge cases when requested
+To test the latest beta version, install it through HACS by redownloading the integration and selecting the beta release.
 
-Being a good beta tester is less about finding problems accidentally and more about testing intentionally.
+1. Open **Home Assistant**.
+2. Open **HACS**.
+3. Go to **Integrations**.
+4. Open **F1 Sensor**.
+5. Select the three-dot menu in the top right corner.
+6. Select **Redownload**.
+7. Choose the latest beta version from the version list.
+8. Confirm and complete the installation.
+9. Restart Home Assistant.
 
-### How to contribute effectively
-
-To make the beta process productive:
-* Always include version numbers and environment details in issues
-* Attach logs or error messages when reporting problems
-* Describe what you expected to happen versus what actually happened
-* Test fixes or new releases and confirm whether issues are resolved
-
-Clear feedback saves time and helps deliver a better integration for everyone.
-
-### Why join?
-* Early access to new features
-* Direct influence on design and behavior
-* A chance to help improve the integration for the entire community
-* Collaboration with others who care about quality and reliability
-
-If this sounds like something you want to be part of, you are very welcome to join as a beta tester and help move the integration forward.
-
----
-
-## Install and prepair for BETA 
-
-### BETA in HACS
-
-To test the latest beta version of the integration, you install it directly through HACS by re downloading the integration and selecting the beta release.
-
-**Step by step**
-	1.	Open Home Assistant
-	2.	Go to HACS
-	3.	Select Integrations F1 Sensor
-	4.	Find and open this integration in the list
-	5.	Click the three dots in the top right corner
-	6.	Select Redownload
-	7.	In the version list, choose the latest beta version
-	8.	Confirm and complete the installation
-
-**After installation**
-* Restart Home Assistant to ensure the beta version is fully loaded
-* Verify the installed version under the integration details
-* Enable debug logging if you plan to report issues
+After installation, verify the installed version under the integration details.
+Enable debug logging if you plan to report issues.
 
 :::warning
-* Beta versions may contain unfinished features or breaking changes
-* Do not install beta versions in a production Home Assistant instance
-* Always read the release notes before updating, especially for beta releases
+Always read the release notes before updating to a beta release.
+Beta releases may include unfinished behavior, temporary limitations, or changes that need extra validation.
 :::
 
-### Enable Debug Logging
+## Enable debug logging
 
-To help with troubleshooting and bug reporting, you may be asked to enable debug logging for the integration. This makes it easier to understand what happens internally and to identify issues.
+Debug logs are often required when you report beta issues.
+Follow [Debug Logging and Logs](/help/debug-logging) before reproducing the problem.
 
-Add the following to your ```configuration.yaml```
-```yaml
-logger:
-  default: warning
-  logs:
-    custom_components.f1_sensor: debug
-```
+## Test Development replay mode
 
-After enabling debug logging
-* Reproduce the issue you are testing or reporting
-* Open Settings → System → Logs
-* Press the three dots in rigt top corner and select "Show raw logs"
-* Copy relevant log entries related to f1_sensor
-
-![Show Raw logs](/img/raw_logs.png)
-
-When creating a GitHub issue, include:
-* What you were doing when the issue occurred
-* What you expected to happen
-* Relevant debug log output
-:::warning
-Debug logging can generate a lot of log data. Disable debug logging once you are done testing to keep logs clean
-:::
-
-
----
-
-## Enable Development (Replay) Mode
-
-Development mode allows you to run the integration in a replay environment using recorded live timing data. This is primarily intended for development, debugging, and beta testing, without relying on an active Formula 1 session.
-
-
-
+Development replay mode lets you run the integration with recorded live timing data.
+This is useful for testing dashboards, automations, and entity behavior without waiting for an active Formula 1 session.
 
 ### About replay dumps
 
-The replay dump is a real time recording of a live session. This means:
-* All timing between events is preserved
-* Delays between updates are exactly the same as during the real session
-* A full replay can take up to three hours to complete
+A replay dump is a real-time recording of a live session.
+Timing between events is preserved, so a full replay can take up to three hours to complete.
 
-The replay usually starts with a ```pre``` session phase, where data such as weather and session metadata are updated continuously. When the session goes ```live```, cars begin running and other sensors, such as tyres, laps, and timing, become active.
+The replay usually starts with a `pre` session phase where weather and session metadata update continuously.
+When the session goes `live`, cars begin running and other sensors such as tyres, laps, and timing become active.
 
-This makes the replay behavior as close to a real live session as possible and is ideal for testing logic, automations, and UI behavior over time.
-
-
-### Available replay dumps
-
-Below are example replay dumps from different sessions during the 2025 season that can be used for testing. Each dump represents a specific session and can be replayed independently by updating the replay dump path.
-
-More dumps may be added over time as additional sessions are recorded and prepared for testing.
 :::tip[Replay dumps]
-You can find the Replay dumps **[here](https://github.com/Nicxe/f1_sensor/tree/develop/replay_dumps)**
+You can find replay dumps in the [F1 Sensor repository](https://github.com/Nicxe/f1_sensor/tree/develop/replay_dumps).
 :::
 
+### Step 1 - Enable replay mode
 
-### How to enable development mode
-1.	Open Home Assistant
-2.	Go to Settings → Devices & services
-3.	Select F1 Sensor
-4.	Click Configure
-5.	Set Operation mode to Development
-6.	Enter the absolute file path to your replay dump in Replay dump path
-7.	Submit the form
+1. Open **Home Assistant**.
+2. Go to **Settings**.
+3. Open **Devices & services**.
+4. Select **F1 Sensor**.
+5. Select **Configure**.
+6. Set **Operation mode** to **Development**.
+7. Enter the absolute file path to your replay dump in **Replay dump path**.
+8. Submit the form.
 
 The integration reloads immediately.
 
 ![Development mode](/img/dev_mode.png)
 
+### Step 2 - Verify replay mode
 
-To verify that replay mode is active, check the logs for the message:
+Check the logs for this message:
 
-```Starting F1 Sensor in development replay mode```
+```text
+Starting F1 Sensor in development replay mode
+```
 
-*If the replay dump path is missing, invalid, or unreadable, the integration will automatically fall back to the live SignalR connection.*
+If the replay dump path is missing, invalid, or unreadable, the integration falls back to the live SignalR connection.
 
+## Report issues and feedback
 
+Clear issue reports are essential for improving the integration.
+Use GitHub Issues for bugs, errors, and broken functionality:
 
----
+```text
+https://github.com/Nicxe/f1_sensor/issues
+```
 
-## Reporting Issues and Providing Feedback
+Use GitHub Discussions for questions, ideas, and general feedback:
 
-Clear and well structured issue reports are essential for improving the integration. If you encounter a bug, unexpected behavior, or regression, please report it using GitHub Issues.
+```text
+https://github.com/Nicxe/f1_sensor/discussions/190
+```
 
-### Where to report issues
-
-**Bugs, errors, and broken functionality**
-
-Report these in Issues: https://github.com/Nicxe/f1_sensor/issues
-
-**Questions, ideas, and general discussions.**
-
-Use Discussions instead: https://github.com/Nicxe/f1_sensor/discussions/190
-:::info[PLEASE]
-Using the correct channel helps keep development focused and efficient.
-:::
-
-### How to write a good issue
-
-When creating an issue, be as detailed as possible. A good issue report should include:
-* The exact version of the integration
-* Your Home Assistant version
-* Whether you are running Live or Development (replay) mode
-* A clear description of the problem
-* What you expected to happen
-* What actually happened
-
-#### Logs and diagnostics
-
-Whenever possible, attach:
-* Relevant debug logs
-* Error messages or stack traces
-* Timestamps for when the issue occurred
-
-Logs are often the key to understanding what went wrong.
-
-#### Screenshots and additional context
-
-Screenshots, screen recordings, or UI examples are strongly encouraged when relevant.
-They help illustrate issues with:
-* Sensor states
-* Dashboards
-* Timing or visual behavior
-
-Any additional context that helps reproduce the issue is valuable.
-
-#### Follow up and re testing
-
-As a beta tester, you may be asked to:
-* Test a proposed fix
-* Verify that an issue is resolved in a new release
-* Provide feedback on changes or behavior
 :::info
-Following up on your own issues helps close them faster and improves quality for everyone.
+Using the correct channel helps keep development focused and easier to follow.
 :::
 
+## Write a useful issue
 
-Thank you for helping improve the integration and for taking the time to report issues clearly and thoughtfully.
+When creating an issue, include:
+
+1. The exact F1 Sensor version.
+2. Your Home Assistant version.
+3. Whether you are running Live mode or Development replay mode.
+4. Whether you are using a beta release or F1TV Auth.
+5. A clear description of the problem.
+6. What you expected to happen.
+7. What actually happened.
+8. Relevant debug logs from [Debug Logging and Logs](/help/debug-logging).
+
+Screenshots, screen recordings, or dashboard examples are helpful when they show sensor states, timing behavior, or visual problems.
+
+As a beta tester, you may be asked to test a proposed fix, verify a new release, or provide more details.
+Following up on your own issues helps close them faster.

--- a/docs/help/debug-logging.md
+++ b/docs/help/debug-logging.md
@@ -1,0 +1,99 @@
+---
+id: debug-logging
+title: Debug Logging and Logs
+---
+
+Debug logging helps you collect useful information when F1 Sensor does not behave as expected.
+Use this page when you are asked to provide logs for a GitHub issue, beta test, replay test, or F1TV Auth problem.
+
+:::warning
+Never share F1TV tokens, full `Authorization` headers, cookies, callback URLs, nonce values, or browser session data in an issue, screenshot, log excerpt, or discussion post.
+Redact secrets before sharing logs.
+:::
+
+## Enable debug logging
+
+Home Assistant can enable debug logging for an integration from the UI.
+Use this flow first when you are collecting logs for an issue:
+
+1. Open **Settings**.
+2. Go to **Devices & services**.
+3. Open **F1 Sensor**.
+4. Select the three-dot menu.
+5. Select **Enable debug logging**.
+
+After debug logging is enabled, reproduce the issue before you disable it again.
+
+:::tip
+When you disable debug logging from the same menu, Home Assistant downloads a debug log file automatically.
+Attach that file to the issue after you remove any secrets.
+:::
+
+## Enable debug logging with YAML
+
+Use YAML only if the UI option is not available, if you need debug logging to start during Home Assistant startup, or if you are asked to keep debug logging enabled across a restart.
+
+Add this to your Home Assistant `configuration.yaml`:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.f1_sensor: debug
+```
+
+Restart Home Assistant after changing the logger configuration.
+
+:::tip
+Enable debug logging before you reproduce the issue.
+Logs are most useful when they include the full sequence from setup, reload, or the failing action.
+:::
+
+## Reproduce the problem
+
+After Home Assistant restarts:
+
+1. Reproduce the issue you are testing or reporting.
+2. Note the approximate time when it happened.
+3. Note the installed F1 Sensor version.
+4. Note whether the integration is running in **Live** mode or **Development** replay mode.
+5. Note whether F1TV Auth was connected, expired, rejected, or not configured.
+
+These details make it easier to match log entries to the behavior you saw.
+
+## Find raw logs
+
+Use Home Assistant raw logs if you need to copy a smaller log excerpt manually.
+
+1. Open **Settings**.
+2. Go to **System**.
+3. Open **Logs**.
+4. Select the three-dot menu in the top right corner.
+5. Select **Show raw logs**.
+6. Copy the relevant entries around the time the issue happened.
+
+![Show raw logs](/img/raw_logs.png)
+
+## What to include in an issue
+
+When you create a GitHub issue, include:
+
+1. The F1 Sensor version.
+2. Your Home Assistant version.
+3. Whether you are using a beta release.
+4. Whether you are using Live mode, Development replay mode, or F1TV Auth.
+5. What you expected to happen.
+6. What actually happened.
+7. Relevant debug log output with secrets removed.
+
+Logs are often the key to understanding setup failures, token problems, replay behavior, and unexpected entity updates.
+
+## Disable debug logging
+
+Debug logging can generate a lot of log data.
+Disable it when you are done testing.
+
+If you enabled debug logging from the UI, return to **Settings** → **Devices & services**, open **F1 Sensor**, select the three-dot menu, and select **Disable debug logging**.
+Home Assistant downloads the debug log file when debug logging is disabled.
+
+If you enabled debug logging with YAML, remove the `custom_components.f1_sensor: debug` entry from `configuration.yaml`, then restart Home Assistant.

--- a/docs/help/experimental-testing.md
+++ b/docs/help/experimental-testing.md
@@ -1,30 +1,29 @@
 ---
 id: experimental-testing
-title: Experimental Testing
+title: F1TV Auth Testing
 ---
 
-Experimental testing is for power users who want to validate F1TV authenticated live timing before it is made available as a normal user-facing feature.
-Use this page when you are testing the development-gated authentication flow, the F1TV Token Helper, token expiry handling, and the fallback to public live timing.
+F1TV Auth testing lets you validate authenticated live timing data with your own Formula 1 browser session.
+Use this page when you are testing the F1TV Token Helper pairing flow, token expiry handling, and the fallback to public live timing.
 
-:::danger[Test environment only]
-Do not test F1TV authentication in your production Home Assistant instance.
-Use a separate Home Assistant test instance, development container, VM, or secondary setup where restarts, broken entities, and temporary configuration changes are acceptable.
+:::danger[Test environment recommended]
+Beta features can change quickly and may not be stable.
+Use a separate Home Assistant test instance, development container, VM, or secondary setup when you test new F1TV Auth behavior.
 :::
 
 ## What you are testing
 
 F1 Sensor works without F1TV authentication by using public live timing streams.
-The experimental authentication flow adds a short-lived F1TV live timing authorization value so the integration can test extra live timing streams during an active Formula 1 session.
+F1TV Auth adds a short-lived live timing authorization value so the integration can test extra F1TV-authenticated streams during an active Formula 1 session.
 
-The current testing flow uses Home Assistant pairing:
+The current beta flow uses Home Assistant pairing:
 
-1. Enable the development-gated controls in the integration code.
-2. Install or update F1 Sensor `v4.3.0-beta.2` or later in Home Assistant.
-3. Install the separate [F1TV Token Helper](https://github.com/Nicxe/f1tv-token-helper) as a local browser extension while the Chrome Web Store beta is under review.
-4. Start **Connect F1TV access with Token Helper** in Home Assistant.
-5. Open the pairing page from Home Assistant.
-6. Open the helper extension, sign in to Formula 1 if needed, select **Fetch**, then select **Send to Home Assistant**.
-7. Verify that public live timing still works and that F1TV-only live data is enabled when the token is valid.
+1. Install or update F1 Sensor `v4.3.0-beta.3` or later in Home Assistant.
+2. Install **F1TV Token Helper BETA** from the [Chrome Web Store](https://chromewebstore.google.com/detail/f1tv-token-helper-beta/bbpgdcjohdjcechlffloekhpgdbjoafh).
+3. Start **Connect F1TV access with Token Helper** in Home Assistant.
+4. Open the pairing page from Home Assistant.
+5. Open the helper extension, sign in to Formula 1 if needed, select **Fetch**, then select **Send to Home Assistant**.
+6. Verify that public live timing still works and that F1TV-only live data is enabled when the token is valid.
 
 :::info
 This flow does not ask Home Assistant for your F1TV username or password.
@@ -33,10 +32,8 @@ The token is extracted from your own browser session by the separate helper and 
 
 ## Current limitations
 
-This is not normal beta testing.
-It is a development-gated authentication test path for advanced users who are comfortable editing local integration files, reading Home Assistant logs, and replacing short-lived tokens.
-
-The current experimental scope is:
+This is still beta testing.
+The feature is intended for users who are comfortable reading Home Assistant logs, reporting clear issues, and replacing short-lived tokens when needed.
 
 | Area | Expected behavior |
 | --- | --- |
@@ -46,11 +43,11 @@ The current experimental scope is:
 | Token renewal | Not automatic |
 | F1TV password | Never entered into Home Assistant |
 | Helper | Separate Chrome or Chromium extension |
-| Chrome Web Store | Submitted for unlisted beta review, not available until approved |
+| Chrome Web Store | Published as an unlisted beta |
 | Auth failure | Downgrades to public live timing |
 | Auth-gated live data | Requires a valid token during live sessions |
 
-The first authentication MVP is intended to test these auth-gated live streams:
+The first authentication beta is intended to test these auth-gated live streams:
 
 ```text
 CarData.z
@@ -75,121 +72,45 @@ If the token is missing, expired, or rejected, auth-gated live data should becom
 Before you start, make sure you have:
 
 1. A non-production Home Assistant instance.
-2. F1 Sensor `v4.3.0-beta.2` or later installed.
+2. F1 Sensor `v4.3.0-beta.3` or later installed.
 3. Access to Home Assistant logs.
 4. A Formula 1 account with the required F1TV access for live timing.
-5. Chrome or another Chromium-based browser for the helper extension.
-6. Node.js 22 or newer for local helper builds while the Chrome Web Store beta is under review.
-7. The [F1TV Token Helper](https://github.com/Nicxe/f1tv-token-helper) repository cloned or unpacked locally.
+5. Chrome or another Chromium-based browser.
+6. The [F1TV Token Helper BETA](https://chromewebstore.google.com/detail/f1tv-token-helper-beta/bbpgdcjohdjcechlffloekhpgdbjoafh) extension installed.
 
-The helper can be stored anywhere on your computer.
-In the examples below, replace this path with the folder where you cloned or unpacked the repository:
+Enable debug logging before testing if you plan to report issues.
+See [Debug Logging and Logs](/help/debug-logging) for the recommended logging setup and log collection steps.
 
-```text
-/path/to/f1tv-token-helper
-```
+## Step 1 - Install the beta version
 
-The integration test copy may be in your Home Assistant custom components directory, for example:
+Install F1 Sensor `v4.3.0-beta.3` or later through HACS.
 
-```text
-/Volumes/config/custom_components/f1_sensor
-```
+1. Open **HACS** in Home Assistant.
+2. Open **F1 Sensor**.
+3. Select the three-dot menu.
+4. Select **Redownload**.
+5. Choose the latest beta version.
+6. Restart Home Assistant after the installation completes.
 
-Adjust the paths if your test environment uses different locations.
+After Home Assistant restarts, verify that the installed version is `v4.3.0-beta.3` or later.
 
-## Step 1 - Enable the development gate
+## Step 2 - Install the helper from Chrome Web Store
 
-F1TV authentication is hidden behind the development UI gate.
-The test build must expose development controls before the pairing option appears in setup or reconfigure.
-
-Open the integration `const.py` file in the Home Assistant test copy:
+Install **F1TV Token Helper BETA** from the Chrome Web Store:
 
 ```text
-custom_components/f1_sensor/const.py
+https://chromewebstore.google.com/detail/f1tv-token-helper-beta/bbpgdcjohdjcechlffloekhpgdbjoafh
 ```
 
-Set the development gate to `True`:
+The Chrome Web Store version is the recommended testing path.
+You do not need to enable Chrome developer mode or load an unpacked extension for normal beta testing.
 
-```python
-ENABLE_DEVELOPMENT_MODE_UI = True
-```
-
-Save the file and restart Home Assistant.
-
-:::warning
-Released builds should keep this gate disabled.
-For normal users, `ENABLE_DEVELOPMENT_MODE_UI` should be `False` so the experimental auth UI and runtime behavior stay hidden.
+:::tip
+Use the local developer installation only if you are working on the helper extension itself or testing an unpublished helper build.
+The extension repository keeps that workflow documented in its README.
 :::
 
-## Step 2 - Confirm the integration exposes pairing controls
-
-After Home Assistant restarts:
-
-1. Open **Settings**.
-2. Go to **Devices & services**.
-3. Open **F1 Sensor**.
-4. Select **Reconfigure**.
-5. Confirm that **Connect F1TV access with Token Helper** is available.
-
-Manual `Bearer <JWT>` paste remains available only as an advanced fallback in development-gated builds.
-The normal test flow should use the helper pairing option.
-
-## Step 3 - Enable debug logging
-
-Enable debug logging before testing so you can verify connection behavior and report useful issues.
-
-Add this to `configuration.yaml`:
-
-```yaml
-logger:
-  default: warning
-  logs:
-    custom_components.f1_sensor: debug
-```
-
-Restart Home Assistant after changing the logger configuration.
-
-When you collect logs, use **Settings** → **System** → **Logs**, then select **Show raw logs** from the menu.
-
-:::warning
-Never share a raw token, a full `Authorization` header, cookies, nonce values, callback bodies, or browser session data in an issue, screenshot, log excerpt, or discussion post.
-Redact secrets before sharing logs.
-:::
-
-## Step 4 - Build the F1TV Token Helper
-
-The token helper is a separate local extension while the Chrome Web Store beta is under review.
-It sends your token only to the Home Assistant callback URL created by the pairing flow and does not send your token to a project server.
-
-Use the [F1TV Token Helper repository](https://github.com/Nicxe/f1tv-token-helper) for the latest setup instructions and source code.
-
-From the helper repository:
-
-```bash
-cd /path/to/f1tv-token-helper
-npm ci
-npm run build
-```
-
-The built extension is created in the `dist/` folder inside your local helper folder:
-
-```text
-/path/to/f1tv-token-helper/dist
-```
-
-## Step 5 - Load the helper in Chrome
-
-Load the helper as a local unpacked extension:
-
-1. Open Chrome.
-2. Go to `chrome://extensions`.
-3. Enable **Developer mode**.
-4. Select **Load unpacked**.
-5. Select the local `dist/` folder inside your F1TV Token Helper repository.
-
-After the Chrome Web Store beta is approved, install the helper from the store link instead of using **Load unpacked**.
-
-## Step 6 - Start pairing from Home Assistant
+## Step 3 - Start pairing from Home Assistant
 
 In Home Assistant:
 
@@ -206,7 +127,7 @@ Keep that tab open and active before opening the extension.
 Pairing sessions are short-lived.
 If the helper says the pairing expired, return to Home Assistant and start the pairing again.
 
-## Step 7 - Send F1TV access to Home Assistant
+## Step 4 - Send F1TV access to Home Assistant
 
 Use the helper from the same browser where you sign in to Formula 1:
 
@@ -221,13 +142,12 @@ It does not store the F1TV token permanently.
 
 Home Assistant should finish the pairing, save the live timing authorization value, and reload the integration.
 
-## Step 8 - Understand token lifetime
+## Step 5 - Understand token lifetime
 
 F1TV tokens are short-lived.
 They are usually valid for only a few days, so you should expect to repeat the helper flow and replace the saved token when it expires.
 
-The integration should tell you when the saved token needs attention.
-It also exposes two helper sensors so you can monitor token health from Home Assistant:
+The integration exposes two helper sensors so you can monitor token health from Home Assistant:
 
 ```text
 sensor.f1_f1tv_token_status
@@ -240,7 +160,7 @@ Use `sensor.f1_f1tv_token_expires_at` to see when the current token expires.
 When the token expires or is rejected, public live timing should continue to work.
 Only the F1TV-authenticated live data needs a fresh token.
 
-## Step 9 - Verify public fallback first
+## Step 6 - Verify public fallback first
 
 Before relying on auth-only behavior, confirm that public live timing still works.
 
@@ -264,8 +184,8 @@ If that does not work, copy the full browser URL from the pairing page, open **P
 
 ### The helper opens but only manual export is available
 
-Make sure you are using F1 Sensor `v4.3.0-beta.2` or later and that you started **Connect F1TV access with Token Helper** from Home Assistant.
-Older beta builds did not include the pairing callback flow.
+Make sure you are using F1 Sensor `v4.3.0-beta.3` or later and that you started **Connect F1TV access with Token Helper** from Home Assistant.
+Older beta builds did not include the normal pairing flow.
 
 ### Home Assistant rejects the pairing
 

--- a/docs/help/f1tv-token-helper.md
+++ b/docs/help/f1tv-token-helper.md
@@ -7,7 +7,7 @@ F1TV Token Helper connects your own Formula 1 browser session to F1 Sensor throu
 Use this page when Home Assistant opens an external website while you are connecting F1TV access.
 
 :::warning[Experimental feature]
-F1TV access is currently available only in development-gated test builds.
+F1TV access is currently a beta feature and requires F1 Sensor `v4.3.0-beta.3` or later.
 Public live timing continues to work without F1TV access.
 :::
 
@@ -15,6 +15,8 @@ Public live timing continues to work without F1TV access.
 
 The helper reads the F1TV live timing token from your local browser session and sends it to your own Home Assistant instance.
 It does not ask for your Formula 1 password, does not send the token to a project server, and does not make F1TV access required for public live timing.
+
+Install the helper from the [Chrome Web Store](https://chromewebstore.google.com/detail/f1tv-token-helper-beta/bbpgdcjohdjcechlffloekhpgdbjoafh) before you start pairing from Home Assistant.
 
 ## Step-by-step
 
@@ -48,6 +50,8 @@ Home Assistant stores only the live timing authorization value it needs.
 If the token expires later, public live timing continues to work.
 
 ## Troubleshooting
+
+For Home Assistant debug logs, see [Debug Logging and Logs](/help/debug-logging).
 
 ### The helper does not show Home Assistant pairing
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,7 +23,7 @@ const sidebars = {
       items: ['entities/static-data', 'entities/live-data', 'entities/diagnostics', 'entities/events'],
     },
 
-   {
+    {
       type: 'doc',
       label: 'Automation',
       id: 'automation',
@@ -43,6 +43,12 @@ const sidebars = {
 
     {
       type: 'category',
+      label: 'Testing',
+      items: ['help/beta-tester', 'help/experimental-testing', 'help/debug-logging'],
+    },
+
+    {
+      type: 'category',
       label: 'Showcase',
       items: [
         'example/e-ink',
@@ -55,30 +61,23 @@ const sidebars = {
       ],
     },
 
-
-      {
+    {
       type: 'category',
       label: 'Need Help?',
       items: [
         'help/faq',
         'help/Issues',
         'help/contact',
-        'help/beta-tester',
-        'help/experimental-testing',
         'help/f1tv-token-helper',
         'help/f1tv-token-helper-privacy',
       ],
     },
-
 
     {
       type: 'doc',
       label: 'Support the project',
       id: 'support',
     },
-
-
-
   ],
 };
 


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 📋 Blueprint (new or updated blueprint)
- [X] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
