### PR TITLE
chore: Resolve npm security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16501,9 +16501,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
-      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.15.0.tgz",
+      "integrity": "sha512-+k0tk7lRnpMUPnC7kTuU/yrV/mnFoPhJQ75VfLtZ6fwbzOVXaPsTE/Il9Pn1DHi482byMyqkHv/XsQ76mNjXLw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -16582,8 +16582,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.1",
-        "@npmcli/config": "^10.7.1",
+        "@npmcli/arborist": "^9.6.0",
+        "@npmcli/config": "^10.9.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -16591,37 +16591,37 @@
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.4",
-        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/tuf": "^4.0.2",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.3",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.4",
-        "libnpmexec": "^10.2.4",
-        "libnpmfund": "^7.0.18",
+        "libnpmdiff": "^8.1.8",
+        "libnpmexec": "^10.2.8",
+        "libnpmfund": "^7.0.22",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.4",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.8",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.4",
-        "minimatch": "^10.2.4",
+        "make-fetch-happen": "^15.0.5",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.3.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -16636,11 +16636,11 @@
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.0",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -16668,24 +16668,12 @@
       }
     },
     "node_modules/npm/node_modules/@gar/promise-retry": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "retry": "^0.13.1"
-      },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@gar/promise-retry/node_modules/retry": {
-      "version": "0.13.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -16723,7 +16711,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.1",
+      "version": "9.6.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -16771,7 +16759,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.7.1",
+      "version": "10.9.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -16965,7 +16953,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.1.0",
+      "version": "3.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -16974,7 +16962,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -16983,24 +16971,24 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.3",
-        "proc-log": "^6.1.0",
-        "promise-retry": "^2.0.1"
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -17088,7 +17076,7 @@
       }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17116,7 +17104,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -17128,7 +17116,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "20.0.3",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17142,8 +17130,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^13.0.0",
-        "unique-filename": "^5.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -17186,7 +17173,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -17242,7 +17229,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -17258,12 +17245,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -17316,7 +17297,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17388,15 +17369,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
     "node_modules/npm/node_modules/ini": {
       "version": "6.0.0",
       "dev": true,
@@ -17424,7 +17396,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -17433,12 +17405,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -17506,12 +17478,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.4",
+      "version": "8.1.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.6.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -17525,13 +17497,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.4",
+      "version": "10.2.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.6.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -17548,12 +17520,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.18",
+      "version": "7.0.22",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1"
+        "@npmcli/arborist": "^9.6.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -17573,12 +17545,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.4",
+      "version": "9.1.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.6.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -17588,7 +17560,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17648,7 +17620,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.6",
+      "version": "11.5.0",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -17657,13 +17629,14 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.4",
+      "version": "15.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
@@ -17679,12 +17652,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -17732,34 +17705,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -17840,7 +17795,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -17848,12 +17803,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -18126,19 +18081,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
       "dev": true,
@@ -18180,15 +18122,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
       "dev": true,
@@ -18197,7 +18130,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18248,12 +18181,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -18322,7 +18255,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.15",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -18350,13 +18283,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -18383,7 +18316,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -18417,28 +18350,13 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "5.0.0",
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.25.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^6.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -20907,9 +20825,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -24350,12 +24268,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -24548,6 +24470,27 @@
         "node": ">= 10"
       }
     },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-dev-middleware": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
@@ -24696,27 +24639,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/webpack-merge": {
@@ -24947,16 +24869,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,12 @@
     "brace-expansion": "^2.0.3",
     "minimatch": "^3.1.4",
     "serialize-javascript": ">=7.0.5",
-    "picomatch": ">=4.0.4"
+    "picomatch": ">=4.0.4",
+    "ip-address": "^10.1.1",
+    "qs": "^6.15.2",
+    "uuid": "^11.1.1",
+    "webpack-dev-server": {
+      "ws": "^8.20.1"
+    }
   }
 }


### PR DESCRIPTION
Updates transitive npm dependencies used by the documentation and release tooling so Dependabot and npm audit no longer report the open security alerts.\n\nValidation run locally:\n- npm ci\n- npm audit\n- npm run build\n- node --check custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js