### PR TITLE
[codex] Mirror support intake prep onto dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -26,6 +26,20 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of F1 Sensor is affected?
+      options:
+        - Integration
+        - Live data card
+        - Blueprint
+        - Both integration and card
+        - Not sure
+    validations:
+      required: true
+
   - type: input
     id: device
     attributes:
@@ -54,8 +68,44 @@ body:
       label: System Architecture
       description: If running in Container or VM, what architecture is it?
       placeholder: e.g. aarch64, armv7, amd64
-    validations:
 
+  - type: dropdown
+    id: card_install_path
+    attributes:
+      label: Card Install Path
+      description: Only needed for live data card issues.
+      options:
+        - Bundled with F1 Sensor
+        - Standalone HACS dashboard repo
+        - Manual resource
+        - Not sure
+
+  - type: input
+    id: dashboard_resource_url
+    attributes:
+      label: Dashboard Resource URL
+      description: Only needed for live data card issues. Add the resource URL if it is visible in your dashboard resources.
+      placeholder: e.g. /local/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+
+  - type: input
+    id: browser_device
+    attributes:
+      label: Browser and Device
+      description: Only needed for live data card issues.
+      placeholder: e.g. Chrome on Windows, Safari on iPhone, Fully Kiosk on tablet
+
+  - type: textarea
+    id: screenshot_or_recording
+    attributes:
+      label: Screenshot or Screen Recording
+      description: Only needed for live data card display issues. Drag and drop images or recordings here.
+
+  - type: input
+    id: old_standalone_card_version
+    attributes:
+      label: Old Standalone Card Version
+      description: Only fill this in if the standalone HACS dashboard card is still installed.
+      placeholder: e.g. 1.4.0
 
   - type: textarea
     id: current_behavior

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -12,6 +12,20 @@ body:
         - label: All information in this issue is written in English. Issues containing non-English content will be closed without response.
           required: true
 
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of F1 Sensor would this improve?
+      options:
+        - Integration
+        - Live data card
+        - Blueprint
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
   - type: textarea
     id: problem
     attributes:

--- a/.github/workflows/issue-component-labeler.yml
+++ b/.github/workflows/issue-component-labeler.yml
@@ -1,0 +1,45 @@
+name: Label issues by component
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-component:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request == null
+    steps:
+      - name: Apply component labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const issueNumber = context.payload.issue.number;
+
+            const extractField = label => {
+              const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const pattern = new RegExp(`### ${escaped}\\s*\\n+([^#]+?)(?=\\n### |$)`, 'i');
+              const match = body.match(pattern);
+              return match ? match[1].trim() : '';
+            };
+
+            const component = extractField('Component').toLowerCase();
+            if (!component || component === 'not sure') return;
+
+            const labels = new Set();
+            if (component.includes('integration')) labels.add('integration');
+            if (component.includes('live data card') || component.includes('card')) labels.add('card');
+            if (component.includes('blueprint')) labels.add('blueprint');
+            if (component.includes('documentation') || component.includes('docs')) labels.add('documentation');
+
+            if (labels.size === 0) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: [...labels],
+            });

--- a/.github/workflows/issue-release-comment.yml
+++ b/.github/workflows/issue-release-comment.yml
@@ -28,25 +28,65 @@ jobs:
               return;
             }
 
