### PR TITLE
[codex] Mirror simplified card issue fields onto dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -69,43 +69,11 @@ body:
       description: If running in Container or VM, what architecture is it?
       placeholder: e.g. aarch64, armv7, amd64
 
-  - type: dropdown
-    id: card_install_path
-    attributes:
-      label: Card Install Path
-      description: Only needed for live data card issues.
-      options:
-        - Bundled with F1 Sensor
-        - Standalone HACS dashboard repo
-        - Manual resource
-        - Not sure
-
-  - type: input
-    id: dashboard_resource_url
-    attributes:
-      label: Dashboard Resource URL
-      description: Only needed for live data card issues. Add the resource URL if it is visible in your dashboard resources.
-      placeholder: e.g. /local/f1-sensor-live-data-card/f1-sensor-live-data-card.js
-
-  - type: input
-    id: browser_device
-    attributes:
-      label: Browser and Device
-      description: Only needed for live data card issues.
-      placeholder: e.g. Chrome on Windows, Safari on iPhone, Fully Kiosk on tablet
-
   - type: textarea
     id: screenshot_or_recording
     attributes:
       label: Screenshot or Screen Recording
       description: Only needed for live data card display issues. Drag and drop images or recordings here.
-
-  - type: input
-    id: old_standalone_card_version
-    attributes:
-      label: Old Standalone Card Version
-      description: Only fill this in if the standalone HACS dashboard card is still installed.
-      placeholder: e.g. 1.4.0
 
   - type: textarea
     id: current_behavior

--- a/.github/workflows/issue-release-comment.yml
+++ b/.github/workflows/issue-release-comment.yml
@@ -44,8 +44,7 @@ jobs:
               return (
                 labels.includes('card') ||
                 component.includes('live data card') ||
-                component.includes('both integration and card') ||
-                extractField(issue.body, 'Old Standalone Card Version') !== ''
+                component.includes('both integration and card')
               );
             };
             const buildComment = cardIssue => {

--- a/.github/workflows/issue-version-check.yml
+++ b/.github/workflows/issue-version-check.yml
@@ -47,11 +47,9 @@ jobs:
             const issueNumber = context.payload.issue.number;
             const existingLabels = context.payload.issue.labels.map(l => l.name);
             const component = extractField(body, 'Component').toLowerCase();
-            const oldStandaloneCardVersion = normalize(extractField(body, 'Old Standalone Card Version'));
             const isCardRelated =
               component.includes('live data card') ||
-              component.includes('both integration and card') ||
-              oldStandaloneCardVersion !== '';
+              component.includes('both integration and card');
 
             // Extract reported version from issue body
             const reportedVersion = normalize(extractField(body, 'F1 Sensor Version'));
@@ -59,9 +57,6 @@ jobs:
 
             const betaVersions = [];
             if (isBeta(reportedVersion)) betaVersions.push(`F1 Sensor ${reportedVersion}`);
-            if (oldStandaloneCardVersion && isBeta(oldStandaloneCardVersion)) {
-              betaVersions.push(`standalone live data card ${oldStandaloneCardVersion}`);
-            }
 
             // Beta version — acknowledge as tester, skip outdated check
             if (betaVersions.length > 0) {
@@ -138,10 +133,6 @@ jobs:
                 '1. Go to **HACS** in your Home Assistant sidebar',
                 '2. Find **F1 Sensor**, click **Download**, and select the latest version',
                 isCardRelated ? '3. Restart Home Assistant, then reload your browser so the dashboard loads fresh card assets' : '3. Restart Home Assistant',
-                ...(isCardRelated && oldStandaloneCardVersion ? [
-                  '',
-                  `You also reported standalone live data card version **${oldStandaloneCardVersion}**. That is useful context for card migration issues, but the update check is based on the installed F1 Sensor version.`,
-                ] : []),
                 '',
                 'If the issue persists after updating, please comment here and we\'ll continue investigating.',
                 'If we don\'t hear back within **24 hours**, this issue will be automatically closed.',


### PR DESCRIPTION
## Summary

This mirrors the simplified card issue intake changes onto `dev` without merging `main` into the development branch.

The bug report template no longer asks for card install path, dashboard resource URL, browser/device, or old standalone card version. The related issue workflows now rely on the component selector or `card` label for card-specific behavior.

## Branch handling

The patch was cherry-picked onto a branch created directly from `origin/dev`, so `dev` keeps its current history and does not receive unrelated `main` or `beta` commits.

## Validation

- Parsed the updated issue template and workflows with Ruby YAML loading.
- Checked the embedded `github-script` JavaScript blocks with `node --check` after wrapping them in an async function.
- Confirmed the removed field names no longer appear in the bug template or related workflows.
- Ran `git diff --check HEAD~1 HEAD`.