-            let comment;
+            const cleanValue = v => {
+              const value = (v || '').trim();
+              return /^_?no response_?$/i.test(value) ? '' : value;
+            };
+            const extractField = (body, label) => {
+              const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const pattern = new RegExp(`### ${escaped}\\s*\\n+([^#]+?)(?=\\n### |$)`, 'i');
+              const match = (body || '').match(pattern);
+              return match ? cleanValue(match[1]) : '';
+            };
+            const isCardIssue = issue => {
+              const labels = issue.labels.map(label => label.name || label);
+              const component = extractField(issue.body, 'Component').toLowerCase();
+              return (
+                labels.includes('card') ||
+                component.includes('live data card') ||
+                component.includes('both integration and card') ||
+                extractField(issue.body, 'Old Standalone Card Version') !== ''
+              );
+            };
+            const buildComment = cardIssue => {
+              if (isPrerelease) {
+                const lines = [
+                  `A fix for this issue is now available in **[${releaseTag}](${releaseUrl})**, a BETA pre-release of F1 Sensor.`,
+                  '',
+                  'To test the beta version, open HACS in Home Assistant, go to **Integrations**, and find **F1 Sensor**. Click the three-dot menu and select **Redownload**. Make sure **Show beta versions** is enabled in the HACS settings for this integration. Alternatively, you can download the release manually from the [Releases page](' + releaseUrl + ').',
+                ];
 
-            if (isPrerelease) {
-              comment = [
-                `A fix for this issue is now available in **[${releaseTag}](${releaseUrl})**, a BETA pre-release of F1 Sensor.`,
-                '',
-                'To test the beta version, open HACS in Home Assistant, go to **Integrations**, and find **F1 Sensor**. Click the three-dot menu and select **Redownload**. Make sure **Show beta versions** is enabled in the HACS settings for this integration. Alternatively, you can download the release manually from the [Releases page](' + releaseUrl + ').',
-                '',
-                'Your feedback on the beta is very welcome \u2014 please report any issues you run into so they can be fixed before the stable release.',
-              ].join('\n');
-            } else {
-              comment = [
+                if (cardIssue) {
+                  lines.push(
+                    '',
+                    'For live data card fixes, restart Home Assistant after updating and reload your browser so the dashboard loads the latest bundled card assets.'
+                  );
+                }
+
+                lines.push(
+                  '',
+                  'Your feedback on the beta is very welcome \u2014 please report any issues you run into so they can be fixed before the stable release.'
+                );
+                return lines.join('\n');
+              }
+
+              const lines = [
                 `A fix for this issue is now available in **[${releaseTag}](${releaseUrl})**, the latest stable release of F1 Sensor.`,
                 '',
                 'To update via HACS, open Home Assistant, go to **HACS \u2192 Integrations**, find **F1 Sensor**, and click **Update**. If you installed it manually, download the latest release from the [Releases page](' + releaseUrl + ') and replace the existing files.',
                 '',
                 'After updating, restart Home Assistant to apply the changes.',
-              ].join('\n');
-            }
+              ];
+
+              if (cardIssue) {
+                lines.push(
+                  '',
+                  'For bundled live data card fixes, reload your browser after restarting Home Assistant. If you still have the old standalone HACS dashboard card installed, remove the old card repository and stale dashboard resource only after confirming the bundled card works.'
+                );
+              }
+
+              return lines.join('\n');
+            };
 
             for (const num of issueNumbers) {
               try {
@@ -59,6 +99,7 @@ jobs:
                 // Skip pull requests
                 if (issue.pull_request) continue;
 
+                const comment = buildComment(isCardIssue(issue));
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/.github/workflows/issue-version-check.yml
+++ b/.github/workflows/issue-version-check.yml
@@ -16,8 +16,18 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const normalize = v => v.trim().replace(/^v/i, '');
+            const cleanValue = v => {
+              const value = (v || '').trim();
+              return /^_?no response_?$/i.test(value) ? '' : value;
+            };
+            const normalize = v => cleanValue(v).replace(/^v/i, '');
             const isBeta = v => /beta/i.test(v);
+            const extractField = (body, label) => {
+              const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const pattern = new RegExp(`### ${escaped}\\s*\\n+([^#]+?)(?=\\n### |$)`, 'i');
+              const match = body.match(pattern);
+              return match ? cleanValue(match[1]) : '';
+            };
 
             const ensureLabel = async (name, color, description) => {
               try {
@@ -36,15 +46,25 @@ jobs:
             const body = context.payload.issue.body || '';
             const issueNumber = context.payload.issue.number;
             const existingLabels = context.payload.issue.labels.map(l => l.name);
+            const component = extractField(body, 'Component').toLowerCase();
+            const oldStandaloneCardVersion = normalize(extractField(body, 'Old Standalone Card Version'));
+            const isCardRelated =
+              component.includes('live data card') ||
+              component.includes('both integration and card') ||
+              oldStandaloneCardVersion !== '';
 
             // Extract reported version from issue body
-            const versionMatch = body.match(/### F1 Sensor Version\s*\n+([^\n#]+)/);
-            if (!versionMatch) return;
-            const reportedVersion = normalize(versionMatch[1]);
+            const reportedVersion = normalize(extractField(body, 'F1 Sensor Version'));
             if (!reportedVersion) return;
 
+            const betaVersions = [];
+            if (isBeta(reportedVersion)) betaVersions.push(`F1 Sensor ${reportedVersion}`);
+            if (oldStandaloneCardVersion && isBeta(oldStandaloneCardVersion)) {
+              betaVersions.push(`standalone live data card ${oldStandaloneCardVersion}`);
+            }
+
             // Beta version — acknowledge as tester, skip outdated check
-            if (isBeta(reportedVersion)) {
+            if (betaVersions.length > 0) {
               if (existingLabels.includes('beta')) return;
 
               await ensureLabel('beta', 'bfd4f2', 'Reported on a beta version');
@@ -61,14 +81,14 @@ jobs:
                 body: [
                   '👋 Thanks for testing the beta and taking the time to report this!',
                   '',
-                  `You're running **${reportedVersion}**, which is a pre-release version. Beta feedback is valuable and helps improve the integration before stable releases.`,
+                  `You're running **${betaVersions.join('** and **')}**, which includes a pre-release version. Beta feedback is valuable and helps improve F1 Sensor before stable releases.`,
                   '',
                   'If this issue is affecting your day-to-day use of F1 Sensor, you can revert to the latest stable release via HACS at any time.',
                   '',
                   '**How to switch back to a stable release via HACS:**',
                   '1. Go to **HACS** in your Home Assistant sidebar',
                   '2. Find **F1 Sensor**, click **Download**, and select the latest stable version',
-                  '3. Restart Home Assistant',
+                  isCardRelated ? '3. Restart Home Assistant, then reload your browser so the dashboard loads fresh card assets' : '3. Restart Home Assistant',
                   '',
                   'We\'ll look into this — thanks again for helping test!',
                 ].join('\n'),
@@ -117,7 +137,11 @@ jobs:
                 '**How to update via HACS:**',
                 '1. Go to **HACS** in your Home Assistant sidebar',
                 '2. Find **F1 Sensor**, click **Download**, and select the latest version',
-                '3. Restart Home Assistant',
+                isCardRelated ? '3. Restart Home Assistant, then reload your browser so the dashboard loads fresh card assets' : '3. Restart Home Assistant',
+                ...(isCardRelated && oldStandaloneCardVersion ? [
+                  '',
+                  `You also reported standalone live data card version **${oldStandaloneCardVersion}**. That is useful context for card migration issues, but the update check is based on the installed F1 Sensor version.`,
+                ] : []),
                 '',
                 'If the issue persists after updating, please comment here and we\'ll continue investigating.',
                 'If we don\'t hear back within **24 hours**, this issue will be automatically closed.',


### PR DESCRIPTION
## Summary

This mirrors the Phase 1 support-intake preparation onto `dev` without merging `main` or `beta` into the development branch.

It carries the same issue form and issue automation changes as the main-targeted support prep: component classification, card-specific bug context, component label automation, standalone card version handling in version checks, and card-aware release issue comments.

## Branch handling

The patch was cherry-picked onto a branch created directly from `origin/dev`, so `dev` keeps its current history and does not receive unrelated `main` or `beta` commits through this PR.

## Validation

- Parsed updated issue forms and workflows with Ruby YAML loading.
- Checked the embedded `github-script` JavaScript blocks with `node --check` after wrapping them in an async function.
- Ran `git diff --check HEAD~1 HEAD`.

`actionlint` is not installed in the local environment, so that check was not run.