### PR TITLE
Change “rain” to “weather” in the LiveSessionCard

### DIFF
--- a/blueprints/f1_incident_notifications.yaml
+++ b/blueprints/f1_incident_notifications.yaml
@@ -1,0 +1,283 @@
+blueprint:
+  homeassistant:
+    min_version: 2024.6.0
+  name: F1 Sensor - Incident Notifications
+  description: >
+    Send neutral notifications for F1 Sensor incident alerts.
+
+    The automation listens for f1_sensor_incident events and can filter by confidence,
+    session type, and event phase. Notifications use a stable tag based on incident_id
+    so supported notify targets update an existing incident notification instead of
+    creating duplicates for the same incident.
+  domain: automation
+  source_url: https://github.com/Nicxe/f1_sensor
+  author: Nicxe
+  input:
+    notification_targets:
+      name: Notification Targets
+      icon: mdi:bell-ring
+      collapsed: false
+      description: Choose where incident notifications should be sent.
+      input:
+        notify_services:
+          name: Notify Services
+          description: >
+            Comma- or semicolon-separated services, for example notify.mobile_app_phone
+            or notify.notify. Leave empty when using notify entity targets only.
+          default: ""
+          selector:
+            text: {}
+        notify_targets:
+          name: Notify Entity Targets
+          description: Optional notify entities to call through notify.send_message.
+          default: []
+          selector:
+            entity:
+              filter:
+                - domain: notify
+              multiple: true
+
+    filters:
+      name: Filters
+      icon: mdi:filter-variant
+      collapsed: false
+      description: Control which incident events create notifications.
+      input:
+        min_confidence:
+          name: Minimum Confidence
+          description: Only notify when the incident confidence is at least this level.
+          default: medium
+          selector:
+            select:
+              mode: dropdown
+              options:
+                - label: Low
+                  value: low
+                - label: Medium
+                  value: medium
+                - label: High
+                  value: high
+        allowed_session_types:
+          name: Session Types
+          description: >
+            Practice and testing are excluded by default. Add practice if you want
+            high-confidence practice incidents to notify.
+          default:
+            - race
+            - sprint
+            - qualifying
+          selector:
+            select:
+              mode: dropdown
+              multiple: true
+              options:
+                - label: Race
+                  value: race
+                - label: Sprint
+                  value: sprint
+                - label: Qualifying
+                  value: qualifying
+                - label: Practice
+                  value: practice
+                - label: Testing
+                  value: testing
+                - label: Unknown
+                  value: unknown
+        include_candidate_events:
+          name: Notify Candidate Events
+          description: Candidate incidents are early signals and are disabled by default.
+          default: false
+          selector:
+            boolean: {}
+        include_cleared_notifications:
+          name: Notify When Cleared
+          description: Send an additional notification when an active incident is cleared.
+          default: false
+          selector:
+            boolean: {}
+
+    notification_content:
+      name: Notification Content
+      icon: mdi:message-badge
+      collapsed: true
+      description: Customize the generated title.
+      input:
+        title_prefix:
+          name: Title Prefix
+          default: F1 Incident Alert
+          selector:
+            text: {}
+
+mode: queued
+max: 10
+
+trigger:
+  - platform: event
+    event_type: f1_sensor_incident
+
+variables:
+  notify_services_raw: !input notify_services
+  notify_targets_input: !input notify_targets
+  min_confidence_input: !input min_confidence
+  allowed_session_types_input: !input allowed_session_types
+  include_candidate_events_input: !input include_candidate_events
+  include_cleared_notifications_input: !input include_cleared_notifications
+  title_prefix_input: !input title_prefix
+
+  incident_id: "{{ trigger.event.data.incident_id | default('', true) | string }}"
+  incident_phase: "{{ trigger.event.data.phase | default('', true) | string | lower }}"
+  incident_confidence: "{{ trigger.event.data.confidence | default('', true) | string | lower }}"
+  incident_reason: "{{ trigger.event.data.reason | default('', true) | string | lower }}"
+  driver: "{{ trigger.event.data.driver | default({}, true) }}"
+  session: "{{ trigger.event.data.session | default({}, true) }}"
+  race_control: "{{ trigger.event.data.race_control | default({}, true) }}"
+  track_status: "{{ trigger.event.data.track_status | default({}, true) }}"
+  driver_label: >-
+    {% set tla = driver.tla | default('', true) | string | trim %}
+    {% set number = driver.racing_number | default('', true) | string | trim %}
+    {% set name = driver.name | default('', true) | string | trim %}
+    {% if tla %}
+      {{ tla }}
+    {% elif number %}
+      Car {{ number }}
+    {% elif name %}
+      {{ name }}
+    {% else %}
+      a car
+    {% endif %}
+  incident_session_type: >-
+    {{ session.session_type | default('unknown', true) | string | lower }}
+  incident_session_name: >-
+    {{ session.session_name | default('', true) | string | trim }}
+  reason_label: >-
+    {% if incident_phase == 'cleared' %}
+      cleared
+    {% elif incident_reason == 'timing_stopped' %}
+      stopped
+    {% elif incident_reason == 'race_control' %}
+      race control report
+    {% elif incident_reason == 'track_status' %}
+      track status alert
+    {% elif incident_reason %}
+      {{ incident_reason | replace('_', ' ') }}
+    {% else %}
+      reported
+    {% endif %}
+  incident_confidence_score: >-
+    {% if incident_confidence == 'high' %}
+      2
+    {% elif incident_confidence == 'medium' %}
+      1
+    {% elif incident_confidence == 'low' %}
+      0
+    {% else %}
+      -1
+    {% endif %}
+  min_confidence_score: >-
+    {% if min_confidence_input == 'high' %}
+      2
+    {% elif min_confidence_input == 'medium' %}
+      1
+    {% else %}
+      0
+    {% endif %}
+  phase_ok: >-
+    {{
+      incident_phase in ['confirmed', 'updated']
+      or (include_candidate_events_input and incident_phase == 'candidate')
+      or (include_cleared_notifications_input and incident_phase == 'cleared')
+    }}
+  session_ok: >-
+    {% set allowed = allowed_session_types_input | default([]) %}
+    {% if allowed is string %}{% set allowed = [allowed] %}{% endif %}
+    {{ incident_session_type in allowed }}
+  confidence_ok: >-
+    {{ incident_confidence_score | int(-1) >= min_confidence_score | int(0) }}
+  notify_service_targets: >-
+    {% set ns = namespace(services=[]) %}
+    {% set raw = (notify_services_raw | default('', true) | string).replace(';', ',') %}
+    {% for item in raw.split(',') %}
+      {% set target = item | trim %}
+      {% if target and '.' in target %}
+        {% set ns.services = ns.services + [target] %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.services }}
+  notify_entity_targets: >-
+    {% set targets = notify_targets_input | default([]) %}
+    {% if targets is string %}
+      {{ [targets] if targets else [] }}
+    {% else %}
+      {{ targets }}
+    {% endif %}
+  notify_target_count: >-
+    {{ (notify_service_targets | default([], true) | count) + (notify_entity_targets | default([], true) | count) }}
+  notification_tag: >-
+    {{ 'f1_incident_' ~ (incident_id | slugify) if incident_id else 'f1_incident' }}
+  notification_title: >-
+    {% set prefix = title_prefix_input | default('F1 Incident Alert', true) | string | trim %}
+    {% set confidence = incident_confidence | upper %}
+    {% if confidence %}
+      {{ prefix ~ ' (' ~ confidence ~ ')' }}
+    {% else %}
+      {{ prefix }}
+    {% endif %}
+  notification_message: >-
+    {% set base = 'Possible on-track incident: ' ~ driver_label ~ ' ' ~ reason_label %}
+    {% set ns = namespace(lines=[base | trim]) %}
+    {% if incident_session_name %}
+      {% set ns.lines = ns.lines + ['Session: ' ~ incident_session_name] %}
+    {% elif incident_session_type %}
+      {% set ns.lines = ns.lines + ['Session: ' ~ (incident_session_type | title)] %}
+    {% endif %}
+    {% set rc_message = race_control.message | default('', true) | string | trim %}
+    {% if rc_message %}
+      {% set ns.lines = ns.lines + ['Race control: ' ~ rc_message] %}
+    {% endif %}
+    {% set track_message = track_status.message | default('', true) | string | trim %}
+    {% if track_message %}
+      {% set ns.lines = ns.lines + ['Track status: ' ~ track_message] %}
+    {% endif %}
+    {{ ns.lines | join('\n') }}
+
+condition:
+  - condition: template
+    value_template: "{{ incident_id | length > 0 }}"
+  - condition: template
+    value_template: "{{ notify_target_count | int(0) > 0 }}"
+  - condition: template
+    value_template: "{{ phase_ok | bool }}"
+  - condition: template
+    value_template: "{{ session_ok | bool }}"
+  - condition: template
+    value_template: "{{ confidence_ok | bool }}"
+
+action:
+  - repeat:
+      for_each: "{{ notify_service_targets }}"
+      sequence:
+        - service: "{{ repeat.item }}"
+          data:
+            title: "{{ notification_title }}"
+            message: "{{ notification_message }}"
+            data:
+              tag: "{{ notification_tag }}"
+              group: f1_incidents
+              incident_id: "{{ incident_id }}"
+              phase: "{{ incident_phase }}"
+              confidence: "{{ incident_confidence }}"
+  - repeat:
+      for_each: "{{ notify_entity_targets }}"
+      sequence:
+        - service: notify.send_message
+          target:
+            entity_id: "{{ repeat.item }}"
+          data:
+            title: "{{ notification_title }}"
+            message: "{{ notification_message }}"
+            data:
+              tag: "{{ notification_tag }}"
+              group: f1_incidents
+              incident_id: "{{ incident_id }}"
+              phase: "{{ incident_phase }}"
+              confidence: "{{ incident_confidence }}"

--- a/blueprints/f1_incident_notifications.yaml
+++ b/blueprints/f1_incident_notifications.yaml
@@ -152,6 +152,10 @@ variables:
   reason_label: >-
     {% if incident_phase == 'cleared' %}
       cleared
+    {% elif incident_reason == 'race_control_stopped_with_car_low_speed' %}
+      stopped
+    {% elif incident_reason.startswith('car_low_speed') %}
+      may have stopped
     {% elif incident_reason == 'timing_stopped' %}
       stopped
     {% elif incident_reason == 'race_control' %}

--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -95,6 +95,16 @@ from .helpers import (
     get_next_race,
     parse_fia_documents,
 )
+from .incident_detection import (
+    CONFIDENCE_ORDER,
+    DATA_QUALITY_BOOTSTRAP,
+    DATA_QUALITY_LIVE,
+    DATA_QUALITY_REPLAY,
+    IncidentChange,
+    IncidentDetector,
+    SessionMetadata,
+    normalize_stream,
+)
 from .live_delay import LiveDelayController, LiveDelayReferenceController
 from .live_window import (
     EventTrackerScheduleSource,
@@ -138,6 +148,17 @@ _RC_LOG_STORE_KEY = "race_control_log_store"
 _RC_LOG_EVENT = f"{DOMAIN}_race_control_event"
 _RC_LOG_RESET_EVENT = f"{DOMAIN}_race_control_log_reset_event"
 _RC_LOG_WS_TYPE = f"{DOMAIN}/race_control_log/get"
+_INCIDENT_EVENT = f"{DOMAIN}_incident"
+_INCIDENT_STREAMS: tuple[str, ...] = (
+    "DriverList",
+    "SessionInfo",
+    "SessionData",
+    "SessionStatus",
+    "TrackStatus",
+    "RaceControlMessages",
+    "TimingData",
+)
+_INCIDENT_BOOTSTRAP_SKIP_STREAMS = frozenset({"RaceControlMessages", "TrackStatus"})
 _DOMAIN_ROOT_INTERNAL_KEYS = frozenset(
     {
         _JOLPICA_STATS_KEY,
@@ -1589,6 +1610,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     weather_data_coordinator = None
     lap_count_coordinator = None
     race_control_coordinator = None
+    incident_coordinator = None
     race_control_log_store = None
     live_mode_coordinator = None
     top_three_coordinator = None
@@ -1813,6 +1835,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             delay_controller=delay_controller,
             live_state=live_state,
         )
+        incident_coordinator = IncidentCoordinator(
+            hass,
+            session_coordinator,
+            live_delay,
+            bus=live_bus,
+            config_entry=entry,
+            delay_controller=delay_controller,
+            live_state=live_state,
+        )
         live_mode_coordinator = LiveModeCoordinator(
             hass,
             race_control_coordinator,
@@ -1863,6 +1894,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await weather_data_coordinator.async_config_entry_first_refresh()
     if lap_count_coordinator:
         await lap_count_coordinator.async_config_entry_first_refresh()
+    if incident_coordinator:
+        await incident_coordinator.async_config_entry_first_refresh()
 
     # Conditionally create live-stream coordinators (require enable_rc + sensor enabled).
     # Replay/auth-gated coordinators stay registered in live mode and expose
@@ -1967,6 +2000,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "session_info_coordinator": session_info_coordinator,
         "session_clock_coordinator": session_clock_coordinator,
         "race_control_coordinator": race_control_coordinator if enable_rc else None,
+        "incident_coordinator": incident_coordinator if enable_rc else None,
         _RC_LOG_STORE_KEY: race_control_log_store if enable_rc else None,
         "live_mode_coordinator": live_mode_coordinator if enable_rc else None,
         "starting_grid_coordinator": starting_grid_coordinator,
@@ -2009,6 +2043,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             live_mode_coordinator if enable_rc else None,
             weather_data_coordinator if enable_rc else None,
             lap_count_coordinator if enable_rc else None,
+            incident_coordinator if enable_rc else None,
             top_three_coordinator,
             pitstop_coordinator,
             championship_prediction_coordinator,
@@ -2529,6 +2564,252 @@ class RaceControlCoordinator(DataUpdateCoordinator):
             ).subscribe("RaceControlMessages", self._on_bus_message)  # type: ignore[attr-defined]
         except Exception:
             self._unsub = None
+
+
+class IncidentCoordinator(DataUpdateCoordinator):
+    """Coordinator that bridges live timing streams to incident events."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        session_coord: LiveSessionCoordinator,
+        delay_seconds: int = 0,
+        bus: LiveBus | None = None,
+        config_entry: ConfigEntry | None = None,
+        delay_controller: LiveDelayController | None = None,
+        live_state: LiveAvailabilityTracker | None = None,
+    ) -> None:
+        super().__init__(
+            hass,
+            coordinator_logger("incident", suppress_manual=True),
+            name="F1 Incident Coordinator",
+            update_interval=None,
+            config_entry=config_entry,
+        )
+        self._session_coord = session_coord
+        self._bus = bus
+        self._detector = IncidentDetector()
+        self._session_metadata = SessionMetadata()
+        self._drivers: dict[str, Any] = {}
+        self._state = self._empty_state()
+        self._latest_change: IncidentChange | None = None
+        self._published_event_keys: set[tuple[str, str, str, str, str]] = set()
+        self._published_event_order: deque[tuple[str, str, str, str, str]] = deque(
+            maxlen=512
+        )
+        self._unsubs: list[Callable[[], None]] = []
+        self._delay_listener: Callable[[], None] | None = None
+        self._live_state_unsub: Callable[[], None] | None = None
+        self._delay = max(0, int(delay_seconds or 0))
+        self._replay_mode = False
+        self._closed = False
+        self.available = True
+        _init_delayed_ingest_state(self)
+        if delay_controller is not None:
+            self._delay_listener = delay_controller.add_listener(self.set_delay)
+        if live_state is not None:
+            self._replay_mode = _is_replay_delay_reason(live_state.reason)
+            self.available = bool(live_state.is_live)
+            self._live_state_unsub = live_state.add_listener(self._handle_live_state)
+
+    @staticmethod
+    def _empty_state() -> dict[str, Any]:
+        return {
+            "active_count": 0,
+            "highest_confidence": None,
+            "latest_incident_id": None,
+            "latest_driver_number": None,
+            "latest_driver_tla": None,
+            "latest_reason": None,
+            "latest_phase": None,
+            "session_type": None,
+            "session_name": None,
+            "data_quality": None,
+            "active_incidents": [],
+        }
+
+    async def async_close(self, *_) -> None:
+        self._closed = True
+        for unsub in self._unsubs:
+            with suppress(Exception):
+                unsub()
+        self._unsubs.clear()
+        self._delay_listener = _call_unsub(self._delay_listener)
+        self._live_state_unsub = _call_unsub(self._live_state_unsub)
+        _close_delayed_ingest_state(self)
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        return self._state
+
+    async def async_config_entry_first_refresh(self) -> None:
+        await super().async_config_entry_first_refresh()
+        bus = self._bus or self.hass.data.get(DOMAIN, {}).get("live_bus")
+        if bus is None:
+            return
+        for stream in _INCIDENT_STREAMS:
+            self._subscribe_stream(bus, stream)
+
+    def _subscribe_stream(self, bus: LiveBus, stream: str) -> None:
+        replaying_cached_payload = True
+
+        def _callback(payload: Any) -> None:
+            nonlocal replaying_cached_payload
+            is_bootstrap = replaying_cached_payload and not self._replay_mode
+            self._queue_stream_payload(
+                stream,
+                payload,
+                is_bootstrap=is_bootstrap,
+            )
+
+        try:
+            self._unsubs.append(bus.subscribe(stream, _callback))
+        except Exception:
+            _LOGGER.debug("Incident: failed to subscribe to %s", stream, exc_info=True)
+        finally:
+            replaying_cached_payload = False
+
+    def _queue_stream_payload(
+        self, stream: str, payload: Any, *, is_bootstrap: bool
+    ) -> None:
+        if self._closed:
+            return
+        observed_at = datetime.now(UTC)
+        if self._replay_mode:
+            data_quality = DATA_QUALITY_REPLAY
+        elif is_bootstrap:
+            data_quality = DATA_QUALITY_BOOTSTRAP
+        else:
+            data_quality = DATA_QUALITY_LIVE
+        _queue_delayed_ingest(
+            self,
+            lambda stream=stream, payload=payload, observed_at=observed_at, data_quality=data_quality: (
+                self._handle_stream_payload(
+                    stream,
+                    payload,
+                    observed_at=observed_at,
+                    data_quality=data_quality,
+                )
+            ),
+        )
+
+    def _handle_stream_payload(
+        self,
+        stream: str,
+        payload: Any,
+        *,
+        observed_at: datetime,
+        data_quality: str,
+    ) -> None:
+        if self._closed or _is_no_spoiler_blocked(self):
+            return
+        if (
+            data_quality == DATA_QUALITY_BOOTSTRAP
+            and stream in _INCIDENT_BOOTSTRAP_SKIP_STREAMS
+        ):
+            return
+        signals = normalize_stream(
+            stream,
+            payload,
+            observed_at,
+            session=self._session_metadata,
+            drivers=self._drivers,
+            data_quality=data_quality,
+        )
+        if not signals:
+            return
+        for signal in signals:
+            if signal.kind == "session_context" and signal.session is not None:
+                self._session_metadata = signal.session
+            if signal.kind == "driver_metadata" and signal.driver is not None:
+                self._drivers[signal.driver.racing_number] = signal.driver
+        changes = self._detector.process_signals(signals)
+        if not changes:
+            return
+        self._refresh_state(changes[-1])
+        if data_quality == DATA_QUALITY_BOOTSTRAP:
+            return
+        for change in changes:
+            self._publish_change(change)
+
+    def _publish_change(self, change: IncidentChange) -> None:
+        event_key = (
+            change.incident_id,
+            change.phase,
+            change.confidence,
+            change.reason,
+            change.updated_at.isoformat(),
+        )
+        if event_key in self._published_event_keys:
+            return
+        if len(self._published_event_order) == self._published_event_order.maxlen:
+            old = self._published_event_order.popleft()
+            self._published_event_keys.discard(old)
+        self._published_event_order.append(event_key)
+        self._published_event_keys.add(event_key)
+
+        payload = {
+            "entry_id": self.config_entry.entry_id if self.config_entry else None,
+            **change.to_event_payload(),
+        }
+        self.hass.bus.async_fire(_INCIDENT_EVENT, payload)
+        _LOGGER.debug(
+            "Incident event phase=%s confidence=%s reason=%s driver=%s",
+            change.phase,
+            change.confidence,
+            change.reason,
+            change.driver.racing_number,
+        )
+
+    def _refresh_state(self, latest_change: IncidentChange | None = None) -> None:
+        if latest_change is not None:
+            self._latest_change = latest_change
+        active = list(self._detector.active_incidents())
+        highest = None
+        if active:
+            highest = max(
+                (change.confidence for change in active),
+                key=lambda value: CONFIDENCE_ORDER.get(value, -1),
+            )
+        latest = self._latest_change
+        self._state = {
+            "active_count": len(active),
+            "highest_confidence": highest,
+            "latest_incident_id": latest.incident_id if latest else None,
+            "latest_driver_number": latest.driver.racing_number if latest else None,
+            "latest_driver_tla": latest.driver.tla if latest else None,
+            "latest_reason": latest.reason if latest else None,
+            "latest_phase": latest.phase if latest else None,
+            "session_type": latest.session.session_type if latest else None,
+            "session_name": latest.session.session_name if latest else None,
+            "data_quality": latest.data_quality if latest else None,
+            "active_incidents": [change.to_event_payload() for change in active],
+        }
+        self.async_set_updated_data(self._state)
+
+    def reset_for_replay(self) -> None:
+        self._detector = IncidentDetector()
+        self._session_metadata = SessionMetadata()
+        self._drivers.clear()
+        self._latest_change = None
+        self._published_event_keys.clear()
+        self._published_event_order.clear()
+        self._state = self._empty_state()
+        _clear_delayed_ingest_state(self)
+        self.async_set_updated_data(self._state)
+
+    def set_delay(self, seconds: int) -> None:
+        _apply_delay_with_queue(self, seconds)
+
+    def _handle_live_state(self, is_live: bool, reason: str | None) -> None:
+        if reason == "init":
+            return
+        replay_mode = _is_replay_delay_reason(reason)
+        if replay_mode and not self._replay_mode:
+            self.reset_for_replay()
+        self._replay_mode = replay_mode
+        self.available = is_live
+        if not is_live:
+            self.reset_for_replay()
 
 
 class LiveModeCoordinator(DataUpdateCoordinator):
@@ -5525,6 +5806,10 @@ def _reset_replay_sensitive_coordinator_state(coordinator: Any) -> None:
         coordinator._seen_ids_order.clear()
         coordinator._startup_cutoff = None
         coordinator.async_set_updated_data(None)
+        return
+
+    if isinstance(coordinator, IncidentCoordinator):
+        coordinator.reset_for_replay()
         return
 
     if isinstance(coordinator, LiveModeCoordinator):

--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -157,6 +157,7 @@ _INCIDENT_STREAMS: tuple[str, ...] = (
     "TrackStatus",
     "RaceControlMessages",
     "TimingData",
+    "CarData.z",
 )
 _INCIDENT_BOOTSTRAP_SKIP_STREAMS = frozenset({"RaceControlMessages", "TrackStatus"})
 _DOMAIN_ROOT_INTERNAL_KEYS = frozenset(

--- a/custom_components/f1_sensor/binary_sensor.py
+++ b/custom_components/f1_sensor/binary_sensor.py
@@ -132,6 +132,17 @@ async def async_setup_entry(
             )
             set_suggested_object_id(sensor, default_object_id("safety_car"))
             sensors.append(sensor)
+    if "on_track_incident" not in disabled:
+        coord = data.get("incident_coordinator")
+        if coord:
+            sensor = F1OnTrackIncidentBinarySensor(
+                coord,
+                f"{entry.entry_id}_on_track_incident",
+                entry.entry_id,
+                base,
+            )
+            set_suggested_object_id(sensor, default_object_id("on_track_incident"))
+            sensors.append(sensor)
     if "formation_start" not in disabled:
         tracker: FormationStartTracker | None = data.get("formation_start_tracker")
         if tracker is not None:
@@ -378,6 +389,102 @@ class F1SafetyCarBinarySensor(F1BaseEntity, RestoreEntity, BinarySensorEntity):
         self._attr_extra_state_attributes = {}
         self._last_ts = None
         self._forced_unavailable = True
+
+
+_ON_TRACK_INCIDENT_ATTR_KEYS = (
+    "active_count",
+    "highest_confidence",
+    "latest_incident_id",
+    "latest_driver_number",
+    "latest_driver_tla",
+    "latest_reason",
+    "latest_phase",
+    "session_type",
+    "session_name",
+    "data_quality",
+)
+_CONFIRMED_INCIDENT_PHASES = frozenset({"confirmed", "updated"})
+_CONFIDENCE_RANK = {"low": 0, "medium": 1, "high": 2}
+
+
+class F1OnTrackIncidentBinarySensor(F1AuxEntity, BinarySensorEntity):
+    """Binary sensor indicating whether a confirmed on-track incident is active."""
+
+    _device_category = "session"
+    _attr_device_class = None
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:alert-circle-outline"
+    _attr_translation_key = "on_track_incident"
+    _unrecorded_attributes = frozenset({"active_incidents"})
+
+    def __init__(
+        self,
+        coordinator: Any | None,
+        unique_id: str,
+        entry_id: str,
+        device_name: str,
+    ) -> None:
+        F1AuxEntity.__init__(self, unique_id, entry_id, device_name)
+        BinarySensorEntity.__init__(self)
+        self.coordinator = coordinator
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if self.coordinator is None:
+            return
+        removal = self.coordinator.async_add_listener(self._safe_write_ha_state)
+        self.async_on_remove(removal)
+
+    @property
+    def available(self) -> bool:
+        coordinator = self.coordinator
+        if coordinator is None:
+            return False
+        with suppress(Exception):
+            return bool(coordinator.available)
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        return self._confirmed_active_count() > 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        data = self._data()
+        attrs = {key: data.get(key) for key in _ON_TRACK_INCIDENT_ATTR_KEYS}
+        confirmed = self._confirmed_active_incidents()
+        attrs["active_count"] = len(confirmed)
+        attrs["highest_confidence"] = self._highest_confidence(confirmed)
+        return attrs
+
+    def _data(self) -> dict[str, Any]:
+        data = getattr(self.coordinator, "data", None)
+        return data if isinstance(data, dict) else {}
+
+    def _confirmed_active_incidents(self) -> list[dict[str, Any]]:
+        incidents = self._data().get("active_incidents")
+        if not isinstance(incidents, list):
+            return []
+        return [
+            incident
+            for incident in incidents
+            if isinstance(incident, dict)
+            and incident.get("phase") in _CONFIRMED_INCIDENT_PHASES
+        ]
+
+    def _confirmed_active_count(self) -> int:
+        return len(self._confirmed_active_incidents())
+
+    @staticmethod
+    def _highest_confidence(incidents: list[dict[str, Any]]) -> str | None:
+        confidence_values = [
+            confidence
+            for incident in incidents
+            if isinstance(confidence := incident.get("confidence"), str)
+        ]
+        if not confidence_values:
+            return None
+        return max(confidence_values, key=lambda value: _CONFIDENCE_RANK.get(value, -1))
 
 
 class F1FormationStartBinarySensor(F1AuxEntity, BinarySensorEntity):

--- a/custom_components/f1_sensor/binary_sensor.py
+++ b/custom_components/f1_sensor/binary_sensor.py
@@ -143,6 +143,19 @@ async def async_setup_entry(
             )
             set_suggested_object_id(sensor, default_object_id("on_track_incident"))
             sensors.append(sensor)
+    if "possible_on_track_incident" not in disabled:
+        coord = data.get("incident_coordinator")
+        if coord:
+            sensor = F1PossibleOnTrackIncidentBinarySensor(
+                coord,
+                f"{entry.entry_id}_possible_on_track_incident",
+                entry.entry_id,
+                base,
+            )
+            set_suggested_object_id(
+                sensor, default_object_id("possible_on_track_incident")
+            )
+            sensors.append(sensor)
     if "formation_start" not in disabled:
         tracker: FormationStartTracker | None = data.get("formation_start_tracker")
         if tracker is not None:
@@ -404,6 +417,7 @@ _ON_TRACK_INCIDENT_ATTR_KEYS = (
     "data_quality",
 )
 _CONFIRMED_INCIDENT_PHASES = frozenset({"confirmed", "updated"})
+_POSSIBLE_INCIDENT_PHASES = frozenset({"candidate", "confirmed", "updated"})
 _CONFIDENCE_RANK = {"low": 0, "medium": 1, "high": 2}
 
 
@@ -416,6 +430,7 @@ class F1OnTrackIncidentBinarySensor(F1AuxEntity, BinarySensorEntity):
     _attr_icon = "mdi:alert-circle-outline"
     _attr_translation_key = "on_track_incident"
     _unrecorded_attributes = frozenset({"active_incidents"})
+    _active_incident_phases = _CONFIRMED_INCIDENT_PHASES
 
     def __init__(
         self,
@@ -446,22 +461,22 @@ class F1OnTrackIncidentBinarySensor(F1AuxEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        return self._confirmed_active_count() > 0
+        return self._active_incident_count() > 0
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         data = self._data()
         attrs = {key: data.get(key) for key in _ON_TRACK_INCIDENT_ATTR_KEYS}
-        confirmed = self._confirmed_active_incidents()
-        attrs["active_count"] = len(confirmed)
-        attrs["highest_confidence"] = self._highest_confidence(confirmed)
+        active = self._filtered_active_incidents()
+        attrs["active_count"] = len(active)
+        attrs["highest_confidence"] = self._highest_confidence(active)
         return attrs
 
     def _data(self) -> dict[str, Any]:
         data = getattr(self.coordinator, "data", None)
         return data if isinstance(data, dict) else {}
 
-    def _confirmed_active_incidents(self) -> list[dict[str, Any]]:
+    def _filtered_active_incidents(self) -> list[dict[str, Any]]:
         incidents = self._data().get("active_incidents")
         if not isinstance(incidents, list):
             return []
@@ -469,11 +484,11 @@ class F1OnTrackIncidentBinarySensor(F1AuxEntity, BinarySensorEntity):
             incident
             for incident in incidents
             if isinstance(incident, dict)
-            and incident.get("phase") in _CONFIRMED_INCIDENT_PHASES
+            and incident.get("phase") in self._active_incident_phases
         ]
 
-    def _confirmed_active_count(self) -> int:
-        return len(self._confirmed_active_incidents())
+    def _active_incident_count(self) -> int:
+        return len(self._filtered_active_incidents())
 
     @staticmethod
     def _highest_confidence(incidents: list[dict[str, Any]]) -> str | None:
@@ -485,6 +500,14 @@ class F1OnTrackIncidentBinarySensor(F1AuxEntity, BinarySensorEntity):
         if not confidence_values:
             return None
         return max(confidence_values, key=lambda value: _CONFIDENCE_RANK.get(value, -1))
+
+
+class F1PossibleOnTrackIncidentBinarySensor(F1OnTrackIncidentBinarySensor):
+    """Binary sensor indicating whether a possible on-track incident is active."""
+
+    _attr_icon = "mdi:alert-outline"
+    _attr_translation_key = "possible_on_track_incident"
+    _active_incident_phases = _POSSIBLE_INCIDENT_PHASES
 
 
 class F1FormationStartBinarySensor(F1AuxEntity, BinarySensorEntity):

--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -79,6 +79,7 @@ SENSOR_OPTIONS = {
     "race_time_to_three_hour_limit": "Race time to 3h limit (live)",
     "safety_car": "Safety car (live)",
     "on_track_incident": "On-track incident (live)",
+    "possible_on_track_incident": "Possible on-track incident (live)",
     "formation_start": "Formation start (replay or live with F1TV access)",
     "race_control": "Race control (live)",
     "top_three": "Top three (leader, live)",

--- a/custom_components/f1_sensor/config_flow.py
+++ b/custom_components/f1_sensor/config_flow.py
@@ -78,6 +78,7 @@ SENSOR_OPTIONS = {
     "session_time_elapsed": "Session time elapsed (live)",
     "race_time_to_three_hour_limit": "Race time to 3h limit (live)",
     "safety_car": "Safety car (live)",
+    "on_track_incident": "On-track incident (live)",
     "formation_start": "Formation start (replay or live with F1TV access)",
     "race_control": "Race control (live)",
     "top_three": "Top three (leader, live)",

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -102,6 +102,7 @@ SUPPORTED_SENSOR_KEYS = frozenset(
         "fia_documents",
         "race_control",
         "on_track_incident",
+        "possible_on_track_incident",
         "top_three",
         "pitstops",
         "championship_prediction",

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -101,6 +101,7 @@ SUPPORTED_SENSOR_KEYS = frozenset(
         "formation_start",
         "fia_documents",
         "race_control",
+        "on_track_incident",
         "top_three",
         "pitstops",
         "championship_prediction",

--- a/custom_components/f1_sensor/device_trigger.py
+++ b/custom_components/f1_sensor/device_trigger.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.homeassistant.triggers import state as state_trigger
 from homeassistant.const import CONF_ENTITY_ID, CONF_FOR, CONF_TYPE
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
@@ -13,8 +13,15 @@ import voluptuous as vol
 
 from .const import DOMAIN
 
-# Maps trigger_type → (unique_id_suffix, entity_domain, to_state or None)
-# to_state=None means "any state change" (fires on every update)
+_INCIDENT_EVENT = f"{DOMAIN}_incident"
+_INCIDENT_EVENT_TRIGGER_PHASES: dict[str, frozenset[str]] = {
+    "possible_on_track_incident_detected": frozenset({"candidate", "confirmed"}),
+    "on_track_incident_detected": frozenset({"confirmed"}),
+}
+
+# Maps trigger_type → (unique_id_suffix, entity_domain, to_state or None).
+# Detected incident triggers are event-based but still use the backing entity for
+# device trigger discovery and config entry scoping.
 _TRIGGER_MAP: dict[str, tuple[str, str, str | None]] = {
     # Race device
     "race_week_started": ("race_week", "binary_sensor", "on"),
@@ -102,7 +109,9 @@ async def async_get_triggers(
 async def async_get_trigger_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, vol.Schema]:
-    """All triggers support the optional 'for' clause."""
+    """Return extra trigger fields supported by the selected trigger type."""
+    if config.get(CONF_TYPE) in _INCIDENT_EVENT_TRIGGER_PHASES:
+        return {"extra_fields": vol.Schema({})}
     return {
         "extra_fields": vol.Schema(
             {vol.Optional(CONF_FOR): cv.positive_time_period_dict}
@@ -118,6 +127,15 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Attach a device trigger by delegating to the HA state trigger."""
     trigger_type = config[CONF_TYPE]
+    if trigger_type in _INCIDENT_EVENT_TRIGGER_PHASES:
+        return _attach_incident_event_trigger(
+            hass,
+            config,
+            action,
+            trigger_info,
+            _INCIDENT_EVENT_TRIGGER_PHASES[trigger_type],
+        )
+
     _suffix, _domain, to_state = _TRIGGER_MAP[trigger_type]
 
     state_config: dict = {
@@ -133,3 +151,45 @@ async def async_attach_trigger(
     return await state_trigger.async_attach_trigger(
         hass, state_config, action, trigger_info, platform_type="device"
     )
+
+
+def _attach_incident_event_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+    phases: frozenset[str],
+) -> CALLBACK_TYPE:
+    """Attach an incident event trigger scoped to the backing F1 config entry."""
+    entity_registry = er.async_get(hass)
+    entity_id = er.async_resolve_entity_id(entity_registry, config[CONF_ENTITY_ID])
+    registry_entry = entity_registry.async_get(entity_id) if entity_id else None
+    config_entry_id = registry_entry.config_entry_id if registry_entry else None
+    job = HassJob(action, f"device trigger {trigger_info}")
+    trigger_data = trigger_info["trigger_data"]
+
+    @callback
+    def _handle_incident_event(event: Event) -> None:
+        event_data = event.data
+        if (
+            config_entry_id is not None
+            and event_data.get("entry_id") != config_entry_id
+        ):
+            return
+        if event_data.get("phase") not in phases:
+            return
+        hass.loop.call_soon(
+            hass.async_run_hass_job,
+            job,
+            {
+                "trigger": {
+                    **trigger_data,
+                    "platform": "device",
+                    "event": event,
+                    "description": f"event '{event.event_type}'",
+                }
+            },
+            event.context,
+        )
+
+    return hass.bus.async_listen(_INCIDENT_EVENT, _handle_incident_event)

--- a/custom_components/f1_sensor/device_trigger.py
+++ b/custom_components/f1_sensor/device_trigger.py
@@ -22,6 +22,18 @@ _TRIGGER_MAP: dict[str, tuple[str, str, str | None]] = {
     # Session device
     "safety_car_deployed": ("safety_car", "binary_sensor", "on"),
     "safety_car_cleared": ("safety_car", "binary_sensor", "off"),
+    "possible_on_track_incident_detected": (
+        "possible_on_track_incident",
+        "binary_sensor",
+        "on",
+    ),
+    "possible_on_track_incident_cleared": (
+        "possible_on_track_incident",
+        "binary_sensor",
+        "off",
+    ),
+    "on_track_incident_detected": ("on_track_incident", "binary_sensor", "on"),
+    "on_track_incident_cleared": ("on_track_incident", "binary_sensor", "off"),
     "formation_start_ready": ("formation_start", "binary_sensor", "on"),
     "overtake_mode_enabled": ("overtake_mode", "binary_sensor", "on"),
     "overtake_mode_disabled": ("overtake_mode", "binary_sensor", "off"),

--- a/custom_components/f1_sensor/diagnostics.py
+++ b/custom_components/f1_sensor/diagnostics.py
@@ -35,6 +35,9 @@ TO_REDACT = {
 _TRACKED_STREAMS = (
     "SessionStatus",
     "TrackStatus",
+    "RaceControlMessages",
+    "TimingData",
+    "DriverList",
     "TopThree",
     "TimingAppData",
     "ChampionshipPrediction",
@@ -96,6 +99,27 @@ def _serialize_live_timing_runtime(live_bus: object) -> dict[str, Any]:
     return runtime
 
 
+def _serialize_incident_runtime(coordinator: object) -> dict[str, Any]:
+    """Return a small incident detection diagnostics summary."""
+    data = getattr(coordinator, "data", None)
+    if not isinstance(data, dict):
+        return {}
+
+    return {
+        "active_count": data.get("active_count"),
+        "highest_confidence": data.get("highest_confidence"),
+        "latest_incident_id": data.get("latest_incident_id"),
+        "latest_driver_number": data.get("latest_driver_number"),
+        "latest_driver_tla": data.get("latest_driver_tla"),
+        "latest_reason": data.get("latest_reason"),
+        "latest_phase": data.get("latest_phase"),
+        "session_type": data.get("session_type"),
+        "session_name": data.get("session_name"),
+        "data_quality": data.get("data_quality"),
+        "available": bool(getattr(coordinator, "available", False)),
+    }
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -132,6 +156,12 @@ async def async_get_config_entry_diagnostics(
     live_bus = entry_runtime.get("live_bus")
     if live_bus is not None:
         runtime["live_timing"] = _serialize_live_timing_runtime(live_bus)
+
+    incident_coordinator = entry_runtime.get("incident_coordinator")
+    if incident_coordinator is not None:
+        runtime["incident_detection"] = _serialize_incident_runtime(
+            incident_coordinator
+        )
 
     entry_data = dict(entry.data)
     if not include_auth_transport:

--- a/custom_components/f1_sensor/incident_detection.py
+++ b/custom_components/f1_sensor/incident_detection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from collections import deque
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
@@ -7,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 import json
 import re
 from typing import Any
+import zlib
 
 DEFAULT_SESSION_KEY = "unknown-session"
 
@@ -53,7 +55,6 @@ SESSION_ACTIVE_STATUSES = frozenset(
 )
 SESSION_TERMINAL_STATUSES = frozenset(
     {
-        "Aborted",
         "Ended",
         "Ends",
         "Finalised",
@@ -130,7 +131,13 @@ _SAFETY_CAR_KEYWORDS = frozenset(
 
 _CAR_WORD_RE = re.compile(r"\b(?:CAR|CARS|DRIVER|DRIVERS)\s+(\d{1,3})\b", re.I)
 _NUMBER_TLA_RE = re.compile(r"\b(\d{1,3})\s*\([A-Z]{2,4}\)\b", re.I)
+_RACE_CONTROL_LAP_DELETION_RE = re.compile(r"\b(?:LAP\s+DELETED|TIME\b.*\bDELETED)\b")
 _NON_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+_CAR_DATA_SPEED_CHANNEL = "2"
+_CAR_DATA_MAX_REASONABLE_SPEED_KPH = 450.0
+_CAR_LOW_SPEED_SIGNAL = "car_low_speed"
+_CAR_MOVING_SIGNAL = "car_moving"
 
 
 @dataclass(frozen=True, slots=True)
@@ -260,6 +267,13 @@ class _ActiveIncident:
     data_quality: str
 
 
+@dataclass(frozen=True, slots=True)
+class _CarSpeedSample:
+    observed_at: datetime
+    speed_kph: float
+    data_quality: str
+
+
 @dataclass(slots=True)
 class _DriverState:
     in_pit: bool | None = None
@@ -270,6 +284,9 @@ class _DriverState:
     seen_stopped_signal: bool = False
     active_incident: _ActiveIncident | None = None
     last_cleared_at: datetime | None = None
+    car_speed_samples: deque[_CarSpeedSample] = field(
+        default_factory=lambda: deque(maxlen=512)
+    )
 
 
 @dataclass(slots=True)
@@ -297,12 +314,30 @@ class IncidentDetector:
         pit_out_hold: timedelta = timedelta(seconds=6),
         cooldown: timedelta = timedelta(seconds=120),
         max_history: int = 256,
+        car_low_speed_threshold_kph: float = 10.0,
+        car_stationary_threshold_kph: float = 3.0,
+        car_moving_clear_threshold_kph: float = 20.0,
+        car_low_speed_duration: timedelta = timedelta(seconds=5),
+        car_stationary_duration: timedelta = timedelta(seconds=2),
+        car_moving_clear_duration: timedelta = timedelta(seconds=5),
+        car_context_window: timedelta = timedelta(seconds=20),
+        car_data_stale_after: timedelta = timedelta(seconds=10),
+        car_candidate_limit: int = 3,
     ) -> None:
         self._correlation_window = correlation_window
         self._pit_out_hold = pit_out_hold
         self._cooldown = cooldown
         self._sessions: dict[str, _SessionState] = {}
         self._max_history = max(1, max_history)
+        self._car_low_speed_threshold_kph = max(0.0, car_low_speed_threshold_kph)
+        self._car_stationary_threshold_kph = max(0.0, car_stationary_threshold_kph)
+        self._car_moving_clear_threshold_kph = max(0.0, car_moving_clear_threshold_kph)
+        self._car_low_speed_duration = car_low_speed_duration
+        self._car_stationary_duration = car_stationary_duration
+        self._car_moving_clear_duration = car_moving_clear_duration
+        self._car_context_window = car_context_window
+        self._car_data_stale_after = car_data_stale_after
+        self._car_candidate_limit = max(1, car_candidate_limit)
 
     def process_signals(
         self, signals: Iterable[IncidentSignal]
@@ -389,6 +424,8 @@ class IncidentDetector:
     def _process_signal(
         self, state: _SessionState, signal: IncidentSignal
     ) -> list[IncidentChange]:
+        if signal.driver is not None:
+            state.drivers[signal.driver.racing_number] = signal.driver
         if signal.kind == "session_context" and signal.session is not None:
             state.metadata = _merge_session_metadata(state.metadata, signal.session)
             return []
@@ -404,6 +441,8 @@ class IncidentDetector:
             return self._apply_race_control(state, signal)
         if signal.kind == "data_gap":
             return []
+        if signal.kind == "car_speed" and signal.racing_number is not None:
+            return self._apply_car_speed(state, signal)
         if signal.kind.startswith("timing_") and signal.racing_number is not None:
             return self._apply_timing(state, signal)
         return []
@@ -464,6 +503,7 @@ class IncidentDetector:
             changes.append(self._make_change(active, PHASE_UPDATED))
             self._remember_incident(state, active.incident_id)
             state.driver_states[rn] = driver_state
+        changes.extend(self._start_car_candidates_from_context(state, signal))
         return changes
 
     def _apply_race_control(
@@ -475,7 +515,7 @@ class IncidentDetector:
 
         changes: list[IncidentChange] = []
         if signal.racing_number is None:
-            return changes
+            return self._start_car_candidates_from_context(state, signal)
 
         driver_state = self._driver_state(state, signal.racing_number)
         active = driver_state.active_incident
@@ -490,12 +530,49 @@ class IncidentDetector:
             active.race_control = rc_context
             _extend_unique(active.signals, signal.signals or ("race_control_incident",))
             active.updated_at = signal.observed_at
+            if (
+                active.phase == PHASE_CANDIDATE
+                and _CAR_LOW_SPEED_SIGNAL in active.signals
+            ):
+                previous = (
+                    active.phase,
+                    active.confidence,
+                    active.reason,
+                    tuple(active.signals),
+                    active.race_control,
+                )
+                if "race_control_stopped" in signal.signals:
+                    active.phase = PHASE_CONFIRMED
+                    active.confidence = CONFIDENCE_HIGH
+                    active.reason = "race_control_stopped_with_car_low_speed"
+                    changes.append(self._make_change(active, PHASE_CONFIRMED))
+                    self._remember_incident(state, active.incident_id)
+                    return changes
+                active.reason = "car_low_speed_with_race_control"
+                current = (
+                    active.phase,
+                    active.confidence,
+                    active.reason,
+                    tuple(active.signals),
+                    active.race_control,
+                )
+                if current == previous:
+                    return []
+                changes.append(self._make_change(active, PHASE_UPDATED))
+                self._remember_incident(state, active.incident_id)
+                return changes
             if _confidence_gt(CONFIDENCE_HIGH, active.confidence):
                 active.confidence = CONFIDENCE_HIGH
                 active.reason = "timing_stopped_with_race_control"
                 changes.append(self._make_change(active, PHASE_UPDATED))
                 self._remember_incident(state, active.incident_id)
             return changes
+
+        car_candidate = self._start_car_candidate_from_context(
+            state, signal.racing_number, signal
+        )
+        if car_candidate:
+            return car_candidate
 
         if not driver_state.seen_stopped_signal or not state.active:
             return []
@@ -560,6 +637,207 @@ class IncidentDetector:
             return []
         return self._start_or_update_stopped_incident(
             state, signal.racing_number, signal
+        )
+
+    def _apply_car_speed(
+        self, state: _SessionState, signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        driver_state = self._driver_state(state, signal.racing_number)
+        speed = _coerce_float(signal.value)
+        if speed is None:
+            return []
+
+        sample = _CarSpeedSample(
+            observed_at=signal.observed_at,
+            speed_kph=speed,
+            data_quality=signal.data_quality,
+        )
+        driver_state.car_speed_samples.append(sample)
+        self._prune_car_speed_samples(driver_state, signal.observed_at)
+
+        if signal.data_quality in {DATA_QUALITY_BOOTSTRAP, DATA_QUALITY_STALE}:
+            return []
+        if not state.active:
+            return []
+
+        moving_change = self._clear_car_candidate_after_movement(
+            driver_state, signal, speed
+        )
+        if moving_change:
+            return moving_change
+
+        if speed > self._car_low_speed_threshold_kph:
+            return []
+
+        track_context, race_context, context_signals = self._find_context(
+            state,
+            signal.racing_number,
+            signal.observed_at,
+            window=self._car_context_window,
+        )
+        if not context_signals:
+            return []
+        if not self._car_candidate_allowed(driver_state, signal.observed_at):
+            return []
+        return self._start_or_update_car_candidate(
+            state,
+            signal.racing_number,
+            signal,
+            track_context=track_context,
+            race_context=race_context,
+            context_signals=context_signals,
+        )
+
+    def _start_car_candidates_from_context(
+        self, state: _SessionState, context_signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        if context_signal.data_quality in {DATA_QUALITY_BOOTSTRAP, DATA_QUALITY_STALE}:
+            return []
+        if not state.active:
+            return []
+
+        candidates = [
+            rn
+            for rn, driver_state in state.driver_states.items()
+            if self._car_candidate_allowed(driver_state, context_signal.observed_at)
+            and self._car_low_speed_context(driver_state, context_signal.observed_at)
+            is not None
+        ]
+        if len(candidates) > self._car_candidate_limit:
+            return []
+
+        changes: list[IncidentChange] = []
+        for rn in candidates:
+            changes.extend(
+                self._start_car_candidate_from_context(state, rn, context_signal)
+            )
+        return changes
+
+    def _start_car_candidate_from_context(
+        self, state: _SessionState, racing_number: str, context_signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        driver_state = self._driver_state(state, racing_number)
+        if not self._car_candidate_allowed(driver_state, context_signal.observed_at):
+            return []
+        if (
+            self._car_low_speed_context(driver_state, context_signal.observed_at)
+            is None
+        ):
+            return []
+
+        track_context, race_context, context_signals = self._context_from_signal(
+            state, racing_number, context_signal
+        )
+        if not context_signals:
+            return []
+
+        return self._start_or_update_car_candidate(
+            state,
+            racing_number,
+            context_signal,
+            track_context=track_context,
+            race_context=race_context,
+            context_signals=context_signals,
+        )
+
+    def _start_or_update_car_candidate(
+        self,
+        state: _SessionState,
+        racing_number: str,
+        signal: IncidentSignal,
+        *,
+        track_context: TrackStatusContext,
+        race_context: RaceControlContext,
+        context_signals: list[str],
+    ) -> list[IncidentChange]:
+        driver_state = self._driver_state(state, racing_number)
+        active = driver_state.active_incident
+        if active is None and not self._has_car_candidate_capacity(state):
+            return []
+        if not self._car_candidate_allowed(driver_state, signal.observed_at):
+            return []
+        low_speed = self._car_low_speed_context(driver_state, signal.observed_at)
+        if low_speed is None:
+            return []
+        low_speed_started_at, stationary = low_speed
+        if self._is_in_cooldown(driver_state, signal.observed_at):
+            return []
+
+        driver = self._driver_metadata(state, racing_number, signal.driver)
+        signals = [_CAR_LOW_SPEED_SIGNAL, *context_signals]
+        if stationary:
+            signals.insert(0, "car_stationary")
+        reason = _reason_for_car_context(
+            track_context=track_context,
+            race_context=race_context,
+        )
+        confidence = CONFIDENCE_MEDIUM
+
+        if active is None:
+            active = _ActiveIncident(
+                incident_id=_build_incident_id(
+                    state.metadata.session_key, racing_number, low_speed_started_at
+                ),
+                phase=PHASE_CANDIDATE,
+                confidence=confidence,
+                reason=reason,
+                driver=driver,
+                session=state.metadata,
+                track_status=track_context,
+                race_control=race_context,
+                signals=signals,
+                started_at=low_speed_started_at,
+                updated_at=signal.observed_at,
+                data_quality=signal.data_quality,
+            )
+            driver_state.active_incident = active
+            self._remember_incident(state, active.incident_id)
+            return [self._make_change(active, PHASE_CANDIDATE)]
+
+        if active.phase != PHASE_CANDIDATE:
+            return []
+
+        previous_signals = tuple(active.signals)
+        previous_confidence = active.confidence
+        previous_reason = active.reason
+        active.driver = driver
+        active.session = state.metadata
+        active.track_status = _merge_track_context(active.track_status, track_context)
+        active.race_control = _merge_race_context(active.race_control, race_context)
+        _extend_unique(active.signals, signals)
+        if _confidence_gt(confidence, active.confidence):
+            active.confidence = confidence
+        active.reason = reason or active.reason
+        if (
+            previous_signals == tuple(active.signals)
+            and previous_confidence == active.confidence
+            and previous_reason == active.reason
+        ):
+            return []
+        active.updated_at = signal.observed_at
+        self._remember_incident(state, active.incident_id)
+        return [self._make_change(active, PHASE_UPDATED)]
+
+    def _clear_car_candidate_after_movement(
+        self, driver_state: _DriverState, signal: IncidentSignal, speed: float
+    ) -> list[IncidentChange]:
+        active = driver_state.active_incident
+        if active is None or active.phase != PHASE_CANDIDATE:
+            return []
+        if _CAR_LOW_SPEED_SIGNAL not in active.signals:
+            return []
+        if speed <= self._car_moving_clear_threshold_kph:
+            return []
+        moving_since = self._car_moving_since(driver_state)
+        if moving_since is None:
+            return []
+        if signal.observed_at - moving_since < self._car_moving_clear_duration:
+            return []
+        return self._clear_driver_incident(
+            driver_state,
+            signal,
+            reason="car_moving",
+            signal_name=_CAR_MOVING_SIGNAL,
         )
 
     def _start_candidate_incident(
@@ -687,8 +965,14 @@ class IncidentDetector:
         return [change]
 
     def _find_context(
-        self, state: _SessionState, racing_number: str, at: datetime
+        self,
+        state: _SessionState,
+        racing_number: str,
+        at: datetime,
+        *,
+        window: timedelta | None = None,
     ) -> tuple[TrackStatusContext, RaceControlContext, list[str]]:
+        correlation_window = self._correlation_window if window is None else window
         track_context = TrackStatusContext()
         race_context = RaceControlContext()
         signals: list[str] = []
@@ -696,7 +980,7 @@ class IncidentDetector:
         for signal in reversed(state.track_status_history):
             if signal.track_status not in TRACK_STATUS_INCIDENT_CONTEXT:
                 continue
-            if not _is_within(signal.observed_at, at, self._correlation_window):
+            if not _is_within(signal.observed_at, at, correlation_window):
                 continue
             track_context = TrackStatusContext(signal.track_status, signal.message)
             signals.append("track_status_" + signal.track_status.lower())
@@ -707,7 +991,7 @@ class IncidentDetector:
                 continue
             if signal.racing_number not in (None, racing_number):
                 continue
-            if not _is_within(signal.observed_at, at, self._correlation_window):
+            if not _is_within(signal.observed_at, at, correlation_window):
                 continue
             race_context = RaceControlContext(
                 signal.message, signal.category, signal.flag
@@ -753,6 +1037,123 @@ class IncidentDetector:
         if state.last_cleared_at is None:
             return False
         return timedelta(0) <= at - state.last_cleared_at < self._cooldown
+
+    def _prune_car_speed_samples(self, state: _DriverState, at: datetime) -> None:
+        retention = max(
+            self._correlation_window,
+            timedelta(seconds=90),
+            key=lambda value: value.total_seconds(),
+        )
+        cutoff = at - retention
+        while (
+            state.car_speed_samples and state.car_speed_samples[0].observed_at < cutoff
+        ):
+            state.car_speed_samples.popleft()
+
+    def _car_candidate_allowed(self, state: _DriverState, at: datetime) -> bool:
+        if state.in_pit is True:
+            return False
+        if self._is_recent_pit_out(state, at):
+            return False
+        if self._is_in_cooldown(state, at):
+            return False
+        active = state.active_incident
+        return active is None or active.phase == PHASE_CANDIDATE
+
+    def _has_car_candidate_capacity(self, state: _SessionState) -> bool:
+        active_car_candidates = 0
+        for driver_state in state.driver_states.values():
+            active = driver_state.active_incident
+            if (
+                active is not None
+                and active.phase == PHASE_CANDIDATE
+                and _CAR_LOW_SPEED_SIGNAL in active.signals
+            ):
+                active_car_candidates += 1
+        return active_car_candidates < self._car_candidate_limit
+
+    def _car_low_speed_context(
+        self, state: _DriverState, at: datetime
+    ) -> tuple[datetime, bool] | None:
+        samples = self._valid_car_samples(state, at)
+        if not samples:
+            return None
+
+        latest = samples[-1]
+        if latest.speed_kph > self._car_low_speed_threshold_kph:
+            return None
+
+        low_speed_started_at = latest.observed_at
+        stationary_started_at = (
+            latest.observed_at
+            if latest.speed_kph <= self._car_stationary_threshold_kph
+            else None
+        )
+        for sample in reversed(samples[:-1]):
+            if sample.speed_kph > self._car_low_speed_threshold_kph:
+                break
+            low_speed_started_at = sample.observed_at
+            if sample.speed_kph <= self._car_stationary_threshold_kph:
+                stationary_started_at = sample.observed_at
+            else:
+                stationary_started_at = None
+
+        low_speed_duration = at - low_speed_started_at
+        stationary = (
+            stationary_started_at is not None
+            and at - stationary_started_at >= self._car_stationary_duration
+        )
+        if low_speed_duration < self._car_low_speed_duration and not stationary:
+            return None
+        return low_speed_started_at, stationary
+
+    def _car_moving_since(self, state: _DriverState) -> datetime | None:
+        samples = [
+            sample
+            for sample in state.car_speed_samples
+            if sample.data_quality not in {DATA_QUALITY_BOOTSTRAP, DATA_QUALITY_STALE}
+        ]
+        if not samples:
+            return None
+        latest = samples[-1]
+        if latest.speed_kph <= self._car_moving_clear_threshold_kph:
+            return None
+        moving_since = latest.observed_at
+        for sample in reversed(samples[:-1]):
+            if sample.speed_kph <= self._car_moving_clear_threshold_kph:
+                break
+            moving_since = sample.observed_at
+        return moving_since
+
+    def _valid_car_samples(
+        self, state: _DriverState, at: datetime
+    ) -> list[_CarSpeedSample]:
+        freshness_window = min(
+            self._car_context_window,
+            self._car_data_stale_after,
+            key=lambda value: value.total_seconds(),
+        )
+        samples = [
+            sample
+            for sample in state.car_speed_samples
+            if sample.data_quality not in {DATA_QUALITY_BOOTSTRAP, DATA_QUALITY_STALE}
+            and timedelta(0) <= at - sample.observed_at <= freshness_window
+        ]
+        samples.sort(key=lambda sample: sample.observed_at)
+        return samples
+
+    def _context_from_signal(
+        self,
+        state: _SessionState,
+        racing_number: str,
+        context_signal: IncidentSignal,
+    ) -> tuple[TrackStatusContext, RaceControlContext, list[str]]:
+        return self._find_context(
+            state,
+            racing_number,
+            context_signal.observed_at,
+            window=self._car_context_window,
+        )
 
     def _remember_incident(self, state: _SessionState, incident_id: str) -> None:
         if incident_id not in state.incident_history:
@@ -834,6 +1235,14 @@ def normalize_stream(
             payload,
             observed_at,
             session=session,
+            data_quality=data_quality,
+        )
+    if stream == "CarData.z":
+        return normalize_car_data(
+            payload,
+            observed_at,
+            session=session,
+            drivers=drivers,
             data_quality=data_quality,
         )
     return []
@@ -1111,6 +1520,17 @@ def normalize_driver_list(
         rn = _normalize_racing_number(raw_driver.get("RacingNumber") or key)
         if rn is None:
             continue
+        if not any(
+            field in raw_driver
+            for field in (
+                "Tla",
+                "FullName",
+                "BroadcastName",
+                "TeamName",
+                "TeamColour",
+            )
+        ):
+            continue
         driver = DriverMetadata(
             racing_number=rn,
             tla=_uppercase_or_none(raw_driver.get("Tla")),
@@ -1134,6 +1554,53 @@ def normalize_driver_list(
     return signals
 
 
+def normalize_car_data(
+    payload: Any,
+    observed_at: datetime | str | None = None,
+    *,
+    session: SessionMetadata | None = None,
+    drivers: Mapping[str, DriverMetadata] | None = None,
+    data_quality: str = DATA_QUALITY_LIVE,
+) -> list[IncidentSignal]:
+    """Normalize CarData.z speed samples into incident detector signals."""
+    observed = _parse_utc(observed_at)
+    session_key = _session_key(session)
+    signals: list[IncidentSignal] = []
+    for entry in _extract_car_data_entries(payload):
+        entry_observed = _parse_utc(_timestamp_from_payload(entry), default=observed)
+        cars = entry.get("Cars")
+        if not isinstance(cars, Mapping):
+            continue
+        for rn_raw, car in cars.items():
+            if not isinstance(car, Mapping):
+                continue
+            rn = _normalize_racing_number(car.get("RacingNumber") or rn_raw)
+            if rn is None:
+                continue
+            speed = _car_speed_from_payload(car)
+            if speed is None:
+                continue
+            signals.append(
+                IncidentSignal(
+                    kind="car_speed",
+                    observed_at=entry_observed,
+                    session_key=session_key,
+                    racing_number=rn,
+                    value=speed,
+                    data_quality=data_quality,
+                    driver=_lookup_driver(drivers, rn),
+                    session=session,
+                    signals=("car_speed",),
+                )
+            )
+    return signals
+
+
+def decode_car_data_payload(payload: Any) -> list[Mapping[str, Any]]:
+    """Decode raw or already-decoded CarData.z payloads into entry mappings."""
+    return _extract_car_data_entries(payload)
+
+
 def normalize_session_type(value: Any) -> str:
     text = str(value or "").strip().lower()
     if not text:
@@ -1142,6 +1609,82 @@ def normalize_session_type(value: Any) -> str:
         if any(needle in text for needle in needles):
             return normalized
     return "unknown"
+
+
+def _extract_car_data_entries(payload: Any) -> list[Mapping[str, Any]]:
+    if isinstance(payload, Mapping):
+        entries = payload.get("Entries")
+        if isinstance(entries, list):
+            return [entry for entry in entries if isinstance(entry, Mapping)]
+        if isinstance(payload.get("Cars"), Mapping):
+            return [payload]
+        return []
+    if isinstance(payload, list):
+        return [entry for entry in payload if isinstance(entry, Mapping)]
+
+    text = _decode_text_payload(payload)
+    if text is None:
+        return []
+
+    entries: list[Mapping[str, Any]] = []
+    for line in text.splitlines() or [text]:
+        line = line.strip()
+        if not line:
+            continue
+        decoded = _decode_car_data_line(line)
+        if isinstance(decoded, Mapping):
+            raw_entries = decoded.get("Entries")
+            if isinstance(raw_entries, list):
+                entries.extend(
+                    entry for entry in raw_entries if isinstance(entry, Mapping)
+                )
+            elif isinstance(decoded.get("Cars"), Mapping):
+                entries.append(decoded)
+    return entries
+
+
+def _decode_text_payload(payload: Any) -> str | None:
+    if isinstance(payload, bytes):
+        return payload.decode("utf-8", errors="ignore")
+    if isinstance(payload, str):
+        return payload
+    return None
+
+
+def _decode_car_data_line(line: str) -> Mapping[str, Any] | None:
+    if not line or line.startswith("URL:"):
+        return None
+    encoded = line
+    if '"' in line:
+        try:
+            _, rest = line.split('"', 1)
+            encoded = rest.split('"', 1)[0]
+        except ValueError:
+            return None
+    encoded = encoded.strip()
+    if not encoded:
+        return None
+    try:
+        raw = base64.b64decode(encoded)
+        payload = zlib.decompress(raw, wbits=-15)
+        decoded = json.loads(payload)
+    except Exception:  # noqa: BLE001
+        return None
+    return decoded if isinstance(decoded, Mapping) else None
+
+
+def _car_speed_from_payload(car: Mapping[str, Any]) -> float | None:
+    channels = car.get("Channels")
+    if not isinstance(channels, Mapping):
+        return None
+    speed = _coerce_float(
+        channels.get(_CAR_DATA_SPEED_CHANNEL)
+        if _CAR_DATA_SPEED_CHANNEL in channels
+        else channels.get(int(_CAR_DATA_SPEED_CHANNEL))
+    )
+    if speed is None or speed < 0 or speed > _CAR_DATA_MAX_REASONABLE_SPEED_KPH:
+        return None
+    return speed
 
 
 def _normalize_signal_datetime(signal: IncidentSignal) -> IncidentSignal:
@@ -1245,6 +1788,22 @@ def _coerce_bool(value: Any) -> bool | None:
     return None
 
 
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            return None
+    return None
+
+
 def _normalize_track_status_value(payload: Mapping[str, Any]) -> str | None:
     message = str(payload.get("Message") or payload.get("TrackStatus") or "").upper()
     status = str(payload.get("Status") or "").strip()
@@ -1292,7 +1851,8 @@ def _race_control_signal_names(item: Mapping[str, Any]) -> tuple[str, ...]:
     names: list[str] = []
     if any(word in text for word in _RACE_CONTROL_CLEAR_WORDS):
         names.append("race_control_clear")
-    if "DOUBLE YELLOW" in text or "YELLOW" in text:
+    yellow_is_context = _race_control_yellow_is_context(text)
+    if yellow_is_context:
         names.append("race_control_yellow")
     if "RED FLAG" in text or re.search(r"\bRED\b", text):
         names.append("race_control_red")
@@ -1300,9 +1860,21 @@ def _race_control_signal_names(item: Mapping[str, Any]) -> tuple[str, ...]:
         names.append("race_control_safety_car")
     if "STOPPED" in text or re.search(r"\bSTOP\b", text):
         names.append("race_control_stopped")
-    if any(word in text for word in _INCIDENT_KEYWORDS):
+    if any(word in text for word in _INCIDENT_KEYWORDS) and (
+        "YELLOW" not in text or yellow_is_context
+    ):
         names.append("race_control_incident")
     return tuple(dict.fromkeys(names))
+
+
+def _race_control_yellow_is_context(text: str) -> bool:
+    if "YELLOW" not in text:
+        return False
+    if "PIT LANE" in text:
+        return False
+    if "DELETED" in text and _RACE_CONTROL_LAP_DELETION_RE.search(text):
+        return False
+    return True
 
 
 def _race_control_is_context(signal: IncidentSignal) -> bool:
@@ -1466,6 +2038,41 @@ def _reason_for_context(
     if track_context is not None and track_context.status is not None:
         return "timing_stopped_with_track_status"
     return "timing_stopped"
+
+
+def _reason_for_car_context(
+    *,
+    track_context: TrackStatusContext | None = None,
+    race_context: RaceControlContext | None = None,
+) -> str:
+    if track_context is not None and track_context.status is not None:
+        if track_context.status == TRACK_STATUS_SC:
+            return "car_low_speed_with_safety_car_context"
+        if track_context.status == TRACK_STATUS_VSC:
+            return "car_low_speed_with_vsc_context"
+        if track_context.status == TRACK_STATUS_RED:
+            return "car_low_speed_with_red_flag_context"
+    if race_context is not None and race_context.message is not None:
+        return "car_low_speed_with_race_control"
+    if track_context is not None and track_context.status is not None:
+        return "car_low_speed_with_track_status"
+    return "car_low_speed"
+
+
+def _merge_track_context(
+    current: TrackStatusContext, new: TrackStatusContext
+) -> TrackStatusContext:
+    if new.status is not None or new.message is not None:
+        return new
+    return current
+
+
+def _merge_race_context(
+    current: RaceControlContext, new: RaceControlContext
+) -> RaceControlContext:
+    if new.message is not None or new.category is not None or new.flag is not None:
+        return new
+    return current
 
 
 def _append_unique(values: list[str], value: str) -> None:

--- a/custom_components/f1_sensor/incident_detection.py
+++ b/custom_components/f1_sensor/incident_detection.py
@@ -1,0 +1,1482 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+import json
+import re
+from typing import Any
+
+DEFAULT_SESSION_KEY = "unknown-session"
+
+CONFIDENCE_LOW = "low"
+CONFIDENCE_MEDIUM = "medium"
+CONFIDENCE_HIGH = "high"
+CONFIDENCE_ORDER = {
+    CONFIDENCE_LOW: 0,
+    CONFIDENCE_MEDIUM: 1,
+    CONFIDENCE_HIGH: 2,
+}
+
+PHASE_CANDIDATE = "candidate"
+PHASE_CONFIRMED = "confirmed"
+PHASE_UPDATED = "updated"
+PHASE_CLEARED = "cleared"
+
+DATA_QUALITY_LIVE = "live"
+DATA_QUALITY_REPLAY = "replay"
+DATA_QUALITY_STALE = "stale"
+DATA_QUALITY_BOOTSTRAP = "bootstrap"
+
+TRACK_STATUS_CLEAR = "CLEAR"
+TRACK_STATUS_YELLOW = "YELLOW"
+TRACK_STATUS_VSC = "VSC"
+TRACK_STATUS_SC = "SC"
+TRACK_STATUS_RED = "RED"
+TRACK_STATUS_INCIDENT_CONTEXT = frozenset(
+    {
+        TRACK_STATUS_YELLOW,
+        TRACK_STATUS_VSC,
+        TRACK_STATUS_SC,
+        TRACK_STATUS_RED,
+    }
+)
+
+SESSION_ACTIVE_STATUSES = frozenset(
+    {
+        "Started",
+        "Resumed",
+        "Green",
+        "GreenFlag",
+    }
+)
+SESSION_TERMINAL_STATUSES = frozenset(
+    {
+        "Aborted",
+        "Ended",
+        "Ends",
+        "Finalised",
+        "Finished",
+        "Inactive",
+    }
+)
+
+_TRACK_STATUS_ALIASES = {
+    "ALLCLEAR": TRACK_STATUS_CLEAR,
+    "CLEAR": TRACK_STATUS_CLEAR,
+    "YELLOW": TRACK_STATUS_YELLOW,
+    "DOUBLE YELLOW": TRACK_STATUS_YELLOW,
+    "DOUBLEYELLOW": TRACK_STATUS_YELLOW,
+    "VSC": TRACK_STATUS_VSC,
+    "VSCDEPLOYED": TRACK_STATUS_VSC,
+    "VSC DEPLOYED": TRACK_STATUS_VSC,
+    "VSC ENDING": TRACK_STATUS_VSC,
+    "VSCENDING": TRACK_STATUS_VSC,
+    "SAFETY CAR": TRACK_STATUS_SC,
+    "SAFETYCAR": TRACK_STATUS_SC,
+    "SC": TRACK_STATUS_SC,
+    "SC DEPLOYED": TRACK_STATUS_SC,
+    "SCDEPLOYED": TRACK_STATUS_SC,
+    "SC ENDING": TRACK_STATUS_SC,
+    "RED": TRACK_STATUS_RED,
+    "RED FLAG": TRACK_STATUS_RED,
+    "REDFLAG": TRACK_STATUS_RED,
+}
+
+_TRACK_STATUS_CODES = {
+    "1": TRACK_STATUS_CLEAR,
+    "2": TRACK_STATUS_YELLOW,
+    "4": TRACK_STATUS_SC,
+    "5": TRACK_STATUS_RED,
+    "6": TRACK_STATUS_VSC,
+    "7": TRACK_STATUS_VSC,
+    "8": TRACK_STATUS_CLEAR,
+}
+
+_SESSION_TYPE_PATTERNS = (
+    ("testing", ("test", "testing")),
+    ("sprint", ("sprint",)),
+    ("qualifying", ("qualifying", "sprint shootout", "shootout")),
+    ("practice", ("practice", "free practice", "fp1", "fp2", "fp3")),
+    ("race", ("race", "grand prix")),
+)
+
+_INCIDENT_KEYWORDS = frozenset(
+    {
+        "ACCIDENT",
+        "CRASH",
+        "DOUBLE YELLOW",
+        "INCIDENT",
+        "OFF TRACK",
+        "RED FLAG",
+        "SPUN",
+        "STOP",
+        "STOPPED",
+        "YELLOW",
+    }
+)
+_RACE_CONTROL_CLEAR_WORDS = frozenset({"CLEAR", "ALL CLEAR"})
+_SAFETY_CAR_KEYWORDS = frozenset(
+    {
+        "SAFETY CAR",
+        "SC DEPLOYED",
+        "SCDEPLOYED",
+        "VSC",
+        "VSC DEPLOYED",
+        "VSCDEPLOYED",
+    }
+)
+
+_CAR_WORD_RE = re.compile(r"\b(?:CAR|CARS|DRIVER|DRIVERS)\s+(\d{1,3})\b", re.I)
+_NUMBER_TLA_RE = re.compile(r"\b(\d{1,3})\s*\([A-Z]{2,4}\)\b", re.I)
+_NON_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass(frozen=True, slots=True)
+class DriverMetadata:
+    racing_number: str
+    tla: str | None = None
+    name: str | None = None
+    team: str | None = None
+    team_color: str | None = None
+
+    def to_event_payload(self) -> dict[str, str | None]:
+        return {
+            "racing_number": self.racing_number,
+            "tla": self.tla,
+            "name": self.name,
+            "team": self.team,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SessionMetadata:
+    session_key: str = DEFAULT_SESSION_KEY
+    meeting_name: str | None = None
+    session_name: str | None = None
+    session_type: str | None = None
+
+    def to_event_payload(self) -> dict[str, str | None]:
+        return {
+            "meeting_name": self.meeting_name,
+            "session_name": self.session_name,
+            "session_type": self.session_type,
+            "session_key": self.session_key,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TrackStatusContext:
+    status: str | None = None
+    message: str | None = None
+
+    def to_event_payload(self) -> dict[str, str | None]:
+        return {
+            "status": self.status,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RaceControlContext:
+    message: str | None = None
+    category: str | None = None
+    flag: str | None = None
+
+    def to_event_payload(self) -> dict[str, str | None]:
+        return {
+            "message": self.message,
+            "category": self.category,
+            "flag": self.flag,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class IncidentSignal:
+    kind: str
+    observed_at: datetime
+    session_key: str = DEFAULT_SESSION_KEY
+    racing_number: str | None = None
+    value: bool | str | int | None = None
+    data_quality: str = DATA_QUALITY_LIVE
+    confidence_hint: str | None = None
+    reason: str | None = None
+    message: str | None = None
+    category: str | None = None
+    flag: str | None = None
+    track_status: str | None = None
+    driver: DriverMetadata | None = None
+    session: SessionMetadata | None = None
+    signals: tuple[str, ...] = ()
+    raw_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class IncidentChange:
+    incident_id: str
+    phase: str
+    confidence: str
+    reason: str
+    driver: DriverMetadata
+    session: SessionMetadata
+    track_status: TrackStatusContext
+    race_control: RaceControlContext
+    signals: tuple[str, ...]
+    started_at: datetime
+    updated_at: datetime
+    data_quality: str
+
+    def to_event_payload(self) -> dict[str, Any]:
+        return {
+            "incident_id": self.incident_id,
+            "phase": self.phase,
+            "confidence": self.confidence,
+            "reason": self.reason,
+            "driver": self.driver.to_event_payload(),
+            "session": self.session.to_event_payload(),
+            "track_status": self.track_status.to_event_payload(),
+            "race_control": self.race_control.to_event_payload(),
+            "signals": list(self.signals),
+            "started_at": _format_utc(self.started_at),
+            "updated_at": _format_utc(self.updated_at),
+            "data_quality": self.data_quality,
+        }
+
+
+@dataclass(slots=True)
+class _ActiveIncident:
+    incident_id: str
+    phase: str
+    confidence: str
+    reason: str
+    driver: DriverMetadata
+    session: SessionMetadata
+    track_status: TrackStatusContext
+    race_control: RaceControlContext
+    signals: list[str]
+    started_at: datetime
+    updated_at: datetime
+    data_quality: str
+
+
+@dataclass(slots=True)
+class _DriverState:
+    in_pit: bool | None = None
+    pit_out: bool | None = None
+    pit_out_at: datetime | None = None
+    retired: bool | None = None
+    stopped: bool | None = None
+    seen_stopped_signal: bool = False
+    active_incident: _ActiveIncident | None = None
+    last_cleared_at: datetime | None = None
+
+
+@dataclass(slots=True)
+class _SessionState:
+    metadata: SessionMetadata = field(default_factory=SessionMetadata)
+    active: bool = True
+    drivers: dict[str, DriverMetadata] = field(default_factory=dict)
+    driver_states: dict[str, _DriverState] = field(default_factory=dict)
+    track_status_history: deque[IncidentSignal] = field(
+        default_factory=lambda: deque(maxlen=256)
+    )
+    race_control_history: deque[IncidentSignal] = field(
+        default_factory=lambda: deque(maxlen=256)
+    )
+    incident_history: deque[str] = field(default_factory=lambda: deque(maxlen=256))
+
+
+class IncidentDetector:
+    """State machine for stopped/on-track incident detection."""
+
+    def __init__(
+        self,
+        *,
+        correlation_window: timedelta = timedelta(seconds=120),
+        pit_out_hold: timedelta = timedelta(seconds=6),
+        cooldown: timedelta = timedelta(seconds=120),
+        max_history: int = 256,
+    ) -> None:
+        self._correlation_window = correlation_window
+        self._pit_out_hold = pit_out_hold
+        self._cooldown = cooldown
+        self._sessions: dict[str, _SessionState] = {}
+        self._max_history = max(1, max_history)
+
+    def process_signals(
+        self, signals: Iterable[IncidentSignal]
+    ) -> list[IncidentChange]:
+        changes: list[IncidentChange] = []
+        for signal in signals:
+            normalized_signal = _normalize_signal_datetime(signal)
+            state = self._session_state(normalized_signal)
+            changes.extend(self._process_signal(state, normalized_signal))
+        return changes
+
+    def process_stream(
+        self,
+        stream: str,
+        payload: Any,
+        observed_at: datetime | str | None = None,
+        *,
+        session: SessionMetadata | None = None,
+        drivers: Mapping[str, DriverMetadata] | None = None,
+        data_quality: str = DATA_QUALITY_LIVE,
+    ) -> list[IncidentChange]:
+        return self.process_signals(
+            normalize_stream(
+                stream,
+                payload,
+                observed_at,
+                session=session,
+                drivers=drivers,
+                data_quality=data_quality,
+            )
+        )
+
+    def get_active_incident(
+        self, session_key: str, racing_number: str
+    ) -> IncidentChange | None:
+        session = self._sessions.get(session_key)
+        if session is None:
+            return None
+        driver = session.driver_states.get(str(racing_number))
+        if driver is None or driver.active_incident is None:
+            return None
+        return self._make_change(driver.active_incident, driver.active_incident.phase)
+
+    def active_incidents(
+        self, session_key: str | None = None
+    ) -> tuple[IncidentChange, ...]:
+        states: Iterable[_SessionState]
+        if session_key is None:
+            states = self._sessions.values()
+        else:
+            state = self._sessions.get(session_key)
+            states = () if state is None else (state,)
+
+        incidents: list[IncidentChange] = []
+        for state in states:
+            for driver_state in state.driver_states.values():
+                if driver_state.active_incident is not None:
+                    incidents.append(
+                        self._make_change(
+                            driver_state.active_incident,
+                            driver_state.active_incident.phase,
+                        )
+                    )
+        return tuple(incidents)
+
+    def _session_state(self, signal: IncidentSignal) -> _SessionState:
+        key = signal.session.session_key if signal.session else signal.session_key
+        if not key:
+            key = DEFAULT_SESSION_KEY
+        state = self._sessions.get(key)
+        if state is None:
+            metadata = signal.session or SessionMetadata(session_key=key)
+            state = _SessionState(
+                metadata=metadata,
+                track_status_history=deque(maxlen=self._max_history),
+                race_control_history=deque(maxlen=self._max_history),
+                incident_history=deque(maxlen=self._max_history),
+            )
+            self._sessions[key] = state
+        elif signal.session is not None:
+            state.metadata = _merge_session_metadata(state.metadata, signal.session)
+        return state
+
+    def _process_signal(
+        self, state: _SessionState, signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        if signal.kind == "session_context" and signal.session is not None:
+            state.metadata = _merge_session_metadata(state.metadata, signal.session)
+            return []
+        if signal.kind == "driver_metadata" and signal.driver is not None:
+            state.drivers[signal.driver.racing_number] = signal.driver
+            self._refresh_active_driver_metadata(state, signal.driver)
+            return []
+        if signal.kind == "session_status":
+            return self._apply_session_status(state, signal)
+        if signal.kind == "track_status":
+            return self._apply_track_status(state, signal)
+        if signal.kind == "race_control":
+            return self._apply_race_control(state, signal)
+        if signal.kind == "data_gap":
+            return []
+        if signal.kind.startswith("timing_") and signal.racing_number is not None:
+            return self._apply_timing(state, signal)
+        return []
+
+    def _apply_session_status(
+        self, state: _SessionState, signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        status = str(signal.value or "").strip()
+        if status in SESSION_ACTIVE_STATUSES:
+            state.active = True
+            return []
+        if status not in SESSION_TERMINAL_STATUSES:
+            return []
+
+        state.active = False
+        changes: list[IncidentChange] = []
+        for driver_state in state.driver_states.values():
+            if driver_state.active_incident is None:
+                continue
+            active = driver_state.active_incident
+            _append_unique(active.signals, "session_ended")
+            active.reason = "session_ended"
+            active.updated_at = signal.observed_at
+            change = self._make_change(active, PHASE_CLEARED)
+            changes.append(change)
+            driver_state.last_cleared_at = signal.observed_at
+            driver_state.active_incident = None
+        return changes
+
+    def _apply_track_status(
+        self, state: _SessionState, signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        if signal.track_status is None:
+            return []
+        state.track_status_history.append(signal)
+        if signal.track_status not in TRACK_STATUS_INCIDENT_CONTEXT:
+            return []
+
+        changes: list[IncidentChange] = []
+        for rn, driver_state in state.driver_states.items():
+            active = driver_state.active_incident
+            if active is None or active.phase != PHASE_CONFIRMED:
+                continue
+            if not _is_within(
+                signal.observed_at, active.started_at, self._correlation_window
+            ):
+                continue
+            if active.confidence == CONFIDENCE_HIGH:
+                continue
+            context = TrackStatusContext(signal.track_status, signal.message)
+            active.track_status = context
+            active.confidence = CONFIDENCE_HIGH
+            active.reason = _reason_for_context(track_context=context)
+            active.updated_at = signal.observed_at
+            _append_unique(
+                active.signals, "track_status_" + signal.track_status.lower()
+            )
+            changes.append(self._make_change(active, PHASE_UPDATED))
+            self._remember_incident(state, active.incident_id)
+            state.driver_states[rn] = driver_state
+        return changes
+
+    def _apply_race_control(
+        self, state: _SessionState, signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        state.race_control_history.append(signal)
+        if not _race_control_is_context(signal):
+            return []
+
+        changes: list[IncidentChange] = []
+        if signal.racing_number is None:
+            return changes
+
+        driver_state = self._driver_state(state, signal.racing_number)
+        active = driver_state.active_incident
+        if active is not None:
+            if not _is_within(
+                signal.observed_at, active.started_at, self._correlation_window
+            ):
+                return []
+            rc_context = RaceControlContext(
+                signal.message, signal.category, signal.flag
+            )
+            active.race_control = rc_context
+            _extend_unique(active.signals, signal.signals or ("race_control_incident",))
+            active.updated_at = signal.observed_at
+            if _confidence_gt(CONFIDENCE_HIGH, active.confidence):
+                active.confidence = CONFIDENCE_HIGH
+                active.reason = "timing_stopped_with_race_control"
+                changes.append(self._make_change(active, PHASE_UPDATED))
+                self._remember_incident(state, active.incident_id)
+            return changes
+
+        if not driver_state.seen_stopped_signal or not state.active:
+            return []
+        if driver_state.stopped is True:
+            return self._start_or_update_stopped_incident(
+                state, signal.racing_number, signal
+            )
+        return self._start_candidate_incident(state, signal.racing_number, signal)
+
+    def _apply_timing(
+        self, state: _SessionState, signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        driver_state = self._driver_state(state, signal.racing_number)
+
+        if signal.kind == "timing_in_pit":
+            driver_state.in_pit = _coerce_bool(signal.value)
+            if driver_state.in_pit is True and driver_state.active_incident is not None:
+                return self._clear_driver_incident(
+                    driver_state,
+                    signal,
+                    reason="pit",
+                    signal_name="pit_suppressed",
+                )
+            return []
+
+        if signal.kind == "timing_pit_out":
+            pit_out = _coerce_bool(signal.value)
+            driver_state.pit_out = pit_out
+            if pit_out is True:
+                driver_state.pit_out_at = signal.observed_at
+            return []
+
+        if signal.kind == "timing_retired":
+            driver_state.retired = _coerce_bool(signal.value)
+            return []
+
+        if signal.kind != "timing_stopped":
+            return []
+
+        stopped = _coerce_bool(signal.value)
+        if stopped is None:
+            return []
+
+        if not driver_state.seen_stopped_signal:
+            driver_state.seen_stopped_signal = True
+            driver_state.stopped = stopped
+            return []
+
+        previous = driver_state.stopped
+        driver_state.stopped = stopped
+        if stopped is False:
+            if driver_state.active_incident is None:
+                return []
+            return self._clear_driver_incident(
+                driver_state,
+                signal,
+                reason="timing_moving",
+                signal_name="timing_moving",
+            )
+
+        if previous is True:
+            return []
+        return self._start_or_update_stopped_incident(
+            state, signal.racing_number, signal
+        )
+
+    def _start_candidate_incident(
+        self, state: _SessionState, racing_number: str, signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        driver_state = self._driver_state(state, racing_number)
+        if self._is_in_cooldown(driver_state, signal.observed_at):
+            return []
+        driver = self._driver_metadata(state, racing_number, signal.driver)
+        incident = _ActiveIncident(
+            incident_id=_build_incident_id(
+                state.metadata.session_key, racing_number, signal.observed_at
+            ),
+            phase=PHASE_CANDIDATE,
+            confidence=signal.confidence_hint or CONFIDENCE_MEDIUM,
+            reason=signal.reason or "race_control_incident",
+            driver=driver,
+            session=state.metadata,
+            track_status=TrackStatusContext(),
+            race_control=RaceControlContext(
+                signal.message, signal.category, signal.flag
+            ),
+            signals=list(signal.signals or ("race_control_incident",)),
+            started_at=signal.observed_at,
+            updated_at=signal.observed_at,
+            data_quality=signal.data_quality,
+        )
+        driver_state.active_incident = incident
+        self._remember_incident(state, incident.incident_id)
+        return [self._make_change(incident, PHASE_CANDIDATE)]
+
+    def _start_or_update_stopped_incident(
+        self, state: _SessionState, racing_number: str, signal: IncidentSignal
+    ) -> list[IncidentChange]:
+        driver_state = self._driver_state(state, racing_number)
+        if not state.active:
+            return []
+        if driver_state.in_pit is True:
+            return []
+        if self._is_recent_pit_out(driver_state, signal.observed_at):
+            return []
+        if self._is_in_cooldown(driver_state, signal.observed_at):
+            return []
+
+        track_context, race_context, context_signals = self._find_context(
+            state, racing_number, signal.observed_at
+        )
+        confidence = CONFIDENCE_HIGH if context_signals else CONFIDENCE_MEDIUM
+        reason = _reason_for_context(
+            track_context=track_context,
+            race_context=race_context,
+        )
+        driver = self._driver_metadata(state, racing_number, signal.driver)
+        active = driver_state.active_incident
+        if (
+            active is not None
+            and active.phase == PHASE_CANDIDATE
+            and not _is_within(
+                active.started_at, signal.observed_at, self._correlation_window
+            )
+        ):
+            driver_state.active_incident = None
+            active = None
+
+        if active is None:
+            active = _ActiveIncident(
+                incident_id=_build_incident_id(
+                    state.metadata.session_key, racing_number, signal.observed_at
+                ),
+                phase=PHASE_CONFIRMED,
+                confidence=confidence,
+                reason=reason,
+                driver=driver,
+                session=state.metadata,
+                track_status=track_context,
+                race_control=race_context,
+                signals=["timing_stopped", *context_signals],
+                started_at=signal.observed_at,
+                updated_at=signal.observed_at,
+                data_quality=signal.data_quality,
+            )
+            driver_state.active_incident = active
+            self._remember_incident(state, active.incident_id)
+            return [self._make_change(active, PHASE_CONFIRMED)]
+
+        active.driver = driver
+        active.session = state.metadata
+        active.updated_at = signal.observed_at
+        active.track_status = track_context
+        active.race_control = race_context
+        _append_unique(active.signals, "timing_stopped")
+        _extend_unique(active.signals, context_signals)
+
+        if active.phase == PHASE_CANDIDATE:
+            active.phase = PHASE_CONFIRMED
+            active.confidence = confidence
+            active.reason = reason
+            self._remember_incident(state, active.incident_id)
+            return [self._make_change(active, PHASE_CONFIRMED)]
+
+        if _confidence_gt(confidence, active.confidence):
+            active.confidence = confidence
+            active.reason = reason
+            self._remember_incident(state, active.incident_id)
+            return [self._make_change(active, PHASE_UPDATED)]
+        return []
+
+    def _clear_driver_incident(
+        self,
+        driver_state: _DriverState,
+        signal: IncidentSignal,
+        *,
+        reason: str,
+        signal_name: str,
+    ) -> list[IncidentChange]:
+        active = driver_state.active_incident
+        if active is None:
+            return []
+        active.reason = reason
+        active.updated_at = signal.observed_at
+        _append_unique(active.signals, signal_name)
+        change = self._make_change(active, PHASE_CLEARED)
+        driver_state.last_cleared_at = signal.observed_at
+        driver_state.active_incident = None
+        return [change]
+
+    def _find_context(
+        self, state: _SessionState, racing_number: str, at: datetime
+    ) -> tuple[TrackStatusContext, RaceControlContext, list[str]]:
+        track_context = TrackStatusContext()
+        race_context = RaceControlContext()
+        signals: list[str] = []
+
+        for signal in reversed(state.track_status_history):
+            if signal.track_status not in TRACK_STATUS_INCIDENT_CONTEXT:
+                continue
+            if not _is_within(signal.observed_at, at, self._correlation_window):
+                continue
+            track_context = TrackStatusContext(signal.track_status, signal.message)
+            signals.append("track_status_" + signal.track_status.lower())
+            break
+
+        for signal in reversed(state.race_control_history):
+            if not _race_control_is_context(signal):
+                continue
+            if signal.racing_number not in (None, racing_number):
+                continue
+            if not _is_within(signal.observed_at, at, self._correlation_window):
+                continue
+            race_context = RaceControlContext(
+                signal.message, signal.category, signal.flag
+            )
+            _extend_unique(signals, signal.signals or ("race_control_incident",))
+            break
+
+        return track_context, race_context, signals
+
+    def _driver_metadata(
+        self,
+        state: _SessionState,
+        racing_number: str,
+        signal_driver: DriverMetadata | None = None,
+    ) -> DriverMetadata:
+        driver = signal_driver or state.drivers.get(racing_number)
+        if driver is not None:
+            return driver
+        return DriverMetadata(racing_number=racing_number, name=racing_number)
+
+    def _driver_state(
+        self, state: _SessionState, racing_number: str | None
+    ) -> _DriverState:
+        rn = str(racing_number or "").strip()
+        return state.driver_states.setdefault(rn, _DriverState())
+
+    def _refresh_active_driver_metadata(
+        self, state: _SessionState, driver: DriverMetadata
+    ) -> None:
+        driver_state = state.driver_states.get(driver.racing_number)
+        if driver_state is None or driver_state.active_incident is None:
+            return
+        driver_state.active_incident.driver = driver
+
+    def _is_recent_pit_out(self, state: _DriverState, at: datetime) -> bool:
+        if state.pit_out is True:
+            return True
+        if state.pit_out_at is None:
+            return False
+        return timedelta(0) <= at - state.pit_out_at <= self._pit_out_hold
+
+    def _is_in_cooldown(self, state: _DriverState, at: datetime) -> bool:
+        if state.last_cleared_at is None:
+            return False
+        return timedelta(0) <= at - state.last_cleared_at < self._cooldown
+
+    def _remember_incident(self, state: _SessionState, incident_id: str) -> None:
+        if incident_id not in state.incident_history:
+            state.incident_history.append(incident_id)
+
+    @staticmethod
+    def _make_change(active: _ActiveIncident, phase: str) -> IncidentChange:
+        return IncidentChange(
+            incident_id=active.incident_id,
+            phase=phase,
+            confidence=active.confidence,
+            reason=active.reason,
+            driver=active.driver,
+            session=active.session,
+            track_status=active.track_status,
+            race_control=active.race_control,
+            signals=tuple(active.signals),
+            started_at=active.started_at,
+            updated_at=active.updated_at,
+            data_quality=active.data_quality,
+        )
+
+
+def normalize_stream(
+    stream: str,
+    payload: Any,
+    observed_at: datetime | str | None = None,
+    *,
+    session: SessionMetadata | None = None,
+    drivers: Mapping[str, DriverMetadata] | None = None,
+    data_quality: str = DATA_QUALITY_LIVE,
+) -> list[IncidentSignal]:
+    if stream == "TimingData":
+        return normalize_timing_data(
+            payload,
+            observed_at,
+            session=session,
+            drivers=drivers,
+            data_quality=data_quality,
+        )
+    if stream == "TrackStatus":
+        return normalize_track_status(
+            payload,
+            observed_at,
+            session=session,
+            data_quality=data_quality,
+        )
+    if stream == "RaceControlMessages":
+        return normalize_race_control_messages(
+            payload,
+            observed_at,
+            session=session,
+            drivers=drivers,
+            data_quality=data_quality,
+        )
+    if stream == "SessionInfo":
+        return normalize_session_info(
+            payload,
+            observed_at,
+            session=session,
+            data_quality=data_quality,
+        )
+    if stream == "SessionData":
+        return normalize_session_data(
+            payload,
+            observed_at,
+            session=session,
+            data_quality=data_quality,
+        )
+    if stream == "SessionStatus":
+        return normalize_session_status(
+            payload,
+            observed_at,
+            session=session,
+            data_quality=data_quality,
+        )
+    if stream == "DriverList":
+        return normalize_driver_list(
+            payload,
+            observed_at,
+            session=session,
+            data_quality=data_quality,
+        )
+    return []
+
+
+def normalize_timing_data(
+    payload: Any,
+    observed_at: datetime | str | None = None,
+    *,
+    session: SessionMetadata | None = None,
+    drivers: Mapping[str, DriverMetadata] | None = None,
+    data_quality: str = DATA_QUALITY_LIVE,
+) -> list[IncidentSignal]:
+    if not isinstance(payload, Mapping):
+        return []
+    lines = payload.get("Lines")
+    if not isinstance(lines, Mapping):
+        return []
+
+    observed = _parse_utc(observed_at)
+    session_key = _session_key(session)
+    signals: list[IncidentSignal] = []
+    for rn_raw, timing in lines.items():
+        if not isinstance(timing, Mapping):
+            continue
+        rn = _normalize_racing_number(timing.get("RacingNumber") or rn_raw)
+        if rn is None:
+            continue
+        driver = _lookup_driver(drivers, rn)
+        for field_name, kind in (
+            ("InPit", "timing_in_pit"),
+            ("PitOut", "timing_pit_out"),
+            ("Retired", "timing_retired"),
+            ("Stopped", "timing_stopped"),
+        ):
+            if field_name not in timing:
+                continue
+            value = _coerce_bool(timing.get(field_name))
+            if value is None:
+                continue
+            signals.append(
+                IncidentSignal(
+                    kind=kind,
+                    observed_at=observed,
+                    session_key=session_key,
+                    racing_number=rn,
+                    value=value,
+                    data_quality=data_quality,
+                    driver=driver,
+                    session=session,
+                    signals=(kind,),
+                )
+            )
+    return signals
+
+
+def normalize_track_status(
+    payload: Any,
+    observed_at: datetime | str | None = None,
+    *,
+    session: SessionMetadata | None = None,
+    data_quality: str = DATA_QUALITY_LIVE,
+) -> list[IncidentSignal]:
+    if not isinstance(payload, Mapping):
+        return []
+    status = _normalize_track_status_value(payload)
+    if status is None:
+        return []
+    message = _string_or_none(payload.get("Message") or payload.get("TrackStatus"))
+    signal_name = "track_status_" + status.lower()
+    return [
+        IncidentSignal(
+            kind="track_status",
+            observed_at=_parse_utc(_timestamp_from_payload(payload) or observed_at),
+            session_key=_session_key(session),
+            value=status,
+            data_quality=data_quality,
+            message=message,
+            track_status=status,
+            session=session,
+            signals=(signal_name,),
+            raw_id=_payload_fingerprint(payload),
+        )
+    ]
+
+
+def normalize_race_control_messages(
+    payload: Any,
+    observed_at: datetime | str | None = None,
+    *,
+    session: SessionMetadata | None = None,
+    drivers: Mapping[str, DriverMetadata] | None = None,
+    data_quality: str = DATA_QUALITY_LIVE,
+) -> list[IncidentSignal]:
+    observed = _parse_utc(observed_at)
+    session_key = _session_key(session)
+    signals: list[IncidentSignal] = []
+    for item in _extract_race_control_items(payload):
+        message = _string_or_none(item.get("Message") or item.get("Text"))
+        category = _string_or_none(item.get("Category") or item.get("CategoryType"))
+        flag = _string_or_none(item.get("Flag"))
+        signal_names = _race_control_signal_names(item)
+        confidence = (
+            CONFIDENCE_HIGH
+            if "race_control_stopped" in signal_names
+            or "race_control_red" in signal_names
+            else CONFIDENCE_MEDIUM
+        )
+        item_observed = _parse_utc(_timestamp_from_payload(item), default=observed)
+        racing_numbers = _extract_racing_numbers(item)
+        if not racing_numbers:
+            signals.append(
+                IncidentSignal(
+                    kind="race_control",
+                    observed_at=item_observed,
+                    session_key=session_key,
+                    data_quality=data_quality,
+                    confidence_hint=confidence,
+                    reason="race_control_incident",
+                    message=message,
+                    category=category,
+                    flag=flag,
+                    session=session,
+                    signals=signal_names,
+                    raw_id=_payload_fingerprint(item),
+                )
+            )
+            continue
+        for rn in racing_numbers:
+            signals.append(
+                IncidentSignal(
+                    kind="race_control",
+                    observed_at=item_observed,
+                    session_key=session_key,
+                    racing_number=rn,
+                    data_quality=data_quality,
+                    confidence_hint=confidence,
+                    reason="race_control_incident",
+                    message=message,
+                    category=category,
+                    flag=flag,
+                    driver=_lookup_driver(drivers, rn),
+                    session=session,
+                    signals=signal_names,
+                    raw_id=_payload_fingerprint(item),
+                )
+            )
+    return signals
+
+
+def normalize_session_info(
+    payload: Any,
+    observed_at: datetime | str | None = None,
+    *,
+    session: SessionMetadata | None = None,
+    data_quality: str = DATA_QUALITY_LIVE,
+) -> list[IncidentSignal]:
+    if not isinstance(payload, Mapping):
+        return []
+    session_type = normalize_session_type(payload.get("Type") or payload.get("Name"))
+    session_name = _string_or_none(
+        payload.get("Name") or payload.get("SessionName") or payload.get("Type")
+    )
+    meeting = payload.get("Meeting")
+    meeting_name = None
+    if isinstance(meeting, Mapping):
+        meeting_name = _string_or_none(
+            meeting.get("Name") or meeting.get("OfficialName")
+        )
+    meeting_name = meeting_name or _string_or_none(
+        payload.get("MeetingName") or payload.get("Meeting")
+    )
+    archive_status = payload.get("ArchiveStatus")
+    archive_path = (
+        archive_status.get("Path") if isinstance(archive_status, Mapping) else None
+    )
+    session_key = _string_or_none(
+        payload.get("SessionKey")
+        or payload.get("Path")
+        or payload.get("LiveTimingPath")
+        or archive_path
+    )
+    if session_key is None:
+        session_key = _build_session_key(
+            meeting_name, session_name, payload.get("StartDate")
+        )
+    metadata = _merge_session_metadata(
+        session or SessionMetadata(session_key=session_key),
+        SessionMetadata(
+            session_key=session_key,
+            meeting_name=meeting_name,
+            session_name=session_name,
+            session_type=session_type,
+        ),
+    )
+    return [
+        IncidentSignal(
+            kind="session_context",
+            observed_at=_parse_utc(_timestamp_from_payload(payload) or observed_at),
+            session_key=metadata.session_key,
+            data_quality=data_quality,
+            session=metadata,
+        )
+    ]
+
+
+def normalize_session_status(
+    payload: Any,
+    observed_at: datetime | str | None = None,
+    *,
+    session: SessionMetadata | None = None,
+    data_quality: str = DATA_QUALITY_LIVE,
+) -> list[IncidentSignal]:
+    if not isinstance(payload, Mapping):
+        return []
+    status = _normalize_session_status_value(payload)
+    if status is None:
+        return []
+    return [
+        IncidentSignal(
+            kind="session_status",
+            observed_at=_parse_utc(_timestamp_from_payload(payload) or observed_at),
+            session_key=_session_key(session),
+            value=status,
+            data_quality=data_quality,
+            session=session,
+            signals=("session_status",),
+        )
+    ]
+
+
+def normalize_session_data(
+    payload: Any,
+    observed_at: datetime | str | None = None,
+    *,
+    session: SessionMetadata | None = None,
+    data_quality: str = DATA_QUALITY_LIVE,
+) -> list[IncidentSignal]:
+    if not isinstance(payload, Mapping):
+        return []
+    observed = _parse_utc(observed_at)
+    signals: list[IncidentSignal] = []
+    for item in _iter_series_items(payload.get("StatusSeries")):
+        status = _normalize_session_status_value(item)
+        if status is None:
+            continue
+        signals.append(
+            IncidentSignal(
+                kind="session_status",
+                observed_at=_parse_utc(item.get("Utc"), default=observed),
+                session_key=_session_key(session),
+                value=status,
+                data_quality=data_quality,
+                session=session,
+                signals=("session_status",),
+            )
+        )
+    return signals
+
+
+def normalize_driver_list(
+    payload: Any,
+    observed_at: datetime | str | None = None,
+    *,
+    session: SessionMetadata | None = None,
+    data_quality: str = DATA_QUALITY_LIVE,
+) -> list[IncidentSignal]:
+    if not isinstance(payload, Mapping):
+        return []
+    observed = _parse_utc(observed_at)
+    signals: list[IncidentSignal] = []
+    for key, raw_driver in payload.items():
+        if not isinstance(raw_driver, Mapping):
+            continue
+        rn = _normalize_racing_number(raw_driver.get("RacingNumber") or key)
+        if rn is None:
+            continue
+        driver = DriverMetadata(
+            racing_number=rn,
+            tla=_uppercase_or_none(raw_driver.get("Tla")),
+            name=_string_or_none(
+                raw_driver.get("FullName") or raw_driver.get("BroadcastName") or rn
+            ),
+            team=_string_or_none(raw_driver.get("TeamName")),
+            team_color=_normalize_team_color(raw_driver.get("TeamColour")),
+        )
+        signals.append(
+            IncidentSignal(
+                kind="driver_metadata",
+                observed_at=observed,
+                session_key=_session_key(session),
+                racing_number=rn,
+                data_quality=data_quality,
+                driver=driver,
+                session=session,
+            )
+        )
+    return signals
+
+
+def normalize_session_type(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    if not text:
+        return "unknown"
+    for normalized, needles in _SESSION_TYPE_PATTERNS:
+        if any(needle in text for needle in needles):
+            return normalized
+    return "unknown"
+
+
+def _normalize_signal_datetime(signal: IncidentSignal) -> IncidentSignal:
+    observed = _parse_utc(signal.observed_at)
+    if observed is signal.observed_at:
+        return signal
+    return IncidentSignal(
+        kind=signal.kind,
+        observed_at=observed,
+        session_key=signal.session_key,
+        racing_number=signal.racing_number,
+        value=signal.value,
+        data_quality=signal.data_quality,
+        confidence_hint=signal.confidence_hint,
+        reason=signal.reason,
+        message=signal.message,
+        category=signal.category,
+        flag=signal.flag,
+        track_status=signal.track_status,
+        driver=signal.driver,
+        session=signal.session,
+        signals=signal.signals,
+        raw_id=signal.raw_id,
+    )
+
+
+def _parse_utc(
+    value: datetime | str | None, *, default: datetime | None = None
+) -> datetime:
+    if value is None:
+        return default or datetime.now(UTC)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    text = str(value).strip()
+    if not text:
+        return default or datetime.now(UTC)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return default or datetime.now(UTC)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _format_utc(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _session_key(session: SessionMetadata | None) -> str:
+    if session is None or not session.session_key:
+        return DEFAULT_SESSION_KEY
+    return session.session_key
+
+
+def _merge_session_metadata(
+    current: SessionMetadata, new: SessionMetadata
+) -> SessionMetadata:
+    return SessionMetadata(
+        session_key=new.session_key or current.session_key,
+        meeting_name=new.meeting_name or current.meeting_name,
+        session_name=new.session_name or current.session_name,
+        session_type=new.session_type or current.session_type,
+    )
+
+
+def _lookup_driver(
+    drivers: Mapping[str, DriverMetadata] | None, racing_number: str
+) -> DriverMetadata | None:
+    if drivers is None:
+        return None
+    return drivers.get(racing_number)
+
+
+def _normalize_racing_number(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text
+
+
+def _coerce_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, float) and value in (0.0, 1.0):
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"1", "true", "t", "yes", "y"}:
+            return True
+        if text in {"0", "false", "f", "no", "n"}:
+            return False
+    return None
+
+
+def _normalize_track_status_value(payload: Mapping[str, Any]) -> str | None:
+    message = str(payload.get("Message") or payload.get("TrackStatus") or "").upper()
+    status = str(payload.get("Status") or "").strip()
+    compact_message = message.replace("_", " ").replace("-", " ")
+
+    for key, value in _TRACK_STATUS_ALIASES.items():
+        if key in compact_message:
+            return value
+    if status in _TRACK_STATUS_CODES:
+        return _TRACK_STATUS_CODES[status]
+    if message in {
+        TRACK_STATUS_CLEAR,
+        TRACK_STATUS_YELLOW,
+        TRACK_STATUS_VSC,
+        TRACK_STATUS_SC,
+        TRACK_STATUS_RED,
+    }:
+        return message
+    return None
+
+
+def _extract_race_control_items(payload: Any) -> list[Mapping[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, Mapping)]
+    if not isinstance(payload, Mapping):
+        return []
+    messages = payload.get("Messages")
+    if isinstance(messages, list):
+        return [item for item in messages if isinstance(item, Mapping)]
+    if isinstance(messages, Mapping):
+        keys = sorted(
+            (key for key in messages if str(key).isdigit()),
+            key=lambda item: int(str(item)),
+        )
+        return [
+            item for key in keys if isinstance((item := messages.get(key)), Mapping)
+        ]
+    if "Messages" in payload:
+        return []
+    return [payload]
+
+
+def _race_control_signal_names(item: Mapping[str, Any]) -> tuple[str, ...]:
+    text = _race_control_text(item)
+    names: list[str] = []
+    if any(word in text for word in _RACE_CONTROL_CLEAR_WORDS):
+        names.append("race_control_clear")
+    if "DOUBLE YELLOW" in text or "YELLOW" in text:
+        names.append("race_control_yellow")
+    if "RED FLAG" in text or re.search(r"\bRED\b", text):
+        names.append("race_control_red")
+    if any(word in text for word in _SAFETY_CAR_KEYWORDS):
+        names.append("race_control_safety_car")
+    if "STOPPED" in text or re.search(r"\bSTOP\b", text):
+        names.append("race_control_stopped")
+    if any(word in text for word in _INCIDENT_KEYWORDS):
+        names.append("race_control_incident")
+    return tuple(dict.fromkeys(names))
+
+
+def _race_control_is_context(signal: IncidentSignal) -> bool:
+    if "race_control_clear" in signal.signals and len(signal.signals) == 1:
+        return False
+    return any(
+        name
+        in {
+            "race_control_incident",
+            "race_control_red",
+            "race_control_safety_car",
+            "race_control_stopped",
+            "race_control_yellow",
+        }
+        for name in signal.signals
+    )
+
+
+def _race_control_text(item: Mapping[str, Any]) -> str:
+    values = (
+        item.get("Message"),
+        item.get("Text"),
+        item.get("Flag"),
+        item.get("Category"),
+        item.get("CategoryType"),
+        item.get("Mode"),
+        item.get("Status"),
+    )
+    return " ".join(str(value).upper() for value in values if value is not None)
+
+
+def _extract_racing_numbers(item: Mapping[str, Any]) -> tuple[str, ...]:
+    direct_values = (
+        item.get("RacingNumber"),
+        item.get("DriverNumber"),
+        item.get("Car"),
+        item.get("CarNumber"),
+    )
+    numbers: list[str] = []
+    for value in direct_values:
+        rn = _normalize_racing_number(value)
+        if rn is not None:
+            numbers.append(rn)
+
+    text = _race_control_text(item)
+    numbers.extend(match.group(1) for match in _CAR_WORD_RE.finditer(text))
+    numbers.extend(match.group(1) for match in _NUMBER_TLA_RE.finditer(text))
+    return tuple(dict.fromkeys(numbers))
+
+
+def _timestamp_from_payload(payload: Mapping[str, Any]) -> Any:
+    return (
+        payload.get("Utc")
+        or payload.get("utc")
+        or payload.get("processedAt")
+        or payload.get("timestamp")
+    )
+
+
+def _normalize_session_status_value(payload: Mapping[str, Any]) -> str | None:
+    raw = (
+        payload.get("SessionStatus")
+        or payload.get("Status")
+        or payload.get("Started")
+        or payload.get("Message")
+    )
+    if raw is None:
+        return None
+    if raw is True:
+        return "Started"
+    if raw is False:
+        return "Inactive"
+    text = str(raw).strip()
+    return text or None
+
+
+def _iter_series_items(series: Any) -> Iterable[Mapping[str, Any]]:
+    if isinstance(series, list):
+        for item in series:
+            if isinstance(item, Mapping):
+                yield item
+        return
+    if isinstance(series, Mapping):
+        keys = sorted(
+            (key for key in series if str(key).isdigit()),
+            key=lambda item: int(str(item)),
+        )
+        for key in keys:
+            item = series.get(key)
+            if isinstance(item, Mapping):
+                yield item
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _uppercase_or_none(value: Any) -> str | None:
+    text = _string_or_none(value)
+    return text.upper() if text is not None else None
+
+
+def _normalize_team_color(value: Any) -> str | None:
+    text = _string_or_none(value)
+    if text is None:
+        return None
+    text = text.lstrip("#")
+    if len(text) != 6:
+        return None
+    if not all(char in "0123456789abcdefABCDEF" for char in text):
+        return None
+    return "#" + text.upper()
+
+
+def _payload_fingerprint(payload: Mapping[str, Any]) -> str:
+    timestamp = _timestamp_from_payload(payload)
+    category = payload.get("Category") or payload.get("CategoryType") or ""
+    message = payload.get("Message") or payload.get("Text") or payload.get("Flag") or ""
+    if timestamp or category or message:
+        return f"{timestamp or ''}|{category}|{message}"
+    return json.dumps(dict(payload), sort_keys=True, default=str)
+
+
+def _build_session_key(
+    meeting_name: str | None, session_name: str | None, start_date: Any
+) -> str:
+    parts = [
+        str(start_date or "")[:10],
+        meeting_name or "",
+        session_name or "",
+    ]
+    slug = _NON_SLUG_RE.sub("-", "-".join(parts).lower()).strip("-")
+    return slug or DEFAULT_SESSION_KEY
+
+
+def _build_incident_id(
+    session_key: str, racing_number: str, observed_at: datetime
+) -> str:
+    return f"{session_key}-{racing_number}-{_format_utc(observed_at)}"
+
+
+def _confidence_gt(left: str, right: str) -> bool:
+    return CONFIDENCE_ORDER.get(left, -1) > CONFIDENCE_ORDER.get(right, -1)
+
+
+def _reason_for_context(
+    *,
+    track_context: TrackStatusContext | None = None,
+    race_context: RaceControlContext | None = None,
+) -> str:
+    if track_context is not None and track_context.status is not None:
+        if track_context.status == TRACK_STATUS_SC:
+            return "timing_stopped_with_safety_car_context"
+        if track_context.status == TRACK_STATUS_VSC:
+            return "timing_stopped_with_vsc_context"
+    if race_context is not None and race_context.message is not None:
+        return "timing_stopped_with_race_control"
+    if track_context is not None and track_context.status is not None:
+        return "timing_stopped_with_track_status"
+    return "timing_stopped"
+
+
+def _append_unique(values: list[str], value: str) -> None:
+    if value not in values:
+        values.append(value)
+
+
+def _extend_unique(values: list[str], new_values: Iterable[str]) -> None:
+    for value in new_values:
+        _append_unique(values, value)
+
+
+def _is_within(left: datetime, right: datetime, window: timedelta) -> bool:
+    return abs(left - right) <= window

--- a/custom_components/f1_sensor/incident_detection.py
+++ b/custom_components/f1_sensor/incident_detection.py
@@ -106,15 +106,14 @@ _SESSION_TYPE_PATTERNS = (
 _INCIDENT_KEYWORDS = frozenset(
     {
         "ACCIDENT",
+        "BARRIER",
         "CRASH",
-        "DOUBLE YELLOW",
-        "INCIDENT",
+        "GRAVEL",
         "OFF TRACK",
-        "RED FLAG",
         "SPUN",
+        "STRANDED",
         "STOP",
         "STOPPED",
-        "YELLOW",
     }
 )
 _RACE_CONTROL_CLEAR_WORDS = frozenset({"CLEAR", "ALL CLEAR"})
@@ -1860,9 +1859,7 @@ def _race_control_signal_names(item: Mapping[str, Any]) -> tuple[str, ...]:
         names.append("race_control_safety_car")
     if "STOPPED" in text or re.search(r"\bSTOP\b", text):
         names.append("race_control_stopped")
-    if any(word in text for word in _INCIDENT_KEYWORDS) and (
-        "YELLOW" not in text or yellow_is_context
-    ):
+    if any(word in text for word in _INCIDENT_KEYWORDS):
         names.append("race_control_incident")
     return tuple(dict.fromkeys(names))
 

--- a/custom_components/f1_sensor/replay_mode.py
+++ b/custom_components/f1_sensor/replay_mode.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import AsyncGenerator, Callable
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from contextlib import suppress
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -65,7 +66,7 @@ INDEX_STATUS_NO_DATA = "no_data"
 INDEX_STATUS_ERROR = "error"
 # Cache version - bump this when replay index contents change in a way that
 # requires re-downloading cached sessions.
-CACHE_VERSION = 8
+CACHE_VERSION = 9
 FORMATION_SEARCH_WINDOW = timedelta(seconds=90)
 FORMATION_HTTP_TIMEOUT = 20
 
@@ -846,6 +847,65 @@ class ReplaySessionManager:
     def _has_timingapp_state(state: dict[str, Any]) -> bool:
         return isinstance(state, dict) and bool(state)
 
+    def _merge_timingdata_state(self, state: dict[str, Any], payload: dict) -> None:
+        """Accumulate TimingData frames into a replay bootstrap snapshot."""
+        if not isinstance(payload, dict):
+            return
+
+        for key, value in payload.items():
+            if key != "Lines":
+                state[key] = deepcopy(value)
+
+        lines = payload.get("Lines")
+        if not isinstance(lines, dict):
+            return
+
+        cur_lines = state.setdefault("Lines", {})
+        for rn, line_data in lines.items():
+            if not isinstance(line_data, dict):
+                continue
+            rn_key = str(rn)
+            entry = cur_lines.setdefault(rn_key, {})
+            self._deep_merge_replay_state(entry, line_data)
+
+    def _deep_merge_replay_state(self, target: Any, delta: Any) -> Any:
+        if isinstance(target, dict) and isinstance(delta, dict):
+            for key, value in delta.items():
+                current = target.get(key)
+                if isinstance(current, dict) and isinstance(value, dict):
+                    self._deep_merge_replay_state(current, value)
+                elif isinstance(current, list) and isinstance(value, dict):
+                    self._merge_replay_list_state(current, value)
+                else:
+                    target[key] = deepcopy(value)
+            return target
+        if isinstance(target, list) and isinstance(delta, dict):
+            return self._merge_replay_list_state(target, delta)
+        return deepcopy(delta)
+
+    def _merge_replay_list_state(
+        self, target: list[Any], delta: dict[str, Any]
+    ) -> list[Any]:
+        for key, value in delta.items():
+            try:
+                idx = int(key)
+            except (TypeError, ValueError):
+                continue
+            if idx < 0:
+                continue
+            while len(target) <= idx:
+                target.append(None)
+            current = target[idx]
+            if isinstance(current, dict) and isinstance(value, dict):
+                self._deep_merge_replay_state(current, value)
+            else:
+                target[idx] = deepcopy(value)
+        return target
+
+    @staticmethod
+    def _has_timingdata_state(state: dict[str, Any]) -> bool:
+        return isinstance(state, dict) and bool(state.get("Lines"))
+
     def _merge_lap_history_state(
         self,
         state: dict[str, Any],
@@ -1030,6 +1090,7 @@ class ReplaySessionManager:
             "withheld": False,
         }
         timingapp_state: dict[str, Any] = {}
+        timingdata_state: dict[str, Any] = {}
         lap_history_state: dict[str, Any] = {}
         last_lap_times: dict[str, str] = {}
 
@@ -1046,7 +1107,7 @@ class ReplaySessionManager:
                 self._merge_lap_history_state(
                     lap_history_state, last_lap_times, frame.payload
                 )
-                initial_state[frame.stream] = frame.payload
+                self._merge_timingdata_state(timingdata_state, frame.payload)
             elif frame.stream == "DriverRaceInfo" and isinstance(frame.payload, dict):
                 self._extract_grid_from_driver_race_info(
                     lap_history_state, frame.payload
@@ -1065,6 +1126,8 @@ class ReplaySessionManager:
             }
         if self._has_timingapp_state(timingapp_state):
             initial_state["TimingAppData"] = timingapp_state
+        if self._has_timingdata_state(timingdata_state):
+            initial_state["TimingData"] = timingdata_state
         if self._has_lap_history_state(lap_history_state):
             initial_state["LapHistory"] = lap_history_state
 

--- a/custom_components/f1_sensor/tests/fixtures/incident_detection/README.md
+++ b/custom_components/f1_sensor/tests/fixtures/incident_detection/README.md
@@ -1,0 +1,71 @@
+# Incident detection fixture baseline
+
+This directory contains the Fas 0 baseline for stopped/on-track incident detection.
+
+The goal is to keep a small, reproducible set of local fixture candidates that can drive the pure detector work in Fas 1 without committing full F1 Live Timing raw dumps. The MVP scope is stopped/on-track incident detection, not crash detection. Fixtures must describe what the public live streams show: stopped timing state, track status, Race Control context, pit state, and session metadata.
+
+## Write scope
+
+All files for this baseline live under `/Volumes/config/custom_components/f1_sensor`. The report also mentions docs under `/Users/niklas/GitHub/f1_sensor/docs`, but that path is outside the write scope for this task and was not changed.
+
+## Fixture policy
+
+Use reduced scenario fixtures, not complete sessions. Each scenario should document:
+
+- source directory under `/Users/niklas/Desktop/import_requests/Streams`
+- session type, session name, and time window
+- driver numbers and names needed for the scenario
+- included streams: `TimingData`, `TrackStatus`, `RaceControlMessages`, `SessionInfo`, and `DriverList`
+- optional streams, especially `CarData.z`, only when the scenario explicitly validates auth-gated early-warning behavior
+- expected detector behavior in user terms
+
+Do not commit large raw dumps. Keep each scenario small enough to inspect in review, preferably under 100 KB unless a later replay test has a concrete reason to exceed that.
+
+## Fas 0 baseline
+
+`fixture_manifest.json` contains four extracted reduced scenarios, one each for race, sprint, qualifying, and practice.
+
+The extracted scenarios are:
+
+- Australian GP qualifying, `00:22:45-00:24:55`, where Race Control reports double yellow and red flag before `TimingData` marks car 3 as stopped.
+- Miami GP race, `01:04:45-01:11:00`, where yellow and safety car context precede stopped timing state for cars 6 and 10.
+- Chinese GP sprint, `01:07:00-01:10:00`, where yellow and safety car context precede stopped timing state for car 27.
+- Chinese GP practice 1, `00:27:00-00:28:30`, where yellow and VSC context precede stopped timing state for car 41.
+
+The manifest also lists optional future candidates for broader replay validation, but the Fas 0 gate is satisfied by the four reduced public-stream scenarios above.
+
+## Fas 2 replay validation
+
+`custom_components/f1_sensor/tests/incident_replay.py` replays the reduced manifest cases directly into the pure `IncidentDetector`. It does not use Home Assistant runtime, `LiveBus`, SignalR, replay downloads, auth-gated streams, or real-time sleeps.
+
+Run the manual timeline helper from `/Volumes/config`:
+
+```bash
+/opt/homebrew/bin/python3.14 -m custom_components.f1_sensor.tests.incident_replay
+```
+
+Observed baseline order:
+
+| Case | Public-stream order | Expected replay result |
+| --- | --- | --- |
+| Australian GP qualifying | `TrackStatus` yellow, `RaceControlMessages` double yellow, Race Control red flag, `TrackStatus` red, Race Control clear, then `TimingData.Stopped` for car 3 | One `confirmed` `high` incident for VER |
+| Miami GP race | `TrackStatus` yellow, Race Control double yellow, Race Control Safety Car, `TrackStatus` Safety Car, then `TimingData.Stopped` for cars 6 and 10 | One `confirmed` `high` incident each for HAD and GAS |
+| Chinese GP sprint | `TrackStatus` yellow, Race Control yellow, Race Control Safety Car, `TrackStatus` Safety Car, then `TimingData.Stopped` for car 27 | One `confirmed` `high` incident for HUL |
+| Chinese GP practice 1 | `TrackStatus` yellow, Race Control double yellow, `TrackStatus` VSC, Race Control VSC, then `TimingData.Stopped` for car 41 | One `confirmed` `high` incident for LIN |
+
+The replay tests also derive a practice weak-signal variant by removing flag and VSC context from the practice case. That variant must stay `medium`, not `high`, so practice-only stopped timing does not look more certain than the available evidence supports.
+
+## Expected wording
+
+Use neutral language:
+
+- "Car stopped on track"
+- "Possible on-track incident"
+- "Driver stopped"
+- "Incident cleared"
+
+Avoid overclaiming:
+
+- do not describe the feature as crash detection
+- do not infer accident, mechanical failure, or off-track state unless Race Control or a later location signal supports it
+- do not treat the fixture data as safety-critical or guaranteed real-time alerting

--- a/custom_components/f1_sensor/tests/fixtures/incident_detection/fixture_manifest.json
+++ b/custom_components/f1_sensor/tests/fixtures/incident_detection/fixture_manifest.json
@@ -1,0 +1,697 @@
+{
+  "version": 1,
+  "phase": "Fas 0",
+  "phase_status": "complete",
+  "created_at": "2026-05-13",
+  "completed_at": "2026-05-13",
+  "purpose": "Baseline fixture catalogue for stopped/on-track incident detection",
+  "write_scope": {
+    "component_root": "/Volumes/config/custom_components/f1_sensor",
+    "external_docs_path_from_report": "/Users/niklas/GitHub/f1_sensor/docs",
+    "external_docs_status": "not_changed_no_user_facing_docs_needed_for_fixture_baseline"
+  },
+  "scope": {
+    "mvp_name": "stopped/on-track incident detection",
+    "not_in_scope": [
+      "crash detection",
+      "automatic cause classification",
+      "Position.z location inference",
+      "auth-gated CarData.z early warnings"
+    ],
+    "raw_dump_policy": "Do not commit large raw stream dumps"
+  },
+  "allowed_streams": [
+    "TimingData",
+    "TrackStatus",
+    "RaceControlMessages",
+    "SessionInfo",
+    "DriverList",
+    "CarData.z"
+  ],
+  "extracted_cases": [
+    {
+      "id": "2026_australian_gp_qualifying_ver_red_flag",
+      "status": "phase_0_extracted_case",
+      "source_directory": "/Users/niklas/Desktop/import_requests/Streams/2026-03-06_Australian_Grand_Prix/2026-03-07_Qualifying",
+      "time_window": {
+        "start_offset": "00:22:45.000",
+        "end_offset": "00:24:55.000"
+      },
+      "session": {
+        "meeting": "Australian Grand Prix",
+        "session_type": "Qualifying",
+        "session_name": "Qualifying",
+        "start_date": "2026-03-07T16:00:00",
+        "end_date": "2026-03-07T17:00:00",
+        "gmt_offset": "11:00:00",
+        "live_timing_path": "2026/2026-03-08_Australian_Grand_Prix/2026-03-07_Qualifying/"
+      },
+      "included_streams": [
+        "TimingData",
+        "TrackStatus",
+        "RaceControlMessages",
+        "SessionInfo",
+        "DriverList"
+      ],
+      "optional_streams_excluded": [
+        "CarData.z"
+      ],
+      "drivers": {
+        "3": {
+          "racing_number": "3",
+          "tla": "VER",
+          "full_name": "Max VERSTAPPEN",
+          "team_name": "Red Bull Racing"
+        }
+      },
+      "state_before_window": {
+        "TimingData": {
+          "Lines": {
+            "3": {
+              "Stopped": false,
+              "InPit": false,
+              "PitOut": false,
+              "Retired": false
+            }
+          }
+        }
+      },
+      "frames": [
+        {
+          "offset": "00:22:58.333",
+          "stream": "TrackStatus",
+          "payload": {
+            "Status": "2",
+            "Message": "Yellow"
+          }
+        },
+        {
+          "offset": "00:22:58.395",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Flag",
+                "Flag": "DOUBLE YELLOW",
+                "Scope": "Sector",
+                "Sector": 2,
+                "Message": "DOUBLE YELLOW IN TRACK SECTOR 2"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "00:23:13.078",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Flag",
+                "Flag": "RED",
+                "Scope": "Track",
+                "Message": "RED FLAG"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "00:23:13.193",
+          "stream": "TrackStatus",
+          "payload": {
+            "Status": "5",
+            "Message": "Red"
+          }
+        },
+        {
+          "offset": "00:23:13.221",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Flag",
+                "Flag": "CLEAR",
+                "Scope": "Sector",
+                "Sector": 2,
+                "Message": "CLEAR IN TRACK SECTOR 2"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "00:23:14.989",
+          "stream": "TimingData",
+          "payload": {
+            "Lines": {
+              "3": {
+                "Stopped": true,
+                "Status": 260
+              }
+            }
+          }
+        }
+      ],
+      "expected_behavior": {
+        "event_expected": true,
+        "expected_phase": "confirmed",
+        "expected_confidence": "high",
+        "expected_reason": "timing_stopped_with_track_status_or_race_control",
+        "should_default_notify": true,
+        "expected_message_contains": [
+          "stopped",
+          "VER"
+        ],
+        "expected_message_excludes": [
+          "crash",
+          "accident",
+          "mechanical failure",
+          "off track"
+        ],
+        "dedupe_behavior": "one incident for car 3 in this window",
+        "cooldown_behavior": "do not emit repeated confirmed notifications for the same stopped state"
+      }
+    },
+    {
+      "id": "2026_miami_gp_race_had_gas_safety_car",
+      "status": "phase_0_extracted_case",
+      "source_directory": "/Users/niklas/Desktop/import_requests/Streams/2026-05-01_Miami_Grand_Prix/2026-05-03_Race",
+      "time_window": {
+        "start_offset": "01:04:45.000",
+        "end_offset": "01:11:00.000"
+      },
+      "session": {
+        "meeting": "Miami Grand Prix",
+        "session_type": "Race",
+        "session_name": "Race",
+        "start_date": "2026-05-03T13:00:00",
+        "end_date": "2026-05-03T15:00:00",
+        "gmt_offset": "-04:00:00",
+        "live_timing_path": "2026/2026-05-03_Miami_Grand_Prix/2026-05-03_Race/"
+      },
+      "included_streams": [
+        "TimingData",
+        "TrackStatus",
+        "RaceControlMessages",
+        "SessionInfo",
+        "DriverList"
+      ],
+      "optional_streams_excluded": [
+        "CarData.z"
+      ],
+      "drivers": {
+        "6": {
+          "racing_number": "6",
+          "tla": "HAD",
+          "full_name": "Isack HADJAR",
+          "team_name": "Red Bull Racing"
+        },
+        "10": {
+          "racing_number": "10",
+          "tla": "GAS",
+          "full_name": "Pierre GASLY",
+          "team_name": "Alpine"
+        }
+      },
+      "state_before_window": {
+        "TimingData": {
+          "Lines": {
+            "6": {
+              "Stopped": false,
+              "InPit": false,
+              "PitOut": false,
+              "Retired": false
+            },
+            "10": {
+              "Stopped": false,
+              "InPit": false,
+              "PitOut": false,
+              "Retired": false
+            }
+          }
+        }
+      },
+      "frames": [
+        {
+          "offset": "01:05:05.815",
+          "stream": "TrackStatus",
+          "payload": {
+            "Status": "2",
+            "Message": "Yellow"
+          }
+        },
+        {
+          "offset": "01:05:05.866",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Flag",
+                "Flag": "DOUBLE YELLOW",
+                "Scope": "Sector",
+                "Sector": 15,
+                "Lap": 5,
+                "Message": "DOUBLE YELLOW IN TRACK SECTOR 15"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "01:05:33.955",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "SafetyCar",
+                "Status": "DEPLOYED",
+                "Mode": "SAFETY CAR",
+                "Lap": 6,
+                "Message": "SAFETY CAR DEPLOYED"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "01:05:34.079",
+          "stream": "TrackStatus",
+          "payload": {
+            "Status": "4",
+            "Message": "SCDeployed"
+          }
+        },
+        {
+          "offset": "01:06:06.544",
+          "stream": "TimingData",
+          "payload": {
+            "Lines": {
+              "6": {
+                "Stopped": true,
+                "Status": 68
+              }
+            }
+          }
+        },
+        {
+          "offset": "01:06:31.697",
+          "stream": "TimingData",
+          "payload": {
+            "Lines": {
+              "10": {
+                "Stopped": true,
+                "Status": 68
+              }
+            }
+          }
+        },
+        {
+          "offset": "01:08:19.307",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Other",
+                "Lap": 7,
+                "Message": "MARSHALS ON TRACK AT TURN 14"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "01:09:25.294",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Other",
+                "Lap": 7,
+                "Message": "RECOVERY VEHICLE ON TRACK AT TURN 17"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "01:10:19.490",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Other",
+                "Lap": 8,
+                "Message": "TURN 17 INCIDENT INVOLVING CAR 10 (GAS) NOTED - CAUSING A COLLISION"
+              }
+            ]
+          }
+        }
+      ],
+      "expected_behavior": {
+        "event_expected": true,
+        "expected_phase": "confirmed",
+        "expected_confidence": "high",
+        "expected_reason": "timing_stopped_with_safety_car_context",
+        "should_default_notify": true,
+        "expected_incidents": [
+          {
+            "driver_number": "6",
+            "expected_message_contains": [
+              "stopped",
+              "HAD"
+            ]
+          },
+          {
+            "driver_number": "10",
+            "expected_message_contains": [
+              "stopped",
+              "GAS"
+            ]
+          }
+        ],
+        "expected_message_excludes": [
+          "crash",
+          "mechanical failure",
+          "off track"
+        ],
+        "dedupe_behavior": "one incident per stopped driver in this window",
+        "cooldown_behavior": "do not repeat confirmed notifications while the same stopped state remains active"
+      }
+    },
+    {
+      "id": "2026_chinese_gp_sprint_hulkenberg_safety_car",
+      "status": "phase_0_extracted_case",
+      "source_directory": "/Users/niklas/Desktop/import_requests/Streams/2026-03-13_Chinese_Grand_Prix/2026-03-14_Sprint",
+      "time_window": {
+        "start_offset": "01:07:00.000",
+        "end_offset": "01:10:00.000"
+      },
+      "session": {
+        "meeting": "Chinese Grand Prix",
+        "session_type": "Sprint",
+        "session_name": "Sprint",
+        "start_date": "2026-03-14T11:00:00",
+        "end_date": "2026-03-14T12:00:00",
+        "gmt_offset": "08:00:00",
+        "live_timing_path": "2026/2026-03-15_Chinese_Grand_Prix/2026-03-14_Sprint/"
+      },
+      "included_streams": [
+        "TimingData",
+        "TrackStatus",
+        "RaceControlMessages",
+        "SessionInfo",
+        "DriverList"
+      ],
+      "optional_streams_excluded": [
+        "CarData.z"
+      ],
+      "drivers": {
+        "27": {
+          "racing_number": "27",
+          "tla": "HUL",
+          "full_name": "Nico HULKENBERG",
+          "team_name": "Audi"
+        }
+      },
+      "state_before_window": {
+        "TimingData": {
+          "Lines": {
+            "27": {
+              "Stopped": false,
+              "InPit": false,
+              "PitOut": false,
+              "Retired": false
+            }
+          }
+        }
+      },
+      "frames": [
+        {
+          "offset": "01:07:07.837",
+          "stream": "TrackStatus",
+          "payload": {
+            "Status": "2",
+            "Message": "Yellow"
+          }
+        },
+        {
+          "offset": "01:07:07.966",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Flag",
+                "Flag": "YELLOW",
+                "Scope": "Sector",
+                "Sector": 1,
+                "Lap": 13,
+                "Message": "YELLOW IN TRACK SECTOR 1"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "01:07:39.396",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "SafetyCar",
+                "Status": "DEPLOYED",
+                "Mode": "SAFETY CAR",
+                "Lap": 13,
+                "Message": "SAFETY CAR DEPLOYED"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "01:07:39.474",
+          "stream": "TrackStatus",
+          "payload": {
+            "Status": "4",
+            "Message": "SCDeployed"
+          }
+        },
+        {
+          "offset": "01:08:08.936",
+          "stream": "TimingData",
+          "payload": {
+            "Lines": {
+              "27": {
+                "Stopped": true,
+                "Status": 68
+              }
+            }
+          }
+        },
+        {
+          "offset": "01:08:58.683",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Other",
+                "Lap": 14,
+                "Message": "RECOVERY VEHICLE ON TRACK AT TURN 1"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "01:09:14.094",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Flag",
+                "Flag": "DOUBLE YELLOW",
+                "Scope": "Sector",
+                "Sector": 1,
+                "Lap": 14,
+                "Message": "DOUBLE YELLOW IN TRACK SECTOR 1"
+              }
+            ]
+          }
+        }
+      ],
+      "expected_behavior": {
+        "event_expected": true,
+        "expected_phase": "confirmed",
+        "expected_confidence": "high",
+        "expected_reason": "timing_stopped_with_safety_car_context",
+        "should_default_notify": true,
+        "expected_message_contains": [
+          "stopped",
+          "HUL"
+        ],
+        "expected_message_excludes": [
+          "crash",
+          "accident",
+          "mechanical failure",
+          "off track"
+        ],
+        "dedupe_behavior": "one incident for car 27 in this window",
+        "cooldown_behavior": "do not emit repeated confirmed notifications for the same stopped state"
+      }
+    },
+    {
+      "id": "2026_chinese_gp_practice_lindblad_vsc",
+      "status": "phase_0_extracted_case",
+      "source_directory": "/Users/niklas/Desktop/import_requests/Streams/2026-03-13_Chinese_Grand_Prix/2026-03-13_Practice_1",
+      "time_window": {
+        "start_offset": "00:27:00.000",
+        "end_offset": "00:28:30.000"
+      },
+      "session": {
+        "meeting": "Chinese Grand Prix",
+        "session_type": "Practice",
+        "session_name": "Practice 1",
+        "start_date": "2026-03-13T11:30:00",
+        "end_date": "2026-03-13T12:30:00",
+        "gmt_offset": "08:00:00",
+        "live_timing_path": "2026/2026-03-15_Chinese_Grand_Prix/2026-03-13_Practice_1/"
+      },
+      "included_streams": [
+        "TimingData",
+        "TrackStatus",
+        "RaceControlMessages",
+        "SessionInfo",
+        "DriverList"
+      ],
+      "optional_streams_excluded": [
+        "CarData.z"
+      ],
+      "drivers": {
+        "41": {
+          "racing_number": "41",
+          "tla": "LIN",
+          "full_name": "Arvid LINDBLAD",
+          "team_name": "Racing Bulls"
+        }
+      },
+      "state_before_window": {
+        "TimingData": {
+          "Lines": {
+            "41": {
+              "Stopped": false,
+              "InPit": false,
+              "PitOut": false,
+              "Retired": false
+            }
+          }
+        }
+      },
+      "frames": [
+        {
+          "offset": "00:27:08.022",
+          "stream": "TrackStatus",
+          "payload": {
+            "Status": "2",
+            "Message": "Yellow"
+          }
+        },
+        {
+          "offset": "00:27:08.069",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "Flag",
+                "Flag": "DOUBLE YELLOW",
+                "Scope": "Sector",
+                "Sector": 17,
+                "Message": "DOUBLE YELLOW IN TRACK SECTOR 17"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "00:27:57.459",
+          "stream": "TrackStatus",
+          "payload": {
+            "Status": "6",
+            "Message": "VSCDeployed"
+          }
+        },
+        {
+          "offset": "00:27:57.475",
+          "stream": "RaceControlMessages",
+          "payload": {
+            "Messages": [
+              {
+                "Category": "SafetyCar",
+                "Status": "DEPLOYED",
+                "Mode": "VSC",
+                "Message": "VSC DEPLOYED"
+              }
+            ]
+          }
+        },
+        {
+          "offset": "00:28:00.553",
+          "stream": "TimingData",
+          "payload": {
+            "Lines": {
+              "41": {
+                "Stopped": true,
+                "Status": 68
+              }
+            }
+          }
+        }
+      ],
+      "expected_behavior": {
+        "event_expected": true,
+        "expected_phase": "confirmed",
+        "expected_confidence": "high",
+        "expected_reason": "timing_stopped_with_vsc_context",
+        "should_default_notify": true,
+        "practice_default_policy": "notify only high-confidence incidents by default",
+        "expected_message_contains": [
+          "stopped",
+          "LIN"
+        ],
+        "expected_message_excludes": [
+          "crash",
+          "accident",
+          "mechanical failure",
+          "off track"
+        ],
+        "dedupe_behavior": "one incident for car 41 in this window",
+        "cooldown_behavior": "do not emit repeated confirmed notifications for the same stopped state"
+      }
+    }
+  ],
+  "future_optional_candidates": [
+    {
+      "id": "2026_japanese_gp_race_compact_sc",
+      "session_type": "Race",
+      "source_directory": "/Users/niklas/Desktop/import_requests/Streams/2026-03-27_Japanese_Grand_Prix/2026-03-29_Race",
+      "time_window": "01:37:20-01:39:10",
+      "expected_use": "additional compact race case with yellow, safety car, and car 87 stopped"
+    },
+    {
+      "id": "2026_miami_gp_sprint_stopped_without_nearby_rc",
+      "session_type": "Sprint",
+      "source_directory": "/Users/niklas/Desktop/import_requests/Streams/2026-05-01_Miami_Grand_Prix/2026-05-02_Sprint",
+      "time_window": "00:45:00-00:46:30",
+      "expected_use": "medium-confidence or suppression edge case without nearby TrackStatus/RaceControl confirmation"
+    },
+    {
+      "id": "2026_miami_gp_qualifying_bortoleto_incident_text",
+      "session_type": "Qualifying",
+      "source_directory": "/Users/niklas/Desktop/import_requests/Streams/2026-05-01_Miami_Grand_Prix/2026-05-02_Qualifying",
+      "time_window": "00:33:15-00:35:45",
+      "expected_use": "additional qualifying case with double yellow and RaceControl incident text"
+    },
+    {
+      "id": "2026_australian_gp_practice_per_vsc",
+      "session_type": "Practice",
+      "source_directory": "/Users/niklas/Desktop/import_requests/Streams/2026-03-06_Australian_Grand_Prix/2026-03-06_Practice_2",
+      "time_window": "01:06:45-01:09:00",
+      "expected_use": "additional practice case with stopped car, yellow, VSC, and clear sequence"
+    }
+  ],
+  "open_questions_for_fas_1": [
+    "Should candidate events ever notify by default, or only confirmed incidents?",
+    "Should practice sessions notify only for high-confidence incidents?",
+    "Should retired without stopped be a separate event type?",
+    "Should closed yellow windows upgrade confidence after TrackStatus has already returned to clear?",
+    "How broad should RaceControl keyword matching be before it becomes too language-sensitive?"
+  ]
+}

--- a/custom_components/f1_sensor/tests/incident_replay.py
+++ b/custom_components/f1_sensor/tests/incident_replay.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from custom_components.f1_sensor.incident_detection import (
+    DATA_QUALITY_BOOTSTRAP,
+    DATA_QUALITY_REPLAY,
+    DriverMetadata,
+    IncidentChange,
+    IncidentDetector,
+    SessionMetadata,
+    normalize_session_type,
+)
+
+FIXTURE_MANIFEST_PATH = (
+    Path(__file__).parent / "fixtures" / "incident_detection" / "fixture_manifest.json"
+)
+
+PUBLIC_REPLAY_STREAMS = frozenset(
+    {
+        "TimingData",
+        "TrackStatus",
+        "RaceControlMessages",
+        "SessionInfo",
+        "SessionData",
+        "SessionStatus",
+        "DriverList",
+    }
+)
+FORBIDDEN_FIXTURE_KEYS = frozenset(
+    {
+        "authorization",
+        "connectiontoken",
+        "cookie",
+        "credential",
+        "password",
+        "refreshtoken",
+        "secret",
+        "setcookie",
+        "token",
+        "accesstoken",
+    }
+)
+MAX_REPLAY_CASE_BYTES = 100_000
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayFrameResult:
+    offset: str
+    observed_at: datetime
+    stream: str
+    changes: tuple[IncidentChange, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayResult:
+    case_id: str
+    session: SessionMetadata
+    frames: tuple[ReplayFrameResult, ...]
+
+    @property
+    def changes(self) -> tuple[IncidentChange, ...]:
+        return tuple(change for frame in self.frames for change in frame.changes)
+
+
+def load_fixture_manifest(
+    path: Path = FIXTURE_MANIFEST_PATH,
+) -> Mapping[str, Any]:
+    with path.open(encoding="utf-8") as manifest_file:
+        manifest = json.load(manifest_file)
+    if not isinstance(manifest, Mapping):
+        raise ValueError("Incident fixture manifest must be a JSON object")
+    return manifest
+
+
+def extracted_cases(
+    manifest: Mapping[str, Any] | None = None,
+) -> tuple[Mapping[str, Any], ...]:
+    source = load_fixture_manifest() if manifest is None else manifest
+    cases = source.get("extracted_cases")
+    if not isinstance(cases, Sequence) or isinstance(cases, str):
+        raise ValueError("Incident fixture manifest must contain extracted_cases")
+    return tuple(case for case in cases if isinstance(case, Mapping))
+
+
+def replay_manifest_case(case: Mapping[str, Any]) -> ReplayResult:
+    validate_replay_case(case)
+
+    case_id = _required_string(case, "id")
+    session = _session_metadata(case)
+    drivers = _driver_metadata(case)
+    start_at = _session_start_utc(case)
+    detector = IncidentDetector()
+    frames: list[ReplayFrameResult] = []
+
+    detector.process_stream(
+        "SessionInfo",
+        _session_info_payload(case, session),
+        start_at,
+        data_quality=DATA_QUALITY_REPLAY,
+    )
+    detector.process_stream(
+        "DriverList",
+        _driver_list_payload(drivers),
+        start_at,
+        session=session,
+        data_quality=DATA_QUALITY_REPLAY,
+    )
+
+    state_before = case.get("state_before_window")
+    if isinstance(state_before, Mapping):
+        before_at = _offset_to_datetime(
+            _required_string(case.get("time_window"), "start_offset"),
+            start_at,
+        )
+        for stream, payload in state_before.items():
+            _validate_replay_stream(str(stream))
+            changes = detector.process_stream(
+                str(stream),
+                payload,
+                before_at,
+                session=session,
+                drivers=drivers,
+                data_quality=DATA_QUALITY_BOOTSTRAP,
+            )
+            frames.append(
+                ReplayFrameResult(
+                    offset="state_before",
+                    observed_at=before_at,
+                    stream=str(stream),
+                    changes=tuple(changes),
+                )
+            )
+
+    for frame in _ordered_frames(case):
+        stream = _required_string(frame, "stream")
+        _validate_replay_stream(stream)
+        offset = _required_string(frame, "offset")
+        observed_at = _offset_to_datetime(offset, start_at)
+        changes = detector.process_stream(
+            stream,
+            frame.get("payload"),
+            observed_at,
+            session=session,
+            drivers=drivers,
+            data_quality=DATA_QUALITY_REPLAY,
+        )
+        frames.append(
+            ReplayFrameResult(
+                offset=offset,
+                observed_at=observed_at,
+                stream=stream,
+                changes=tuple(changes),
+            )
+        )
+
+    return ReplayResult(case_id=case_id, session=session, frames=tuple(frames))
+
+
+def validate_replay_case(case: Mapping[str, Any]) -> None:
+    _assert_no_forbidden_keys(case)
+    if replay_case_size_bytes(case) > MAX_REPLAY_CASE_BYTES:
+        raise ValueError("Incident replay case is too large for a reduced fixture")
+    for stream in case.get("included_streams", ()):
+        _validate_replay_stream(str(stream))
+    _ordered_frames(case)
+
+
+def replay_case_size_bytes(case: Mapping[str, Any]) -> int:
+    return len(json.dumps(case, separators=(",", ":"), default=str).encode())
+
+
+def format_replay_timeline(result: ReplayResult) -> str:
+    lines = [f"{result.case_id} ({result.session.session_name})"]
+    for frame in result.frames:
+        if not frame.changes:
+            lines.append(f"{frame.offset} {frame.stream}: no incident change")
+            continue
+        for change in frame.changes:
+            lines.append(
+                " ".join(
+                    (
+                        f"{frame.offset} {frame.stream}:",
+                        change.phase,
+                        change.confidence,
+                        f"car {change.driver.racing_number}",
+                        change.reason,
+                    )
+                )
+            )
+    return "\n".join(lines)
+
+
+def _session_metadata(case: Mapping[str, Any]) -> SessionMetadata:
+    session = case.get("session")
+    if not isinstance(session, Mapping):
+        raise ValueError("Incident fixture case must contain session metadata")
+    return SessionMetadata(
+        session_key=_required_string(session, "live_timing_path"),
+        meeting_name=_string_or_none(session.get("meeting")),
+        session_name=_string_or_none(session.get("session_name")),
+        session_type=normalize_session_type(session.get("session_type")),
+    )
+
+
+def _session_info_payload(
+    case: Mapping[str, Any], session: SessionMetadata
+) -> dict[str, Any]:
+    raw_session = case.get("session")
+    if not isinstance(raw_session, Mapping):
+        raise ValueError("Incident fixture case must contain session metadata")
+    return {
+        "Name": session.session_name,
+        "Type": raw_session.get("session_type"),
+        "StartDate": raw_session.get("start_date"),
+        "Meeting": {"Name": session.meeting_name},
+        "ArchiveStatus": {"Path": session.session_key},
+    }
+
+
+def _driver_metadata(case: Mapping[str, Any]) -> dict[str, DriverMetadata]:
+    raw_drivers = case.get("drivers")
+    if not isinstance(raw_drivers, Mapping):
+        raise ValueError("Incident fixture case must contain drivers")
+
+    drivers: dict[str, DriverMetadata] = {}
+    for raw_number, raw_driver in raw_drivers.items():
+        if not isinstance(raw_driver, Mapping):
+            continue
+        racing_number = str(raw_driver.get("racing_number") or raw_number)
+        drivers[racing_number] = DriverMetadata(
+            racing_number=racing_number,
+            tla=_string_or_none(raw_driver.get("tla")),
+            name=_string_or_none(raw_driver.get("full_name")),
+            team=_string_or_none(raw_driver.get("team_name")),
+        )
+    return drivers
+
+
+def _driver_list_payload(
+    drivers: Mapping[str, DriverMetadata],
+) -> dict[str, dict[str, str | None]]:
+    return {
+        racing_number: {
+            "RacingNumber": driver.racing_number,
+            "Tla": driver.tla,
+            "FullName": driver.name,
+            "TeamName": driver.team,
+        }
+        for racing_number, driver in drivers.items()
+    }
+
+
+def _ordered_frames(case: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    frames = case.get("frames")
+    if not isinstance(frames, Sequence) or isinstance(frames, str):
+        raise ValueError("Incident fixture case must contain frames")
+    typed_frames = tuple(frame for frame in frames if isinstance(frame, Mapping))
+    previous_offset: timedelta | None = None
+    for frame in typed_frames:
+        offset = _parse_offset_delta(_required_string(frame, "offset"))
+        if previous_offset is not None and offset < previous_offset:
+            raise ValueError("Incident replay frame offsets must be monotonic")
+        previous_offset = offset
+    return typed_frames
+
+
+def _session_start_utc(case: Mapping[str, Any]) -> datetime:
+    session = case.get("session")
+    if not isinstance(session, Mapping):
+        raise ValueError("Incident fixture case must contain session metadata")
+
+    start_date = _required_string(session, "start_date")
+    parsed_start = datetime.fromisoformat(start_date)
+    if parsed_start.tzinfo is None:
+        parsed_start = parsed_start.replace(
+            tzinfo=timezone(
+                _parse_offset_delta(_required_string(session, "gmt_offset"))
+            )
+        )
+    return parsed_start.astimezone(UTC)
+
+
+def _offset_to_datetime(offset: str, start_at: datetime) -> datetime:
+    return start_at + _parse_offset_delta(offset)
+
+
+def _parse_offset_delta(value: str) -> timedelta:
+    sign = -1 if value.startswith("-") else 1
+    text = value[1:] if value.startswith(("-", "+")) else value
+    hour_text, minute_text, second_text = text.split(":", 2)
+    seconds = float(second_text)
+    whole_seconds = int(seconds)
+    microseconds = round((seconds - whole_seconds) * 1_000_000)
+    return sign * timedelta(
+        hours=int(hour_text),
+        minutes=int(minute_text),
+        seconds=whole_seconds,
+        microseconds=microseconds,
+    )
+
+
+def _validate_replay_stream(stream: str) -> None:
+    if stream not in PUBLIC_REPLAY_STREAMS:
+        raise ValueError(f"Unsupported public incident replay stream: {stream}")
+
+
+def _assert_no_forbidden_keys(value: Any) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized_key = "".join(
+                char for char in str(key).lower() if char.isalnum()
+            )
+            if normalized_key in FORBIDDEN_FIXTURE_KEYS:
+                raise ValueError("Incident replay fixture contains secret-like keys")
+            _assert_no_forbidden_keys(item)
+        return
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        for item in value:
+            _assert_no_forbidden_keys(item)
+
+
+def _required_string(source: Any, key: str) -> str:
+    if not isinstance(source, Mapping):
+        raise ValueError(f"Expected mapping while reading {key}")
+    value = source.get(key)
+    text = _string_or_none(value)
+    if text is None:
+        raise ValueError(f"Missing required incident replay field: {key}")
+    return text
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+if __name__ == "__main__":
+    for replay_case in extracted_cases():
+        print(format_replay_timeline(replay_manifest_case(replay_case)))
+        print()

--- a/custom_components/f1_sensor/tests/test_device_trigger.py
+++ b/custom_components/f1_sensor/tests/test_device_trigger.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.helpers import entity_registry as er
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.f1_sensor import device_trigger
+from custom_components.f1_sensor.const import DOMAIN
+
+
+def _trigger_info() -> dict[str, Any]:
+    return {"trigger_data": {"id": "device-trigger-test"}, "variables": {}}
+
+
+def _register_incident_entity(hass, entry, suffix: str) -> er.RegistryEntry:
+    registry = er.async_get(hass)
+    return registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{entry.entry_id}_{suffix}",
+        config_entry=entry,
+    )
+
+
+@pytest.mark.asyncio
+async def test_possible_incident_device_trigger_fires_for_each_new_candidate(
+    hass,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    entity = _register_incident_entity(hass, entry, "possible_on_track_incident")
+    calls: list[dict[str, Any]] = []
+
+    async def action(variables, _context=None) -> None:
+        calls.append(variables["trigger"]["event"].data)
+
+    remove = await device_trigger.async_attach_trigger(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "possible_on_track_incident_detected",
+            "entity_id": entity.id,
+        },
+        action,
+        _trigger_info(),
+    )
+    try:
+        hass.bus.async_fire(
+            "f1_sensor_incident",
+            {"entry_id": entry.entry_id, "phase": "candidate", "incident_id": "one"},
+        )
+        hass.bus.async_fire(
+            "f1_sensor_incident",
+            {"entry_id": entry.entry_id, "phase": "updated", "incident_id": "one"},
+        )
+        hass.bus.async_fire(
+            "f1_sensor_incident",
+            {"entry_id": entry.entry_id, "phase": "candidate", "incident_id": "two"},
+        )
+        hass.bus.async_fire(
+            "f1_sensor_incident",
+            {"entry_id": "other-entry", "phase": "candidate", "incident_id": "other"},
+        )
+        await hass.async_block_till_done()
+    finally:
+        remove()
+
+    assert [call["incident_id"] for call in calls] == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_confirmed_incident_device_trigger_fires_for_each_confirmation(
+    hass,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    entity = _register_incident_entity(hass, entry, "on_track_incident")
+    calls: list[dict[str, Any]] = []
+
+    async def action(variables, _context=None) -> None:
+        calls.append(variables["trigger"]["event"].data)
+
+    remove = await device_trigger.async_attach_trigger(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "on_track_incident_detected",
+            "entity_id": entity.id,
+        },
+        action,
+        _trigger_info(),
+    )
+    try:
+        hass.bus.async_fire(
+            "f1_sensor_incident",
+            {"entry_id": entry.entry_id, "phase": "candidate", "incident_id": "one"},
+        )
+        hass.bus.async_fire(
+            "f1_sensor_incident",
+            {"entry_id": entry.entry_id, "phase": "confirmed", "incident_id": "one"},
+        )
+        hass.bus.async_fire(
+            "f1_sensor_incident",
+            {"entry_id": entry.entry_id, "phase": "confirmed", "incident_id": "two"},
+        )
+        await hass.async_block_till_done()
+    finally:
+        remove()
+
+    assert [call["incident_id"] for call in calls] == ["one", "two"]

--- a/custom_components/f1_sensor/tests/test_diagnostics.py
+++ b/custom_components/f1_sensor/tests/test_diagnostics.py
@@ -45,9 +45,25 @@ async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
             "last_payload_keys": ["Drivers", "Teams"],
         }
     }
+    incident_coordinator = MagicMock()
+    incident_coordinator.available = True
+    incident_coordinator.data = {
+        "active_count": 1,
+        "highest_confidence": "high",
+        "latest_incident_id": "2026-miami-race-10-2026-05-03T17:00:01Z",
+        "latest_driver_number": "10",
+        "latest_driver_tla": "GAS",
+        "latest_reason": "timing_stopped_with_race_control",
+        "latest_phase": "confirmed",
+        "session_type": "race",
+        "session_name": "Race",
+        "data_quality": "live",
+        "active_incidents": [{"large": "detail"}],
+    }
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "operation_mode": OPERATION_MODE_LIVE,
         "live_bus": live_bus,
+        "incident_coordinator": incident_coordinator,
         "signalr_stream_capabilities": {
             "public_live_streams": frozenset({"SessionStatus", "TrackStatus"}),
             "auth_gated_live_streams": frozenset(
@@ -100,6 +116,20 @@ async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
         "last_seen_age_s": 1.0,
         "last_payload_keys": ["Drivers", "Teams"],
     }
+    assert payload["runtime"]["incident_detection"] == {
+        "active_count": 1,
+        "highest_confidence": "high",
+        "latest_incident_id": "2026-miami-race-10-2026-05-03T17:00:01Z",
+        "latest_driver_number": "10",
+        "latest_driver_tla": "GAS",
+        "latest_reason": "timing_stopped_with_race_control",
+        "latest_phase": "confirmed",
+        "session_type": "race",
+        "session_name": "Race",
+        "data_quality": "live",
+        "available": True,
+    }
+    assert "active_incidents" not in str(payload["runtime"]["incident_detection"])
     assert "secret-token" not in str(payload)
 
 

--- a/custom_components/f1_sensor/tests/test_formation_start.py
+++ b/custom_components/f1_sensor/tests/test_formation_start.py
@@ -14,6 +14,7 @@ import pytest
 
 from custom_components.f1_sensor.formation_start import FormationStartTracker
 from custom_components.f1_sensor.replay_mode import (
+    CACHE_VERSION,
     ReplayController,
     ReplayFrame,
     ReplayIndex,
@@ -760,7 +761,7 @@ async def test_replay_manager_rebuilds_old_cache_with_formation_marker(
 
     assert manager._download_stream.await_count > 0
     saved = json.loads((session_dir / "index.json").read_text(encoding="utf-8"))
-    assert saved["cache_version"] == 8
+    assert saved["cache_version"] == CACHE_VERSION
     assert saved["formation_start_utc"] == formation_start.isoformat()
     assert index.formation_start_utc == formation_start
 

--- a/custom_components/f1_sensor/tests/test_incident_binary_sensor.py
+++ b/custom_components/f1_sensor/tests/test_incident_binary_sensor.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import Mock
+
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.json import json_bytes
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util.json import json_loads
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.f1_sensor import binary_sensor as binary_sensor_platform
+from custom_components.f1_sensor.binary_sensor import F1OnTrackIncidentBinarySensor
+from custom_components.f1_sensor.const import DOMAIN, SUPPORTED_SENSOR_KEYS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _coordinator(hass, data: dict[str, Any]) -> DataUpdateCoordinator:
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="incident-test",
+        update_method=None,
+    )
+    coordinator.data = data
+    coordinator.available = True
+    return coordinator
+
+
+async def _add_entity_and_get_state(hass, entity: F1OnTrackIncidentBinarySensor):
+    component = EntityComponent(_LOGGER, "binary_sensor", hass)
+    await component.async_add_entities([entity])
+    await hass.async_block_till_done()
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    return state
+
+
+def _state_recorder_attrs(state) -> dict[str, Any]:
+    unrecorded = frozenset()
+    if state.state_info is not None:
+        unrecorded = state.state_info.get("unrecorded_attributes", frozenset())
+    recorded = {
+        key: value for key, value in state.attributes.items() if key not in unrecorded
+    }
+    return json_loads(json_bytes(recorded))
+
+
+def _incident(
+    *,
+    phase: str = "confirmed",
+    confidence: str = "medium",
+    incident_id: str = "2026-miami-race-10-2026-05-03T17:00:01Z",
+) -> dict[str, Any]:
+    return {
+        "incident_id": incident_id,
+        "phase": phase,
+        "confidence": confidence,
+        "reason": "timing_stopped",
+        "driver": {
+            "racing_number": "10",
+            "tla": "GAS",
+            "name": "Pierre Gasly",
+            "team": "Alpine",
+        },
+        "session": {
+            "meeting_name": "Miami Grand Prix",
+            "session_name": "Race",
+            "session_type": "race",
+            "session_key": "2026-miami-race",
+        },
+        "signals": ["timing_stopped"],
+    }
+
+
+def _coordinator_data(
+    active_incidents: list[dict[str, Any]],
+    *,
+    latest_phase: str = "confirmed",
+) -> dict[str, Any]:
+    return {
+        "active_count": len(active_incidents),
+        "highest_confidence": "medium" if active_incidents else None,
+        "latest_incident_id": "2026-miami-race-10-2026-05-03T17:00:01Z",
+        "latest_driver_number": "10",
+        "latest_driver_tla": "GAS",
+        "latest_reason": "timing_stopped",
+        "latest_phase": latest_phase,
+        "session_type": "race",
+        "session_name": "Race",
+        "data_quality": "live",
+        "active_incidents": active_incidents,
+    }
+
+
+@pytest.mark.asyncio
+async def test_on_track_incident_setup_entry_uses_incident_coordinator(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "RaceHub",
+            "disabled_sensors": sorted(SUPPORTED_SENSOR_KEYS - {"on_track_incident"}),
+        },
+    )
+    entry.add_to_hass(hass)
+    coordinator = _coordinator(hass, _coordinator_data([]))
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "race_coordinator": Mock(),
+        "incident_coordinator": coordinator,
+    }
+
+    async_add_entities = Mock()
+    await binary_sensor_platform.async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    entity = entities[0]
+    assert isinstance(entity, F1OnTrackIncidentBinarySensor)
+    assert entity.coordinator is coordinator
+    assert entity.unique_id == f"{entry.entry_id}_on_track_incident"
+    assert entity._attr_translation_key == "on_track_incident"
+    assert entity._attr_has_entity_name is True
+    assert entity._attr_suggested_object_id == "f1_on_track_incident"
+
+
+@pytest.mark.asyncio
+async def test_on_track_incident_state_and_attributes_follow_confirmed_incidents(
+    hass,
+) -> None:
+    coordinator = _coordinator(hass, _coordinator_data([]))
+    entity = F1OnTrackIncidentBinarySensor(
+        coordinator,
+        "incident-entry_on_track_incident",
+        "incident-entry",
+        "F1",
+    )
+
+    state = await _add_entity_and_get_state(hass, entity)
+    assert state.state == STATE_OFF
+    assert state.attributes["active_count"] == 0
+    assert set(state.attributes) >= {
+        "active_count",
+        "highest_confidence",
+        "latest_incident_id",
+        "latest_driver_number",
+        "latest_driver_tla",
+        "latest_reason",
+        "latest_phase",
+        "session_type",
+        "session_name",
+        "data_quality",
+    }
+
+    coordinator.async_set_updated_data(
+        _coordinator_data(
+            [
+                _incident(confidence="medium"),
+                _incident(
+                    confidence="high",
+                    incident_id="2026-miami-race-44-2026-05-03T17:00:02Z",
+                ),
+            ]
+        )
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes["active_count"] == 2
+    assert state.attributes["highest_confidence"] == "high"
+    assert state.attributes["latest_incident_id"] == (
+        "2026-miami-race-10-2026-05-03T17:00:01Z"
+    )
+    assert state.attributes["latest_driver_number"] == "10"
+    assert state.attributes["latest_driver_tla"] == "GAS"
+    assert state.attributes["latest_phase"] == "confirmed"
+    assert state.attributes["session_type"] == "race"
+    assert state.attributes["session_name"] == "Race"
+    assert state.attributes["data_quality"] == "live"
+
+    coordinator.async_set_updated_data(_coordinator_data([], latest_phase="cleared"))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes["active_count"] == 0
+    assert state.attributes["highest_confidence"] is None
+    assert state.attributes["latest_phase"] == "cleared"
+
+
+@pytest.mark.asyncio
+async def test_on_track_incident_ignores_active_candidates(hass) -> None:
+    coordinator = _coordinator(
+        hass,
+        _coordinator_data([_incident(phase="candidate", confidence="high")]),
+    )
+    entity = F1OnTrackIncidentBinarySensor(
+        coordinator,
+        "incident-entry_on_track_incident",
+        "incident-entry",
+        "F1",
+    )
+
+    state = await _add_entity_and_get_state(hass, entity)
+
+    assert state.state == STATE_OFF
+    assert state.attributes["active_count"] == 0
+    assert state.attributes["highest_confidence"] is None
+
+
+@pytest.mark.asyncio
+async def test_on_track_incident_unavailable_without_available_coordinator(
+    hass,
+) -> None:
+    missing = F1OnTrackIncidentBinarySensor(
+        None,
+        "incident-entry_on_track_incident_missing",
+        "incident-entry",
+        "F1",
+    )
+    state = await _add_entity_and_get_state(hass, missing)
+    assert state.state == STATE_UNAVAILABLE
+
+    coordinator = _coordinator(hass, _coordinator_data([_incident()]))
+    coordinator.available = False
+    unavailable = F1OnTrackIncidentBinarySensor(
+        coordinator,
+        "incident-entry_on_track_incident_unavailable",
+        "incident-entry",
+        "F1",
+    )
+    state = await _add_entity_and_get_state(hass, unavailable)
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_on_track_incident_does_not_expose_active_list_to_recorder(
+    hass,
+) -> None:
+    coordinator = _coordinator(
+        hass,
+        _coordinator_data([_incident(confidence="high")]),
+    )
+    entity = F1OnTrackIncidentBinarySensor(
+        coordinator,
+        "incident-entry_on_track_incident",
+        "incident-entry",
+        "F1",
+    )
+
+    state = await _add_entity_and_get_state(hass, entity)
+
+    assert "active_incidents" not in state.attributes
+    assert state.state_info is not None
+    assert "active_incidents" in state.state_info["unrecorded_attributes"]
+    recorded_attrs = _state_recorder_attrs(state)
+    assert "active_incidents" not in recorded_attrs
+    assert recorded_attrs["active_count"] == 1

--- a/custom_components/f1_sensor/tests/test_incident_binary_sensor.py
+++ b/custom_components/f1_sensor/tests/test_incident_binary_sensor.py
@@ -13,7 +13,10 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.f1_sensor import binary_sensor as binary_sensor_platform
-from custom_components.f1_sensor.binary_sensor import F1OnTrackIncidentBinarySensor
+from custom_components.f1_sensor.binary_sensor import (
+    F1OnTrackIncidentBinarySensor,
+    F1PossibleOnTrackIncidentBinarySensor,
+)
 from custom_components.f1_sensor.const import DOMAIN, SUPPORTED_SENSOR_KEYS
 
 _LOGGER = logging.getLogger(__name__)
@@ -128,6 +131,40 @@ async def test_on_track_incident_setup_entry_uses_incident_coordinator(hass) -> 
 
 
 @pytest.mark.asyncio
+async def test_possible_on_track_incident_setup_entry_uses_incident_coordinator(
+    hass,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "RaceHub",
+            "disabled_sensors": sorted(
+                SUPPORTED_SENSOR_KEYS - {"possible_on_track_incident"}
+            ),
+        },
+    )
+    entry.add_to_hass(hass)
+    coordinator = _coordinator(hass, _coordinator_data([]))
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "race_coordinator": Mock(),
+        "incident_coordinator": coordinator,
+    }
+
+    async_add_entities = Mock()
+    await binary_sensor_platform.async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    entity = entities[0]
+    assert isinstance(entity, F1PossibleOnTrackIncidentBinarySensor)
+    assert entity.coordinator is coordinator
+    assert entity.unique_id == f"{entry.entry_id}_possible_on_track_incident"
+    assert entity._attr_translation_key == "possible_on_track_incident"
+    assert entity._attr_has_entity_name is True
+    assert entity._attr_suggested_object_id == "f1_possible_on_track_incident"
+
+
+@pytest.mark.asyncio
 async def test_on_track_incident_state_and_attributes_follow_confirmed_incidents(
     hass,
 ) -> None:
@@ -212,6 +249,40 @@ async def test_on_track_incident_ignores_active_candidates(hass) -> None:
     assert state.state == STATE_OFF
     assert state.attributes["active_count"] == 0
     assert state.attributes["highest_confidence"] is None
+
+
+@pytest.mark.asyncio
+async def test_possible_on_track_incident_turns_on_for_active_candidates(hass) -> None:
+    coordinator = _coordinator(
+        hass,
+        _coordinator_data(
+            [_incident(phase="candidate", confidence="medium")],
+            latest_phase="candidate",
+        ),
+    )
+    entity = F1PossibleOnTrackIncidentBinarySensor(
+        coordinator,
+        "incident-entry_possible_on_track_incident",
+        "incident-entry",
+        "F1",
+    )
+
+    state = await _add_entity_and_get_state(hass, entity)
+
+    assert state.state == STATE_ON
+    assert state.attributes["active_count"] == 1
+    assert state.attributes["highest_confidence"] == "medium"
+    assert state.attributes["latest_phase"] == "candidate"
+
+    coordinator.async_set_updated_data(_coordinator_data([], latest_phase="cleared"))
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes["active_count"] == 0
+    assert state.attributes["highest_confidence"] is None
+    assert state.attributes["latest_phase"] == "cleared"
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_incident_detection.py
+++ b/custom_components/f1_sensor/tests/test_incident_detection.py
@@ -182,6 +182,49 @@ def test_normalize_race_control_extracts_driver_number_from_message() -> None:
     assert "race_control_incident" in signals[0].signals
 
 
+def test_normalize_race_control_ignores_pit_lane_yellow_context() -> None:
+    signals = normalize_race_control_messages(
+        {
+            "Messages": [
+                {
+                    "Utc": BASE.isoformat().replace("+00:00", "Z"),
+                    "Category": "Other",
+                    "Message": "YELLOW IN PIT LANE",
+                }
+            ]
+        },
+        BASE,
+        session=SESSION,
+        drivers=DRIVERS,
+    )
+
+    assert len(signals) == 1
+    assert signals[0].signals == ()
+
+
+def test_normalize_race_control_ignores_lap_deletion_yellow_context() -> None:
+    signals = normalize_race_control_messages(
+        {
+            "Messages": [
+                {
+                    "Utc": BASE.isoformat().replace("+00:00", "Z"),
+                    "Category": "Other",
+                    "Message": (
+                        "CAR 87 (BEA) TIME 1:29.883 DELETED - DOUBLE YELLOW AT TURN 1"
+                    ),
+                }
+            ]
+        },
+        BASE,
+        session=SESSION,
+        drivers=DRIVERS,
+    )
+
+    assert len(signals) == 1
+    assert signals[0].racing_number == "87"
+    assert signals[0].signals == ()
+
+
 def test_normalize_race_control_without_driver_is_global_signal() -> None:
     signals = _race_control(BASE, "RED FLAG", flag="RED")
 
@@ -213,6 +256,43 @@ def test_normalize_driver_list_creates_driver_metadata_signal() -> None:
         team="Alpine",
         team_color="#0093CC",
     )
+
+
+def test_normalize_driver_list_ignores_position_only_delta() -> None:
+    signals = normalize_driver_list(
+        {"10": {"Line": 2}},
+        BASE,
+        session=SESSION,
+    )
+
+    assert signals == []
+
+
+def test_driver_list_position_delta_does_not_overwrite_driver_identity() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(
+        normalize_driver_list(
+            {
+                "10": {
+                    "Tla": "GAS",
+                    "FullName": "Pierre Gasly",
+                    "TeamName": "Alpine",
+                }
+            },
+            BASE,
+            session=SESSION,
+        )
+    )
+    detector.process_signals(normalize_driver_list({"10": {"Line": 2}}, BASE))
+    _bootstrap_clean(detector)
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )
+
+    assert len(changes) == 1
+    assert changes[0].driver.tla == "GAS"
+    assert changes[0].driver.name == "Pierre Gasly"
 
 
 def test_normalize_session_data_extracts_terminal_status() -> None:

--- a/custom_components/f1_sensor/tests/test_incident_detection.py
+++ b/custom_components/f1_sensor/tests/test_incident_detection.py
@@ -1,0 +1,692 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from custom_components.f1_sensor.incident_detection import (
+    CONFIDENCE_HIGH,
+    CONFIDENCE_MEDIUM,
+    DATA_QUALITY_LIVE,
+    PHASE_CANDIDATE,
+    PHASE_CLEARED,
+    PHASE_CONFIRMED,
+    PHASE_UPDATED,
+    DriverMetadata,
+    IncidentDetector,
+    IncidentSignal,
+    SessionMetadata,
+    normalize_driver_list,
+    normalize_race_control_messages,
+    normalize_session_data,
+    normalize_timing_data,
+    normalize_track_status,
+)
+
+BASE = datetime(2026, 5, 3, 17, 0, 0, tzinfo=UTC)
+SESSION = SessionMetadata(
+    session_key="2026-miami-race",
+    meeting_name="Miami Grand Prix",
+    session_name="Race",
+    session_type="race",
+)
+DRIVERS = {
+    "10": DriverMetadata(
+        racing_number="10",
+        tla="GAS",
+        name="Pierre Gasly",
+        team="Alpine",
+    )
+}
+
+
+def _timing(
+    at: datetime,
+    racing_number: str = "10",
+    *,
+    stopped: bool | None = None,
+    in_pit: bool | None = None,
+    pit_out: bool | None = None,
+    retired: bool | None = None,
+) -> list[IncidentSignal]:
+    payload: dict[str, dict[str, dict[str, bool]]] = {"Lines": {racing_number: {}}}
+    line = payload["Lines"][racing_number]
+    if in_pit is not None:
+        line["InPit"] = in_pit
+    if pit_out is not None:
+        line["PitOut"] = pit_out
+    if retired is not None:
+        line["Retired"] = retired
+    if stopped is not None:
+        line["Stopped"] = stopped
+    return normalize_timing_data(
+        payload,
+        at,
+        session=SESSION,
+        drivers=DRIVERS,
+    )
+
+
+def _bootstrap_clean(
+    detector: IncidentDetector,
+    *,
+    at: datetime = BASE,
+    racing_number: str = "10",
+) -> None:
+    changes = detector.process_signals(
+        _timing(
+            at,
+            racing_number,
+            stopped=False,
+            in_pit=False,
+            pit_out=False,
+            retired=False,
+        )
+    )
+    assert changes == []
+
+
+def _track(at: datetime, status: str, message: str) -> list[IncidentSignal]:
+    return normalize_track_status(
+        {"Status": status, "Message": message},
+        at,
+        session=SESSION,
+    )
+
+
+def _race_control(
+    at: datetime,
+    message: str,
+    *,
+    category: str = "Flag",
+    flag: str = "DOUBLE YELLOW",
+) -> list[IncidentSignal]:
+    return normalize_race_control_messages(
+        {
+            "Messages": [
+                {
+                    "Utc": at.isoformat().replace("+00:00", "Z"),
+                    "Category": category,
+                    "Flag": flag,
+                    "Message": message,
+                }
+            ]
+        },
+        at,
+        session=SESSION,
+        drivers=DRIVERS,
+    )
+
+
+def test_normalize_timingdata_stopped_creates_timing_stopped_signal() -> None:
+    signals = normalize_timing_data(
+        {"Lines": {"10": {"Stopped": True, "Status": 260}}},
+        BASE.isoformat(),
+        session=SESSION,
+        drivers=DRIVERS,
+    )
+
+    assert len(signals) == 1
+    assert signals[0].kind == "timing_stopped"
+    assert signals[0].value is True
+    assert signals[0].racing_number == "10"
+    assert signals[0].observed_at == BASE
+    assert signals[0].driver == DRIVERS["10"]
+
+
+def test_normalize_timingdata_in_pit_creates_pit_signal() -> None:
+    signals = normalize_timing_data(
+        {"Lines": {"10": {"InPit": "true"}}},
+        BASE,
+        session=SESSION,
+    )
+
+    assert [(signal.kind, signal.value) for signal in signals] == [
+        ("timing_in_pit", True)
+    ]
+
+
+def test_normalize_timingdata_retired_without_stopped_is_not_stopped_signal() -> None:
+    signals = normalize_timing_data(
+        {"Lines": {"10": {"Retired": 1, "Stopped": False}}},
+        BASE,
+        session=SESSION,
+    )
+
+    assert [signal.kind for signal in signals] == [
+        "timing_retired",
+        "timing_stopped",
+    ]
+    assert signals[1].value is False
+
+
+def test_normalize_track_status_accepts_code_and_message() -> None:
+    by_code = normalize_track_status({"Status": "2"}, BASE, session=SESSION)
+    by_message = normalize_track_status(
+        {"Status": "1", "Message": "Double Yellow"},
+        BASE,
+        session=SESSION,
+    )
+
+    assert by_code[0].track_status == "YELLOW"
+    assert by_message[0].track_status == "YELLOW"
+
+
+def test_normalize_race_control_extracts_driver_number_from_message() -> None:
+    signals = _race_control(BASE, "DOUBLE YELLOW FOR CAR 10")
+
+    assert len(signals) == 1
+    assert signals[0].kind == "race_control"
+    assert signals[0].racing_number == "10"
+    assert "race_control_yellow" in signals[0].signals
+    assert "race_control_incident" in signals[0].signals
+
+
+def test_normalize_race_control_without_driver_is_global_signal() -> None:
+    signals = _race_control(BASE, "RED FLAG", flag="RED")
+
+    assert len(signals) == 1
+    assert signals[0].racing_number is None
+    assert "race_control_red" in signals[0].signals
+
+
+def test_normalize_driver_list_creates_driver_metadata_signal() -> None:
+    signals = normalize_driver_list(
+        {
+            "10": {
+                "Tla": "gas",
+                "FullName": "Pierre Gasly",
+                "TeamName": "Alpine",
+                "TeamColour": "0093cc",
+            }
+        },
+        BASE,
+        session=SESSION,
+    )
+
+    assert len(signals) == 1
+    assert signals[0].kind == "driver_metadata"
+    assert signals[0].driver == DriverMetadata(
+        racing_number="10",
+        tla="GAS",
+        name="Pierre Gasly",
+        team="Alpine",
+        team_color="#0093CC",
+    )
+
+
+def test_normalize_session_data_extracts_terminal_status() -> None:
+    signals = normalize_session_data(
+        {
+            "StatusSeries": {
+                "0": {
+                    "Utc": "2026-05-03T18:00:00Z",
+                    "SessionStatus": "Finalised",
+                }
+            }
+        },
+        BASE,
+        session=SESSION,
+    )
+
+    assert len(signals) == 1
+    assert signals[0].kind == "session_status"
+    assert signals[0].value == "Finalised"
+    assert signals[0].observed_at == datetime(2026, 5, 3, 18, tzinfo=UTC)
+
+
+def test_normalize_invalid_payload_returns_empty_list() -> None:
+    assert normalize_timing_data(None, BASE) == []
+    assert normalize_timing_data({"Lines": []}, BASE) == []
+    assert normalize_track_status([], BASE) == []
+    assert normalize_race_control_messages({"Messages": "bad"}, BASE) == []
+
+
+def test_stopped_non_pit_confirms_medium_incident() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )
+
+    assert len(changes) == 1
+    change = changes[0]
+    assert change.phase == PHASE_CONFIRMED
+    assert change.confidence == CONFIDENCE_MEDIUM
+    assert change.reason == "timing_stopped"
+    assert change.driver.racing_number == "10"
+    assert change.incident_id == "2026-miami-race-10-2026-05-03T17:00:01Z"
+    assert "timing_stopped" in change.signals
+    assert change.data_quality == DATA_QUALITY_LIVE
+
+
+def test_stopped_in_pit_is_suppressed() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True, in_pit=True)
+    )
+
+    assert changes == []
+    assert detector.get_active_incident(SESSION.session_key, "10") is None
+
+
+def test_recent_pit_out_suppresses_stopped_signal() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    assert (
+        detector.process_signals(_timing(BASE + timedelta(seconds=1), pit_out=True))
+        == []
+    )
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=5), stopped=True, pit_out=False)
+    )
+
+    assert changes == []
+    assert detector.get_active_incident(SESSION.session_key, "10") is None
+
+
+def test_pit_out_hold_expires_before_stopped_confirms_incident() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    detector.process_signals(_timing(BASE + timedelta(seconds=1), pit_out=True))
+    detector.process_signals(_timing(BASE + timedelta(seconds=2), pit_out=False))
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=8), stopped=True)
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+    assert changes[0].confidence == CONFIDENCE_MEDIUM
+
+
+def test_track_yellow_without_driver_does_not_create_driver_incident() -> None:
+    detector = IncidentDetector()
+
+    changes = detector.process_signals(_track(BASE, "2", "Yellow"))
+
+    assert changes == []
+    assert detector.active_incidents(SESSION.session_key) == ()
+
+
+def test_stopped_plus_yellow_confirms_high_incident() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    detector.process_signals(_track(BASE + timedelta(seconds=1), "2", "Yellow"))
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=2), stopped=True)
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+    assert changes[0].confidence == CONFIDENCE_HIGH
+    assert changes[0].reason == "timing_stopped_with_track_status"
+    assert changes[0].track_status.status == "YELLOW"
+
+
+def test_race_control_before_stopped_upgrades_to_high_when_stopped_arrives() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    candidate = detector.process_signals(
+        _race_control(BASE + timedelta(seconds=10), "DOUBLE YELLOW FOR CAR 10")
+    )
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=20), stopped=True)
+    )
+
+    assert len(candidate) == 1
+    assert candidate[0].phase == PHASE_CANDIDATE
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+    assert changes[0].confidence == CONFIDENCE_HIGH
+    assert changes[0].incident_id == candidate[0].incident_id
+    assert changes[0].reason == "timing_stopped_with_race_control"
+
+
+def test_stopped_before_race_control_updates_existing_incident_to_high() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    confirmed = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )[0]
+
+    changes = detector.process_signals(
+        _race_control(BASE + timedelta(seconds=30), "TURN 17 INCIDENT FOR CAR 10")
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_UPDATED
+    assert changes[0].confidence == CONFIDENCE_HIGH
+    assert changes[0].incident_id == confirmed.incident_id
+
+
+def test_race_control_for_other_driver_does_not_upgrade_stopped_incident() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    confirmed = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )[0]
+
+    changes = detector.process_signals(
+        normalize_race_control_messages(
+            {
+                "Messages": [
+                    {
+                        "Category": "Other",
+                        "Message": "INCIDENT INVOLVING CAR 6",
+                    }
+                ]
+            },
+            BASE + timedelta(seconds=30),
+            session=SESSION,
+        )
+    )
+
+    assert changes == []
+    active = detector.get_active_incident(SESSION.session_key, "10")
+    assert active is not None
+    assert active.incident_id == confirmed.incident_id
+    assert active.confidence == CONFIDENCE_MEDIUM
+
+
+def test_race_control_outside_time_window_does_not_upgrade_incident() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    detector.process_signals(
+        _race_control(BASE + timedelta(seconds=1), "DOUBLE YELLOW FOR CAR 10")
+    )
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=130), stopped=True)
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+    assert changes[0].confidence == CONFIDENCE_MEDIUM
+    assert changes[0].incident_id == "2026-miami-race-10-2026-05-03T17:02:10Z"
+
+
+def test_first_snapshot_with_already_stopped_driver_bootstraps_without_alert() -> None:
+    detector = IncidentDetector()
+
+    assert detector.process_signals(_timing(BASE, stopped=True, in_pit=False)) == []
+    assert (
+        detector.process_signals(_timing(BASE + timedelta(seconds=1), stopped=True))
+        == []
+    )
+    assert detector.active_incidents(SESSION.session_key) == ()
+
+
+def test_stopped_after_clean_bootstrap_confirms_incident() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+
+
+def test_duplicate_stopped_signals_do_not_emit_multiple_confirmed_changes() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+
+    first = detector.process_signals(_timing(BASE + timedelta(seconds=1), stopped=True))
+    second = detector.process_signals(
+        _timing(BASE + timedelta(seconds=2), stopped=True)
+    )
+
+    assert len(first) == 1
+    assert second == []
+
+
+def test_clear_when_stopped_becomes_false() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    confirmed = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )[0]
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=10), stopped=False)
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CLEARED
+    assert changes[0].incident_id == confirmed.incident_id
+    assert detector.get_active_incident(SESSION.session_key, "10") is None
+
+
+def test_same_driver_new_stop_after_clear_and_cooldown_can_create_new_incident() -> (
+    None
+):
+    detector = IncidentDetector(cooldown=timedelta(seconds=10))
+    _bootstrap_clean(detector)
+    first = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )[0]
+    detector.process_signals(_timing(BASE + timedelta(seconds=2), stopped=False))
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=13), stopped=True)
+    )
+
+    assert len(changes) == 1
+    assert changes[0].incident_id != first.incident_id
+
+
+def test_same_driver_stop_inside_cooldown_is_deduped() -> None:
+    detector = IncidentDetector(cooldown=timedelta(seconds=20))
+    _bootstrap_clean(detector)
+    detector.process_signals(_timing(BASE + timedelta(seconds=1), stopped=True))
+    detector.process_signals(_timing(BASE + timedelta(seconds=2), stopped=False))
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=10), stopped=True)
+    )
+
+    assert changes == []
+
+
+def test_session_end_clears_active_incident() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    confirmed = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )[0]
+
+    changes = detector.process_signals(
+        [
+            IncidentSignal(
+                kind="session_status",
+                observed_at=BASE + timedelta(seconds=20),
+                session_key=SESSION.session_key,
+                value="Finalised",
+                session=SESSION,
+            )
+        ]
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CLEARED
+    assert changes[0].reason == "session_ended"
+    assert changes[0].incident_id == confirmed.incident_id
+    assert detector.get_active_incident(SESSION.session_key, "10") is None
+
+
+def test_session_end_suppresses_new_stopped_until_session_active_again() -> None:
+    detector = IncidentDetector(cooldown=timedelta(seconds=0))
+    _bootstrap_clean(detector)
+    detector.process_signals(
+        [
+            IncidentSignal(
+                kind="session_status",
+                observed_at=BASE + timedelta(seconds=1),
+                session_key=SESSION.session_key,
+                value="Finalised",
+                session=SESSION,
+            )
+        ]
+    )
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=2), stopped=True)
+    )
+
+    assert changes == []
+
+
+def test_data_gap_does_not_create_or_clear_incident_by_itself() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    confirmed = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )[0]
+
+    changes = detector.process_signals(
+        [
+            IncidentSignal(
+                kind="data_gap",
+                observed_at=BASE + timedelta(seconds=30),
+                session_key=SESSION.session_key,
+            )
+        ]
+    )
+
+    assert changes == []
+    active = detector.get_active_incident(SESSION.session_key, "10")
+    assert active is not None
+    assert active.incident_id == confirmed.incident_id
+
+
+def test_retired_without_stopped_does_not_confirm_on_track_incident() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), retired=True)
+    )
+
+    assert changes == []
+    assert detector.active_incidents(SESSION.session_key) == ()
+
+
+def test_practice_stopped_non_pit_confirms_medium_with_session_context() -> None:
+    practice = SessionMetadata(
+        session_key="2026-china-practice",
+        meeting_name="Chinese Grand Prix",
+        session_name="Practice 1",
+        session_type="practice",
+    )
+    detector = IncidentDetector()
+    detector.process_signals(
+        normalize_timing_data(
+            {"Lines": {"41": {"Stopped": False, "InPit": False}}},
+            BASE,
+            session=practice,
+        )
+    )
+
+    changes = detector.process_signals(
+        normalize_timing_data(
+            {"Lines": {"41": {"Stopped": True}}},
+            BASE + timedelta(seconds=1),
+            session=practice,
+        )
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+    assert changes[0].confidence == CONFIDENCE_MEDIUM
+    assert changes[0].session.session_type == "practice"
+
+
+@pytest.mark.parametrize(
+    ("session_type", "session_name"),
+    (
+        ("sprint", "Sprint"),
+        ("qualifying", "Qualifying"),
+    ),
+)
+def test_sprint_and_qualifying_stopped_non_pit_confirm_medium(
+    session_type: str, session_name: str
+) -> None:
+    session = SessionMetadata(
+        session_key=f"2026-miami-{session_type}",
+        meeting_name="Miami Grand Prix",
+        session_name=session_name,
+        session_type=session_type,
+    )
+    detector = IncidentDetector()
+    detector.process_signals(
+        normalize_timing_data(
+            {"Lines": {"10": {"Stopped": False, "InPit": False}}},
+            BASE,
+            session=session,
+            drivers=DRIVERS,
+        )
+    )
+
+    changes = detector.process_signals(
+        normalize_timing_data(
+            {"Lines": {"10": {"Stopped": True}}},
+            BASE + timedelta(seconds=1),
+            session=session,
+            drivers=DRIVERS,
+        )
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+    assert changes[0].confidence == CONFIDENCE_MEDIUM
+    assert changes[0].session.session_type == session_type
+
+
+def test_change_payload_is_json_serializable_and_stable() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+    change = detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=True)
+    )[0]
+
+    payload = change.to_event_payload()
+
+    assert payload == {
+        "incident_id": "2026-miami-race-10-2026-05-03T17:00:01Z",
+        "phase": "confirmed",
+        "confidence": "medium",
+        "reason": "timing_stopped",
+        "driver": {
+            "racing_number": "10",
+            "tla": "GAS",
+            "name": "Pierre Gasly",
+            "team": "Alpine",
+        },
+        "session": {
+            "meeting_name": "Miami Grand Prix",
+            "session_name": "Race",
+            "session_type": "race",
+            "session_key": "2026-miami-race",
+        },
+        "track_status": {
+            "status": None,
+            "message": None,
+        },
+        "race_control": {
+            "message": None,
+            "category": None,
+            "flag": None,
+        },
+        "signals": ["timing_stopped"],
+        "started_at": "2026-05-03T17:00:01Z",
+        "updated_at": "2026-05-03T17:00:01Z",
+        "data_quality": "live",
+    }

--- a/custom_components/f1_sensor/tests/test_incident_detection.py
+++ b/custom_components/f1_sensor/tests/test_incident_detection.py
@@ -179,7 +179,37 @@ def test_normalize_race_control_extracts_driver_number_from_message() -> None:
     assert signals[0].kind == "race_control"
     assert signals[0].racing_number == "10"
     assert "race_control_yellow" in signals[0].signals
-    assert "race_control_incident" in signals[0].signals
+    assert "race_control_incident" not in signals[0].signals
+
+
+def test_normalize_race_control_sporting_incident_is_not_incident_context() -> None:
+    signals = _race_control(
+        BASE,
+        "TURN 14 INCIDENT INVOLVING CAR 10 (GAS) NOTED - IMPEDING (16:34:57)",
+        category="Other",
+        flag="",
+    )
+
+    assert len(signals) == 1
+    assert signals[0].racing_number == "10"
+    assert signals[0].signals == ()
+
+
+def test_sporting_race_control_message_does_not_create_candidate() -> None:
+    detector = IncidentDetector()
+    _bootstrap_clean(detector)
+
+    changes = detector.process_signals(
+        _race_control(
+            BASE + timedelta(seconds=10),
+            "TURN 14 INCIDENT INVOLVING CAR 10 (GAS) NOTED - IMPEDING (16:34:57)",
+            category="Other",
+            flag="",
+        )
+    )
+
+    assert changes == []
+    assert detector.active_incidents(SESSION.session_key) == ()
 
 
 def test_normalize_race_control_ignores_pit_lane_yellow_context() -> None:

--- a/custom_components/f1_sensor/tests/test_incident_detection_cardata.py
+++ b/custom_components/f1_sensor/tests/test_incident_detection_cardata.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime, timedelta
+import json
+import zlib
+
+from custom_components.f1_sensor.incident_detection import (
+    CONFIDENCE_HIGH,
+    CONFIDENCE_MEDIUM,
+    DATA_QUALITY_BOOTSTRAP,
+    DATA_QUALITY_LIVE,
+    PHASE_CANDIDATE,
+    PHASE_CLEARED,
+    PHASE_CONFIRMED,
+    DriverMetadata,
+    IncidentDetector,
+    SessionMetadata,
+    normalize_car_data,
+    normalize_race_control_messages,
+    normalize_session_status,
+    normalize_timing_data,
+    normalize_track_status,
+)
+
+BASE = datetime(2026, 5, 3, 17, 0, 0, tzinfo=UTC)
+SESSION = SessionMetadata(
+    session_key="2026-miami-race",
+    meeting_name="Miami Grand Prix",
+    session_name="Race",
+    session_type="race",
+)
+DRIVERS = {
+    "10": DriverMetadata(
+        racing_number="10",
+        tla="GAS",
+        name="Pierre Gasly",
+        team="Alpine",
+    ),
+    "30": DriverMetadata(racing_number="30", tla="LAW"),
+    "6": DriverMetadata(racing_number="6", tla="HAD"),
+}
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _encoded_cardata_payload(at: datetime, speed: float, rn: str = "10") -> str:
+    data = {
+        "Entries": [
+            {
+                "Utc": _iso(at),
+                "Cars": {rn: {"Channels": {"2": speed}}},
+            }
+        ]
+    }
+    raw = json.dumps(data).encode()
+    compressor = zlib.compressobj(wbits=-15)
+    compressed = compressor.compress(raw) + compressor.flush()
+    return '"' + base64.b64encode(compressed).decode() + '"'
+
+
+def _car_speed(
+    at: datetime,
+    speed: float,
+    *,
+    rn: str = "10",
+    data_quality: str = DATA_QUALITY_LIVE,
+):
+    return normalize_car_data(
+        {
+            "Entries": [
+                {
+                    "Utc": _iso(at),
+                    "Cars": {rn: {"Channels": {"2": speed}}},
+                }
+            ]
+        },
+        at,
+        session=SESSION,
+        drivers=DRIVERS,
+        data_quality=data_quality,
+    )
+
+
+def _timing(
+    at: datetime,
+    *,
+    rn: str = "10",
+    stopped: bool | None = None,
+    in_pit: bool | None = None,
+    pit_out: bool | None = None,
+):
+    line: dict[str, bool] = {}
+    if stopped is not None:
+        line["Stopped"] = stopped
+    if in_pit is not None:
+        line["InPit"] = in_pit
+    if pit_out is not None:
+        line["PitOut"] = pit_out
+    return normalize_timing_data(
+        {"Lines": {rn: line}},
+        at,
+        session=SESSION,
+        drivers=DRIVERS,
+    )
+
+
+def _track(at: datetime, status: str = "2", message: str = "Yellow"):
+    return normalize_track_status(
+        {"Status": status, "Message": message},
+        at,
+        session=SESSION,
+    )
+
+
+def _session_status(at: datetime, status: str):
+    return normalize_session_status(
+        {"Status": status},
+        at,
+        session=SESSION,
+    )
+
+
+def _race_control(at: datetime, message: str):
+    return normalize_race_control_messages(
+        {
+            "Messages": [
+                {
+                    "Utc": _iso(at),
+                    "Category": "Other",
+                    "Message": message,
+                }
+            ]
+        },
+        at,
+        session=SESSION,
+        drivers=DRIVERS,
+    )
+
+
+def test_normalize_cardata_decodes_speed_channel_from_payload() -> None:
+    signals = normalize_car_data(
+        {
+            "Entries": [
+                {
+                    "Utc": "2026-05-03T17:11:41Z",
+                    "Cars": {"10": {"Channels": {"2": "0"}}},
+                }
+            ]
+        },
+        BASE,
+        session=SESSION,
+        drivers=DRIVERS,
+    )
+
+    assert len(signals) == 1
+    assert signals[0].kind == "car_speed"
+    assert signals[0].racing_number == "10"
+    assert signals[0].value == 0.0
+    assert signals[0].observed_at == datetime(2026, 5, 3, 17, 11, 41, tzinfo=UTC)
+    assert signals[0].driver == DRIVERS["10"]
+
+
+def test_normalize_cardata_decodes_compressed_live_payload() -> None:
+    signals = normalize_car_data(
+        _encoded_cardata_payload(BASE + timedelta(seconds=1), 4, rn="6"),
+        BASE,
+        session=SESSION,
+        drivers=DRIVERS,
+    )
+
+    assert len(signals) == 1
+    assert signals[0].racing_number == "6"
+    assert signals[0].value == 4.0
+
+
+def test_normalize_cardata_ignores_malformed_or_invalid_speed() -> None:
+    assert normalize_car_data(None, BASE, session=SESSION) == []
+    assert normalize_car_data({"Entries": "bad"}, BASE, session=SESSION) == []
+    assert (
+        normalize_car_data(
+            {"Entries": [{"Utc": _iso(BASE), "Cars": {"10": {"Channels": {}}}}]},
+            BASE,
+            session=SESSION,
+        )
+        == []
+    )
+    assert (
+        normalize_car_data(
+            {
+                "Entries": [
+                    {"Utc": _iso(BASE), "Cars": {"10": {"Channels": {"2": 999}}}}
+                ]
+            },
+            BASE,
+            session=SESSION,
+        )
+        == []
+    )
+
+
+def test_low_speed_before_yellow_creates_candidate_not_confirmed() -> None:
+    detector = IncidentDetector()
+    assert detector.process_signals(_car_speed(BASE, 0)) == []
+    assert detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0)) == []
+
+    changes = detector.process_signals(_track(BASE + timedelta(seconds=5)))
+
+    assert len(changes) == 1
+    change = changes[0]
+    assert change.phase == PHASE_CANDIDATE
+    assert change.confidence == CONFIDENCE_MEDIUM
+    assert change.reason == "car_low_speed_with_track_status"
+    assert change.driver.racing_number == "10"
+    assert "car_low_speed" in change.signals
+    assert "track_status_yellow" in change.signals
+
+
+def test_miami_like_cardata_points_out_had_within_seconds_after_yellow() -> None:
+    detector = IncidentDetector()
+    low_start = datetime(2026, 5, 3, 17, 11, 40, 989594, tzinfo=UTC)
+    detector.process_signals(_car_speed(low_start, 4, rn="6"))
+    detector.process_signals(
+        _car_speed(datetime(2026, 5, 3, 17, 11, 41, 229559, tzinfo=UTC), 0, rn="6")
+    )
+    detector.process_signals(
+        _car_speed(datetime(2026, 5, 3, 17, 11, 42, 270404, tzinfo=UTC), 0, rn="6")
+    )
+
+    changes = detector.process_signals(
+        _track(
+            datetime(2026, 5, 3, 17, 11, 46, tzinfo=UTC),
+            status="2",
+            message="Yellow",
+        )
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CANDIDATE
+    assert changes[0].driver.racing_number == "6"
+    assert changes[0].driver.tla == "HAD"
+    assert changes[0].started_at == low_start
+    assert changes[0].updated_at == datetime(2026, 5, 3, 17, 11, 46, tzinfo=UTC)
+
+
+def test_yellow_before_low_speed_creates_candidate_after_duration() -> None:
+    detector = IncidentDetector()
+    assert detector.process_signals(_track(BASE)) == []
+    assert detector.process_signals(_car_speed(BASE + timedelta(seconds=1), 0)) == []
+
+    changes = detector.process_signals(_car_speed(BASE + timedelta(seconds=3), 0))
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CANDIDATE
+    assert changes[0].reason == "car_low_speed_with_track_status"
+
+
+def test_cardata_candidate_promotes_with_timing_stopped() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(_timing(BASE - timedelta(seconds=1), stopped=False))
+    detector.process_signals(_car_speed(BASE, 0))
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0))
+    candidate = detector.process_signals(_track(BASE + timedelta(seconds=5)))[0]
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=20), stopped=True)
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+    assert changes[0].incident_id == candidate.incident_id
+    assert "timing_stopped" in changes[0].signals
+    assert "car_low_speed" in changes[0].signals
+
+
+def test_strict_stopped_race_control_promotes_cardata_candidate() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(_car_speed(BASE, 0))
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0))
+    candidate = detector.process_signals(_track(BASE + timedelta(seconds=5)))[0]
+
+    changes = detector.process_signals(
+        _race_control(BASE + timedelta(seconds=6), "CAR 10 STOPPED ON TRACK")
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+    assert changes[0].confidence == CONFIDENCE_HIGH
+    assert changes[0].incident_id == candidate.incident_id
+    assert changes[0].reason == "race_control_stopped_with_car_low_speed"
+
+
+def test_low_speed_in_pit_is_suppressed() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(
+        _timing(BASE - timedelta(seconds=1), stopped=False, in_pit=True)
+    )
+    detector.process_signals(_car_speed(BASE, 0))
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0))
+
+    changes = detector.process_signals(_track(BASE + timedelta(seconds=5)))
+
+    assert changes == []
+    assert detector.active_incidents(SESSION.session_key) == ()
+
+
+def test_low_speed_after_yellow_in_pit_is_suppressed() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(_track(BASE))
+    detector.process_signals(
+        _timing(BASE + timedelta(seconds=1), stopped=False, in_pit=True)
+    )
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0))
+
+    changes = detector.process_signals(_car_speed(BASE + timedelta(seconds=4), 0))
+
+    assert changes == []
+    assert detector.active_incidents(SESSION.session_key) == ()
+
+
+def test_recent_pit_out_suppresses_low_speed_candidate() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(_timing(BASE, pit_out=True))
+    detector.process_signals(_timing(BASE + timedelta(seconds=1), pit_out=False))
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0))
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=4), 0))
+
+    changes = detector.process_signals(_track(BASE + timedelta(seconds=5)))
+
+    assert changes == []
+
+
+def test_recent_pit_out_after_yellow_suppresses_low_speed_candidate() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(_track(BASE))
+    detector.process_signals(_timing(BASE + timedelta(seconds=1), pit_out=True))
+    detector.process_signals(_timing(BASE + timedelta(seconds=2), pit_out=False))
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=3), 0))
+
+    changes = detector.process_signals(_car_speed(BASE + timedelta(seconds=5), 0))
+
+    assert changes == []
+    assert detector.active_incidents(SESSION.session_key) == ()
+
+
+def test_bootstrap_cardata_is_not_used_for_live_context() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(_car_speed(BASE, 0, data_quality=DATA_QUALITY_BOOTSTRAP))
+    detector.process_signals(
+        _car_speed(
+            BASE + timedelta(seconds=2),
+            0,
+            data_quality=DATA_QUALITY_BOOTSTRAP,
+        )
+    )
+
+    changes = detector.process_signals(_track(BASE + timedelta(seconds=5)))
+
+    assert changes == []
+
+
+def test_stale_cardata_is_not_used_for_context() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(_car_speed(BASE, 0))
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0))
+
+    changes = detector.process_signals(_track(BASE + timedelta(seconds=30)))
+
+    assert changes == []
+
+
+def test_global_red_with_too_many_low_speed_drivers_is_suppressed() -> None:
+    detector = IncidentDetector(car_candidate_limit=2)
+    for rn in ("6", "10", "30"):
+        detector.process_signals(_car_speed(BASE, 0, rn=rn))
+        detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0, rn=rn))
+
+    changes = detector.process_signals(
+        _track(BASE + timedelta(seconds=5), status="5", message="Red")
+    )
+
+    assert changes == []
+
+
+def test_direct_cardata_candidates_respect_global_limit() -> None:
+    detector = IncidentDetector(car_candidate_limit=2)
+    detector.process_signals(_track(BASE))
+    changes = []
+
+    for rn in ("6", "10", "30"):
+        detector.process_signals(_car_speed(BASE + timedelta(seconds=1), 0, rn=rn))
+        changes.extend(
+            detector.process_signals(_car_speed(BASE + timedelta(seconds=3), 0, rn=rn))
+        )
+
+    assert [(change.phase, change.driver.racing_number) for change in changes] == [
+        (PHASE_CANDIDATE, "6"),
+        (PHASE_CANDIDATE, "10"),
+    ]
+    assert detector.get_active_incident(SESSION.session_key, "30") is None
+
+
+def test_red_flag_aborted_keeps_candidate_active_until_stopped_confirms() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(
+        _timing(BASE - timedelta(seconds=1), rn="30", stopped=False)
+    )
+    detector.process_signals(_car_speed(BASE, 0, rn="30"))
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0, rn="30"))
+    candidate = detector.process_signals(_track(BASE + timedelta(seconds=5)))[0]
+
+    assert (
+        detector.process_signals(
+            _session_status(BASE + timedelta(seconds=10), "Aborted")
+        )
+        == []
+    )
+    active = detector.get_active_incident(SESSION.session_key, "30")
+    assert active is not None
+    assert active.incident_id == candidate.incident_id
+
+    changes = detector.process_signals(
+        _timing(BASE + timedelta(seconds=20), rn="30", stopped=True)
+    )
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CONFIRMED
+    assert changes[0].incident_id == candidate.incident_id
+
+
+def test_movement_clears_unconfirmed_cardata_candidate() -> None:
+    detector = IncidentDetector()
+    detector.process_signals(_car_speed(BASE, 0))
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=2), 0))
+    candidate = detector.process_signals(_track(BASE + timedelta(seconds=5)))[0]
+    detector.process_signals(_car_speed(BASE + timedelta(seconds=6), 30))
+
+    changes = detector.process_signals(_car_speed(BASE + timedelta(seconds=12), 40))
+
+    assert len(changes) == 1
+    assert changes[0].phase == PHASE_CLEARED
+    assert changes[0].incident_id == candidate.incident_id
+    assert changes[0].reason == "car_moving"

--- a/custom_components/f1_sensor/tests/test_incident_detection_events.py
+++ b/custom_components/f1_sensor/tests/test_incident_detection_events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 import json
 import logging
 from typing import Any
@@ -111,6 +112,25 @@ def _timing(stopped: bool) -> dict[str, Any]:
     }
 
 
+def _cardata(at, speed: int = 0) -> dict[str, Any]:
+    return {
+        "Entries": [
+            {
+                "Utc": at.isoformat().replace("+00:00", "Z"),
+                "Cars": {"10": {"Channels": {"2": speed}}},
+            }
+        ]
+    }
+
+
+def _track_status(at, status: str = "2", message: str = "Yellow") -> dict[str, Any]:
+    return {
+        "Utc": at.isoformat().replace("+00:00", "Z"),
+        "Status": status,
+        "Message": message,
+    }
+
+
 def _race_control() -> dict[str, Any]:
     return {
         "Messages": [
@@ -211,6 +231,41 @@ async def test_incident_events_confirm_update_dedupe_and_clear(hass) -> None:
         assert events[-1]["incident_id"] == confirmed["incident_id"]
         assert coordinator.data["active_count"] == 0
         assert coordinator.data["latest_phase"] == "cleared"
+    finally:
+        unsub()
+        await coordinator.async_close()
+
+
+@pytest.mark.asyncio
+async def test_incident_cardata_candidate_event_is_deduped_and_not_confirmed(
+    hass,
+) -> None:
+    bus = FakeIncidentLiveBus(auth_header="Bearer secret-token")
+    events = []
+    unsub = hass.bus.async_listen(
+        _INCIDENT_EVENT, lambda event: events.append(event.data)
+    )
+    coordinator = await _coordinator(hass, bus)
+    base = datetime.now(UTC).replace(microsecond=0)
+
+    try:
+        await _prime_context(hass, bus)
+        bus.emit("CarData.z", _cardata(base, 0))
+        bus.emit("CarData.z", _cardata(base + timedelta(seconds=2), 0))
+        bus.emit("TrackStatus", _track_status(base + timedelta(seconds=5)))
+        await hass.async_block_till_done()
+
+        assert [event["phase"] for event in events] == ["candidate"]
+        candidate = events[-1]
+        assert candidate["confidence"] == "medium"
+        assert candidate["reason"] == "car_low_speed_with_track_status"
+        assert "car_low_speed" in candidate["signals"]
+        assert coordinator.data["active_count"] == 1
+
+        bus.emit("TrackStatus", _track_status(base + timedelta(seconds=6)))
+        await hass.async_block_till_done()
+
+        assert [event["phase"] for event in events] == ["candidate"]
     finally:
         unsub()
         await coordinator.async_close()

--- a/custom_components/f1_sensor/tests/test_incident_detection_events.py
+++ b/custom_components/f1_sensor/tests/test_incident_detection_events.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.f1_sensor import (
+    _INCIDENT_EVENT,
+    _INCIDENT_STREAMS,
+    IncidentCoordinator,
+)
+from custom_components.f1_sensor.const import DOMAIN
+from custom_components.f1_sensor.live_window import LiveAvailabilityTracker
+
+
+class FakeIncidentLiveBus:
+    def __init__(
+        self, last_payload: dict[str, Any] | None = None, *, auth_header: str = ""
+    ) -> None:
+        self.last_payload = last_payload or {}
+        self.auth_header = auth_header
+        self.subscribers: dict[str, list] = {}
+        self.unsubscribe_count = 0
+
+    @property
+    def auth_enabled(self) -> bool:
+        return bool(self.auth_header)
+
+    def subscribe(self, stream: str, callback):
+        self.subscribers.setdefault(stream, []).append(callback)
+        if stream in self.last_payload:
+            callback(self.last_payload[stream])
+
+        def _unsub() -> None:
+            callbacks = self.subscribers.get(stream, [])
+            if callback in callbacks:
+                callbacks.remove(callback)
+                self.unsubscribe_count += 1
+
+        return _unsub
+
+    def emit(self, stream: str, payload: Any) -> None:
+        for callback in list(self.subscribers.get(stream, [])):
+            callback(payload)
+
+
+def _entry(hass) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, entry_id="incident-entry")
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def _coordinator(
+    hass,
+    bus: FakeIncidentLiveBus,
+    *,
+    delay_seconds: int = 0,
+    live_state: LiveAvailabilityTracker | None = None,
+) -> IncidentCoordinator:
+    if live_state is None:
+        live_state = LiveAvailabilityTracker()
+        live_state.set_state(True, "live")
+    coordinator = IncidentCoordinator(
+        hass,
+        session_coord=object(),
+        delay_seconds=delay_seconds,
+        bus=bus,
+        config_entry=_entry(hass),
+        live_state=live_state,
+    )
+    await coordinator.async_refresh()
+    for stream in _INCIDENT_STREAMS:
+        coordinator._subscribe_stream(bus, stream)  # noqa: SLF001
+    return coordinator
+
+
+def _driver_list() -> dict[str, Any]:
+    return {
+        "10": {
+            "Tla": "GAS",
+            "FullName": "Pierre Gasly",
+            "TeamName": "Alpine",
+        }
+    }
+
+
+def _session_info() -> dict[str, Any]:
+    return {
+        "Meeting": {"Name": "Miami Grand Prix"},
+        "Name": "Race",
+        "Type": "Race",
+        "Path": "2026-miami-race",
+        "StartDate": "2026-05-03T20:00:00Z",
+    }
+
+
+def _timing(stopped: bool) -> dict[str, Any]:
+    return {
+        "Lines": {
+            "10": {
+                "Stopped": stopped,
+                "InPit": False,
+                "PitOut": False,
+                "Retired": False,
+            }
+        }
+    }
+
+
+def _race_control() -> dict[str, Any]:
+    return {
+        "Messages": [
+            {
+                "Category": "Flag",
+                "Flag": "DOUBLE YELLOW",
+                "Message": "DOUBLE YELLOW FOR CAR 10",
+            }
+        ]
+    }
+
+
+async def _prime_context(hass, bus: FakeIncidentLiveBus) -> None:
+    bus.emit("SessionInfo", _session_info())
+    bus.emit("DriverList", _driver_list())
+    bus.emit("TimingData", _timing(False))
+    await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_startup_cache_does_not_fire_incident(hass) -> None:
+    bus = FakeIncidentLiveBus(
+        {
+            "TimingData": _timing(True),
+            "RaceControlMessages": _race_control(),
+        }
+    )
+    events = []
+    unsub = hass.bus.async_listen(_INCIDENT_EVENT, lambda event: events.append(event))
+
+    coordinator = await _coordinator(hass, bus)
+    try:
+        await hass.async_block_till_done()
+        assert events == []
+        assert coordinator.data["active_count"] == 0
+
+        bus.emit("TimingData", _timing(True))
+        await hass.async_block_till_done()
+
+        assert events == []
+        assert coordinator.data["active_count"] == 0
+    finally:
+        unsub()
+        await coordinator.async_close()
+
+
+@pytest.mark.asyncio
+async def test_incident_events_confirm_update_dedupe_and_clear(hass) -> None:
+    bus = FakeIncidentLiveBus()
+    events = []
+    unsub = hass.bus.async_listen(
+        _INCIDENT_EVENT, lambda event: events.append(event.data)
+    )
+    coordinator = await _coordinator(hass, bus)
+
+    try:
+        await _prime_context(hass, bus)
+
+        bus.emit("TimingData", _timing(True))
+        await hass.async_block_till_done()
+
+        assert [event["phase"] for event in events] == ["confirmed"]
+        confirmed = events[-1]
+        assert confirmed["entry_id"] == "incident-entry"
+        assert confirmed["confidence"] == "medium"
+        assert confirmed["driver"] == {
+            "racing_number": "10",
+            "tla": "GAS",
+            "name": "Pierre Gasly",
+            "team": "Alpine",
+        }
+
+        bus.emit("TimingData", _timing(True))
+        await hass.async_block_till_done()
+        assert [event["phase"] for event in events] == ["confirmed"]
+
+        bus.emit("RaceControlMessages", _race_control())
+        await hass.async_block_till_done()
+
+        assert [event["phase"] for event in events] == ["confirmed", "updated"]
+        updated = events[-1]
+        assert updated["incident_id"] == confirmed["incident_id"]
+        assert updated["confidence"] == "high"
+        assert updated["race_control"]["message"] == "DOUBLE YELLOW FOR CAR 10"
+
+        bus.emit("RaceControlMessages", _race_control())
+        await hass.async_block_till_done()
+        assert [event["phase"] for event in events] == ["confirmed", "updated"]
+
+        bus.emit("TimingData", _timing(False))
+        await hass.async_block_till_done()
+
+        assert [event["phase"] for event in events] == [
+            "confirmed",
+            "updated",
+            "cleared",
+        ]
+        assert events[-1]["incident_id"] == confirmed["incident_id"]
+        assert coordinator.data["active_count"] == 0
+        assert coordinator.data["latest_phase"] == "cleared"
+    finally:
+        unsub()
+        await coordinator.async_close()
+
+
+@pytest.mark.asyncio
+async def test_incident_payload_is_stable_json_and_does_not_leak_tokens(
+    hass, caplog
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="custom_components.f1_sensor")
+    bus = FakeIncidentLiveBus(auth_header="Bearer secret-token")
+    events = []
+    unsub = hass.bus.async_listen(
+        _INCIDENT_EVENT, lambda event: events.append(event.data)
+    )
+    coordinator = await _coordinator(hass, bus)
+
+    try:
+        await _prime_context(hass, bus)
+        bus.emit(
+            "TimingData",
+            {
+                "Authorization": "Bearer secret-token",
+                "subscription_token": "secret-token",
+                **_timing(True),
+            },
+        )
+        await hass.async_block_till_done()
+
+        payload = events[-1]
+        json.dumps(payload)
+        assert set(payload) == {
+            "entry_id",
+            "incident_id",
+            "phase",
+            "confidence",
+            "reason",
+            "driver",
+            "session",
+            "track_status",
+            "race_control",
+            "signals",
+            "started_at",
+            "updated_at",
+            "data_quality",
+        }
+        assert set(payload["driver"]) == {"racing_number", "tla", "name", "team"}
+        assert set(payload["session"]) == {
+            "meeting_name",
+            "session_name",
+            "session_type",
+            "session_key",
+        }
+        assert set(payload["track_status"]) == {"status", "message"}
+        assert set(payload["race_control"]) == {"message", "category", "flag"}
+        serialized = json.dumps(payload)
+        assert "secret-token" not in serialized
+        assert "Bearer" not in serialized
+        assert "secret-token" not in caplog.text
+    finally:
+        unsub()
+        await coordinator.async_close()
+
+
+@pytest.mark.asyncio
+async def test_incident_events_respect_live_delay(hass) -> None:
+    bus = FakeIncidentLiveBus()
+    events = []
+    unsub = hass.bus.async_listen(
+        _INCIDENT_EVENT, lambda event: events.append(event.data)
+    )
+    coordinator = await _coordinator(hass, bus)
+
+    try:
+        await _prime_context(hass, bus)
+        coordinator.set_delay(1)
+        bus.emit("TimingData", _timing(True))
+
+        await asyncio.sleep(0.2)
+        await hass.async_block_till_done()
+        assert events == []
+
+        await asyncio.sleep(0.9)
+        await hass.async_block_till_done()
+        assert [event["phase"] for event in events] == ["confirmed"]
+    finally:
+        unsub()
+        await coordinator.async_close()
+
+
+@pytest.mark.asyncio
+async def test_incident_replay_bypasses_live_delay(hass) -> None:
+    live_state = LiveAvailabilityTracker()
+    live_state.set_state(True, "replay-mode")
+    bus = FakeIncidentLiveBus()
+    events = []
+    unsub = hass.bus.async_listen(
+        _INCIDENT_EVENT, lambda event: events.append(event.data)
+    )
+    coordinator = await _coordinator(
+        hass,
+        bus,
+        delay_seconds=1,
+        live_state=live_state,
+    )
+
+    try:
+        await _prime_context(hass, bus)
+        bus.emit("TimingData", _timing(True))
+        await hass.async_block_till_done()
+
+        assert [event["phase"] for event in events] == ["confirmed"]
+        assert events[-1]["data_quality"] == "replay"
+    finally:
+        unsub()
+        await coordinator.async_close()
+
+
+@pytest.mark.asyncio
+async def test_incident_close_unsubscribes_and_cancels_delayed_events(hass) -> None:
+    bus = FakeIncidentLiveBus()
+    events = []
+    unsub = hass.bus.async_listen(
+        _INCIDENT_EVENT, lambda event: events.append(event.data)
+    )
+    coordinator = await _coordinator(hass, bus)
+
+    try:
+        await _prime_context(hass, bus)
+        coordinator.set_delay(1)
+        bus.emit("TimingData", _timing(True))
+
+        await coordinator.async_close()
+        await asyncio.sleep(1.1)
+        await hass.async_block_till_done()
+
+        assert events == []
+        assert bus.unsubscribe_count == len(_INCIDENT_STREAMS)
+    finally:
+        unsub()
+        await coordinator.async_close()

--- a/custom_components/f1_sensor/tests/test_incident_detection_replay.py
+++ b/custom_components/f1_sensor/tests/test_incident_detection_replay.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from custom_components.f1_sensor.incident_detection import (
+    CONFIDENCE_HIGH,
+    CONFIDENCE_MEDIUM,
+    DATA_QUALITY_REPLAY,
+    PHASE_CONFIRMED,
+)
+from custom_components.f1_sensor.tests.incident_replay import (
+    MAX_REPLAY_CASE_BYTES,
+    PUBLIC_REPLAY_STREAMS,
+    extracted_cases,
+    format_replay_timeline,
+    load_fixture_manifest,
+    replay_case_size_bytes,
+    replay_manifest_case,
+    validate_replay_case,
+)
+
+EXPECTED_REPLAY_INCIDENTS = {
+    "2026_australian_gp_qualifying_ver_red_flag": {
+        "drivers": {"3"},
+        "reason": "timing_stopped_with_race_control",
+        "session_type": "qualifying",
+    },
+    "2026_miami_gp_race_had_gas_safety_car": {
+        "drivers": {"6", "10"},
+        "reason": "timing_stopped_with_safety_car_context",
+        "session_type": "race",
+    },
+    "2026_chinese_gp_sprint_hulkenberg_safety_car": {
+        "drivers": {"27"},
+        "reason": "timing_stopped_with_safety_car_context",
+        "session_type": "sprint",
+    },
+    "2026_chinese_gp_practice_lindblad_vsc": {
+        "drivers": {"41"},
+        "reason": "timing_stopped_with_vsc_context",
+        "session_type": "practice",
+    },
+}
+
+
+def _case_by_id(case_id: str):
+    return next(case for case in extracted_cases() if case["id"] == case_id)
+
+
+def test_fixture_manifest_contains_only_public_phase_2_replay_streams() -> None:
+    manifest = load_fixture_manifest()
+    cases = extracted_cases(manifest)
+
+    assert manifest["version"] == 1
+    assert {case["id"] for case in cases} == set(EXPECTED_REPLAY_INCIDENTS)
+    for case in cases:
+        validate_replay_case(case)
+        assert replay_case_size_bytes(case) < MAX_REPLAY_CASE_BYTES
+        assert case["optional_streams_excluded"] == ["CarData.z"]
+        assert set(case["included_streams"]).issubset(PUBLIC_REPLAY_STREAMS)
+        assert {frame["stream"] for frame in case["frames"]}.issubset(
+            PUBLIC_REPLAY_STREAMS
+        )
+
+
+@pytest.mark.parametrize("case_id", sorted(EXPECTED_REPLAY_INCIDENTS))
+def test_replay_fixture_confirms_expected_incidents(case_id: str) -> None:
+    expected = EXPECTED_REPLAY_INCIDENTS[case_id]
+
+    result = replay_manifest_case(_case_by_id(case_id))
+    confirmed = [change for change in result.changes if change.phase == PHASE_CONFIRMED]
+
+    assert result.frames[0].offset == "state_before"
+    assert result.frames[0].changes == ()
+    assert {change.driver.racing_number for change in confirmed} == expected["drivers"]
+    assert {change.confidence for change in confirmed} == {CONFIDENCE_HIGH}
+    assert {change.reason for change in confirmed} == {expected["reason"]}
+    assert {change.session.session_type for change in confirmed} == {
+        expected["session_type"]
+    }
+    assert {change.data_quality for change in confirmed} == {DATA_QUALITY_REPLAY}
+    assert all("timing_stopped" in change.signals for change in confirmed)
+    assert all(change.track_status.status is not None for change in confirmed)
+
+
+@pytest.mark.parametrize("case_id", sorted(EXPECTED_REPLAY_INCIDENTS))
+def test_replay_fixture_dedupes_confirmed_incidents_per_driver(case_id: str) -> None:
+    result = replay_manifest_case(_case_by_id(case_id))
+    confirmed = [change for change in result.changes if change.phase == PHASE_CONFIRMED]
+
+    assert len(confirmed) == len({change.driver.racing_number for change in confirmed})
+    assert all(change.started_at == change.updated_at for change in confirmed)
+
+
+def test_practice_replay_without_context_stays_medium_not_high() -> None:
+    case = deepcopy(_case_by_id("2026_chinese_gp_practice_lindblad_vsc"))
+    case["frames"] = [
+        frame for frame in case["frames"] if frame["stream"] == "TimingData"
+    ]
+
+    result = replay_manifest_case(case)
+    confirmed = [change for change in result.changes if change.phase == PHASE_CONFIRMED]
+
+    assert len(confirmed) == 1
+    assert confirmed[0].driver.racing_number == "41"
+    assert confirmed[0].confidence == CONFIDENCE_MEDIUM
+    assert confirmed[0].reason == "timing_stopped"
+
+
+def test_replay_timeline_uses_neutral_incident_language() -> None:
+    timeline = format_replay_timeline(
+        replay_manifest_case(_case_by_id("2026_chinese_gp_practice_lindblad_vsc"))
+    )
+
+    assert "00:28:00.553 TimingData: confirmed high car 41" in timeline
+    assert "crash" not in timeline.lower()
+    assert "accident" not in timeline.lower()
+    assert "mechanical failure" not in timeline.lower()
+    assert "off track" not in timeline.lower()

--- a/custom_components/f1_sensor/tests/test_incident_notifications_blueprint.py
+++ b/custom_components/f1_sensor/tests/test_incident_notifications_blueprint.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.setup import async_setup_component
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_BLUEPRINT_FILENAME = "f1_incident_notifications.yaml"
+BLUEPRINT_SOURCE = (
+    _REPO_ROOT / "blueprints" / "automation" / "homeassistant" / _BLUEPRINT_FILENAME
+)
+BLUEPRINT_DEST = Path(
+    "blueprints/automation/homeassistant/f1_incident_notifications.yaml"
+)
+
+
+async def _install_blueprint(hass: HomeAssistant) -> None:
+    destination = Path(hass.config.path(str(BLUEPRINT_DEST)))
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        BLUEPRINT_SOURCE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+
+def _register_notification_service(hass: HomeAssistant) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    register_service = getattr(hass.services, "async_" + "register")
+
+    async def _record(call: ServiceCall) -> None:
+        calls.append(dict(call.data))
+
+    register_service("test", "record_notification", _record)
+    return calls
+
+
+async def _setup_blueprint_automation(
+    hass: HomeAssistant,
+    *,
+    min_confidence: str = "medium",
+    allowed_session_types: list[str] | None = None,
+    include_candidate_events: bool = False,
+    include_cleared_notifications: bool = False,
+) -> bool:
+    config = {
+        "automation": [
+            {
+                "id": "incident_notifications_blueprint_test",
+                "alias": "Incident Notifications Blueprint Test",
+                "use_blueprint": {
+                    "path": "homeassistant/f1_incident_notifications.yaml",
+                    "input": {
+                        "notify_services": "test.record_notification",
+                        "notify_targets": [],
+                        "min_confidence": min_confidence,
+                        "allowed_session_types": allowed_session_types
+                        or ["race", "sprint", "qualifying"],
+                        "include_candidate_events": include_candidate_events,
+                        "include_cleared_notifications": include_cleared_notifications,
+                        "title_prefix": "F1 Incident Test",
+                    },
+                },
+            }
+        ]
+    }
+    result = await async_setup_component(hass, "automation", config)
+    await hass.async_block_till_done()
+    return result
+
+
+def _incident_event(
+    *,
+    incident_id: str = "2026-miami-race-10-2026-05-03T17:00:01Z",
+    phase: str = "confirmed",
+    confidence: str = "medium",
+    session_type: str = "race",
+    session_name: str = "Race",
+) -> dict[str, Any]:
+    return {
+        "entry_id": "incident-entry",
+        "incident_id": incident_id,
+        "phase": phase,
+        "confidence": confidence,
+        "reason": "timing_stopped",
+        "driver": {
+            "racing_number": "10",
+            "tla": "GAS",
+            "name": "Pierre Gasly",
+            "team": "Alpine",
+        },
+        "session": {
+            "meeting_name": "Miami Grand Prix",
+            "session_name": session_name,
+            "session_type": session_type,
+            "session_key": f"2026-miami-{session_type}",
+        },
+        "track_status": {
+            "status": None,
+            "message": None,
+        },
+        "race_control": {
+            "message": None,
+            "category": None,
+            "flag": None,
+        },
+        "signals": ["timing_stopped"],
+        "started_at": "2026-05-03T17:00:01Z",
+        "updated_at": "2026-05-03T17:00:01Z",
+        "data_quality": "live",
+    }
+
+
+async def _fire_incident(hass: HomeAssistant, **kwargs: Any) -> None:
+    hass.bus.async_fire("f1_sensor_incident", _incident_event(**kwargs))
+    await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_default_incident_notification_is_neutral_and_tagged(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_notification_service(hass)
+
+    assert await _setup_blueprint_automation(hass)
+    calls.clear()
+
+    await _fire_incident(hass)
+
+    assert calls == [
+        {
+            "title": "F1 Incident Test (MEDIUM)",
+            "message": "Possible on-track incident: GAS stopped\nSession: Race",
+            "data": {
+                "tag": "f1_incident_2026_miami_race_10_2026_05_03t17_00_01z",
+                "group": "f1_incidents",
+                "incident_id": "2026-miami-race-10-2026-05-03T17:00:01Z",
+                "phase": "confirmed",
+                "confidence": "medium",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_default_filters_skip_candidate_cleared_practice_and_testing(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_notification_service(hass)
+
+    assert await _setup_blueprint_automation(hass)
+    calls.clear()
+
+    await _fire_incident(hass, phase="candidate", confidence="high")
+    await _fire_incident(hass, phase="cleared", confidence="high")
+    await _fire_incident(hass, confidence="low")
+    await _fire_incident(
+        hass,
+        confidence="medium",
+        session_type="practice",
+        session_name="Practice 1",
+    )
+    await _fire_incident(
+        hass,
+        confidence="high",
+        session_type="practice",
+        session_name="Practice 1",
+    )
+    await _fire_incident(
+        hass,
+        confidence="high",
+        session_type="testing",
+        session_name="Testing",
+    )
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_practice_high_can_pass_when_practice_is_selected(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_notification_service(hass)
+
+    assert await _setup_blueprint_automation(
+        hass,
+        min_confidence="high",
+        allowed_session_types=["race", "sprint", "qualifying", "practice"],
+    )
+    calls.clear()
+
+    await _fire_incident(
+        hass,
+        confidence="high",
+        session_type="practice",
+        session_name="Practice 1",
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["message"] == (
+        "Possible on-track incident: GAS stopped\nSession: Practice 1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_candidate_and_cleared_notifications_are_opt_in(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_notification_service(hass)
+
+    assert await _setup_blueprint_automation(
+        hass,
+        include_candidate_events=True,
+        include_cleared_notifications=True,
+    )
+    calls.clear()
+
+    await _fire_incident(hass, phase="candidate", confidence="medium")
+    await _fire_incident(hass, phase="cleared", confidence="medium")
+
+    assert [call["data"]["phase"] for call in calls] == ["candidate", "cleared"]
+    assert calls[1]["message"] == (
+        "Possible on-track incident: GAS cleared\nSession: Race"
+    )
+
+
+@pytest.mark.asyncio
+async def test_incident_updates_use_same_notification_tag_for_dedupe(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_notification_service(hass)
+
+    assert await _setup_blueprint_automation(hass)
+    calls.clear()
+
+    await _fire_incident(hass, phase="confirmed", confidence="medium")
+    await _fire_incident(hass, phase="updated", confidence="high")
+
+    assert len(calls) == 2
+    assert calls[0]["data"]["tag"] == calls[1]["data"]["tag"]
+    assert calls[1]["data"]["phase"] == "updated"
+    assert calls[1]["data"]["confidence"] == "high"

--- a/custom_components/f1_sensor/tests/test_incident_notifications_blueprint.py
+++ b/custom_components/f1_sensor/tests/test_incident_notifications_blueprint.py
@@ -9,9 +9,14 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _BLUEPRINT_FILENAME = "f1_incident_notifications.yaml"
-BLUEPRINT_SOURCE = (
+
+# In the repo the blueprint lives directly under blueprints/, while in a
+# Home Assistant dev instance it sits under blueprints/automation/homeassistant/.
+_REPO_PATH = _REPO_ROOT / "blueprints" / _BLUEPRINT_FILENAME
+_HA_PATH = (
     _REPO_ROOT / "blueprints" / "automation" / "homeassistant" / _BLUEPRINT_FILENAME
 )
+BLUEPRINT_SOURCE = _REPO_PATH if _REPO_PATH.exists() else _HA_PATH
 BLUEPRINT_DEST = Path(
     "blueprints/automation/homeassistant/f1_incident_notifications.yaml"
 )

--- a/custom_components/f1_sensor/tests/test_replay_seek.py
+++ b/custom_components/f1_sensor/tests/test_replay_seek.py
@@ -27,6 +27,12 @@ from custom_components.f1_sensor.const import (
     RCM_OVERTAKE_ENABLED,
     REPLAY_START_REFERENCE_SESSION,
 )
+from custom_components.f1_sensor.incident_detection import (
+    DATA_QUALITY_BOOTSTRAP,
+    DATA_QUALITY_REPLAY,
+    PHASE_CONFIRMED,
+    IncidentDetector,
+)
 from custom_components.f1_sensor.live_window import LiveAvailabilityTracker
 from custom_components.f1_sensor.replay_mode import (
     ReplayController,
@@ -374,6 +380,74 @@ def test_build_initial_state_merges_timingapp_stints_without_tyre_stints(hass) -
     assert timingapp["Lines"]["16"]["Stints"]["0"]["LapTime"] == "1:23.000"
     assert timingapp["Lines"]["16"]["Stints"]["1"]["Compound"] == "SOFT"
     assert timingapp["Lines"]["81"]["Stints"]["0"]["Compound"] == "HARD"
+
+
+def test_build_initial_state_merges_timingdata_for_incident_baseline(hass) -> None:
+    manager = ReplaySessionManager(hass, ENTRY_ID, AsyncMock())  # type: ignore[arg-type]
+    frames = [
+        ReplayFrame(
+            timestamp_ms=0,
+            stream="TimingData",
+            payload={
+                "Lines": {
+                    "6": {
+                        "Stopped": False,
+                        "InPit": False,
+                        "Status": 64,
+                        "Sectors": [
+                            {"Stopped": False},
+                            {"Stopped": False},
+                            {"Stopped": False},
+                        ],
+                    },
+                    "10": {"Stopped": False, "InPit": False, "Status": 64},
+                }
+            },
+        ),
+        ReplayFrame(
+            timestamp_ms=500,
+            stream="TimingData",
+            payload={
+                "Lines": {
+                    "5": {"Sectors": {"2": {"Segments": {"6": {"Status": 2048}}}}}
+                }
+            },
+        ),
+        ReplayFrame(
+            timestamp_ms=1_000,
+            stream="TrackStatus",
+            payload={"Status": "4", "Message": "SCDeployed"},
+        ),
+    ]
+
+    initial_state = manager._build_initial_state(frames, 1_000)
+
+    timing_data = initial_state["TimingData"]
+    assert timing_data["Lines"]["6"]["Stopped"] is False
+    assert timing_data["Lines"]["6"]["InPit"] is False
+    assert timing_data["Lines"]["10"]["Stopped"] is False
+    assert timing_data["Lines"]["5"]["Sectors"]["2"]["Segments"]["6"]["Status"] == 2048
+
+    detector = IncidentDetector()
+    detector.process_stream(
+        "TimingData",
+        timing_data,
+        data_quality=DATA_QUALITY_BOOTSTRAP,
+    )
+    detector.process_stream(
+        "TrackStatus",
+        {"Status": "4", "Message": "SCDeployed"},
+        data_quality=DATA_QUALITY_REPLAY,
+    )
+
+    changes = detector.process_stream(
+        "TimingData",
+        {"Lines": {"6": {"Stopped": True, "Status": 68}}},
+        data_quality=DATA_QUALITY_REPLAY,
+    )
+
+    assert [change.phase for change in changes] == [PHASE_CONFIRMED]
+    assert changes[0].driver.racing_number == "6"
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_setup.py
+++ b/custom_components/f1_sensor/tests/test_setup.py
@@ -862,6 +862,7 @@ async def test_async_setup_entry_live_mode_registers_replay_only_components(
             "RaceControlCoordinator",
             "WeatherDataCoordinator",
             "LapCountCoordinator",
+            "IncidentCoordinator",
             "LiveModeCoordinator",
             "LiveDriversCoordinator",
             "TopThreeCoordinator",
@@ -893,6 +894,7 @@ async def test_async_setup_entry_live_mode_registers_replay_only_components(
     entry_data = hass.data[DOMAIN][entry.entry_id]
     assert entry_data["operation_mode"] == OPERATION_MODE_LIVE
     assert entry_data["formation_start_tracker"] is sentinel_tracker
+    assert entry_data["incident_coordinator"] is not None
     assert entry_data["pitstop_coordinator"] is not None
     assert entry_data["championship_prediction_coordinator"] is not None
 

--- a/custom_components/f1_sensor/tests/test_timing_card_layout.py
+++ b/custom_components/f1_sensor/tests/test_timing_card_layout.py
@@ -184,7 +184,17 @@ const Harnesses = new Function(
   ${helperSources.join("\n\n")}
 
   class LiveSessionHarness {
+    constructor(config = {}, host = {}) {
+      Object.assign(this, buildHost(host));
+      this.config = {
+        layout_mode: 'auto',
+        ...config,
+      };
+    }
+
     ${extractMethod(liveSessionClass, "getGridOptions() {")}
+    ${extractMethod(liveSessionClass, "_normalizeLayoutMode(value) {")}
+    ${extractMethod(liveSessionClass, "_getEffectiveLayoutMode() {")}
   }
 
   class QualifyingHarness {
@@ -322,6 +332,11 @@ if (payload.action === "measure_width") {
     throw new Error(`Unknown className: ${className}`);
   }
   result = new Klass(payload.config || {}).getGridOptions();
+} else if (payload.action === "live_session_layout_mode") {
+  result = new Harnesses.LiveSessionHarness(
+    payload.config || {},
+    payload.host || {},
+  )._getEffectiveLayoutMode();
 } else if (payload.action === "install_options") {
   result = extractInstallOptions(payload.className);
 } else if (payload.action === "driver_lap_columns") {
@@ -495,6 +510,33 @@ def test_overflowing_content_still_uses_narrow_layout_breakpoints() -> None:
     )
 
     assert result == "narrow"
+
+
+@pytest.mark.parametrize(
+    ("config", "host", "expected"),
+    [
+        ({}, {"hostWidth": 700, "cardWidth": 700}, "full"),
+        ({}, {"hostWidth": 360, "cardWidth": 360}, "compact"),
+        ({"layout_mode": "compact"}, {"hostWidth": 700, "cardWidth": 700}, "compact"),
+        ({"layout_mode": "full"}, {"hostWidth": 360, "cardWidth": 360}, "full"),
+        ({"layout_mode": "invalid"}, {"hostWidth": 700, "cardWidth": 700}, "full"),
+    ],
+)
+def test_live_session_card_layout_mode_supports_auto_compact(
+    config: dict,
+    host: dict,
+    expected: str,
+) -> None:
+    """Live session status should auto-condense only on narrow cards by default."""
+    result = _run_probe(
+        {
+            "action": "live_session_layout_mode",
+            "config": config,
+            "host": host,
+        }
+    )
+
+    assert result == expected
 
 
 @pytest.mark.parametrize(

--- a/custom_components/f1_sensor/translations/da.json
+++ b/custom_components/f1_sensor/translations/da.json
@@ -158,6 +158,9 @@
       "safety_car": {
         "name": "Sikkerhedsbil"
       },
+      "on_track_incident": {
+        "name": "Incident på banen"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/da.json
+++ b/custom_components/f1_sensor/translations/da.json
@@ -161,6 +161,9 @@
       "on_track_incident": {
         "name": "Incident på banen"
       },
+      "possible_on_track_incident": {
+        "name": "Mulig incident på banen"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/de.json
+++ b/custom_components/f1_sensor/translations/de.json
@@ -161,6 +161,9 @@
       "on_track_incident": {
         "name": "Zwischenfall auf der Strecke"
       },
+      "possible_on_track_incident": {
+        "name": "Möglicher Zwischenfall auf der Strecke"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/de.json
+++ b/custom_components/f1_sensor/translations/de.json
@@ -158,6 +158,9 @@
       "safety_car": {
         "name": "Sicherheitsauto"
       },
+      "on_track_incident": {
+        "name": "Zwischenfall auf der Strecke"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -5,6 +5,10 @@
       "race_week_ended": "Race week has ended",
       "safety_car_deployed": "Safety car deployed",
       "safety_car_cleared": "Safety car cleared",
+      "possible_on_track_incident_detected": "Possible on-track incident detected",
+      "possible_on_track_incident_cleared": "Possible on-track incident cleared",
+      "on_track_incident_detected": "On-track incident detected",
+      "on_track_incident_cleared": "On-track incident cleared",
       "formation_start_ready": "Formation start ready",
       "overtake_mode_enabled": "Overtake mode enabled",
       "overtake_mode_disabled": "Overtake mode disabled",
@@ -341,6 +345,9 @@
       },
       "on_track_incident": {
         "name": "On-track incident"
+      },
+      "possible_on_track_incident": {
+        "name": "Possible on-track incident"
       },
       "formation_start": {
         "name": "Formation start"

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -339,6 +339,9 @@
       "safety_car": {
         "name": "Safety car"
       },
+      "on_track_incident": {
+        "name": "On-track incident"
+      },
       "formation_start": {
         "name": "Formation start"
       },

--- a/custom_components/f1_sensor/translations/fi.json
+++ b/custom_components/f1_sensor/translations/fi.json
@@ -5,6 +5,10 @@
       "race_week_ended": "Kilpailuviikko on päättynyt",
       "safety_car_deployed": "Turva-auto radalla",
       "safety_car_cleared": "Turva-auto poistunut",
+      "possible_on_track_incident_detected": "Mahdollinen ratatapahtuma havaittu",
+      "possible_on_track_incident_cleared": "Mahdollinen ratatapahtuma poistunut",
+      "on_track_incident_detected": "Ratatapahtuma havaittu",
+      "on_track_incident_cleared": "Ratatapahtuma poistunut",
       "formation_start_ready": "Lämmittelykierroksen aloitus valmis",
       "overtake_mode_enabled": "Ohitustila käytössä",
       "overtake_mode_disabled": "Ohitustila pois käytöstä",
@@ -304,6 +308,9 @@
       },
       "on_track_incident": {
         "name": "Ratatapahtuma"
+      },
+      "possible_on_track_incident": {
+        "name": "Mahdollinen ratatapahtuma"
       },
       "formation_start": {
         "name": "Lämmittelykierroksen alku"

--- a/custom_components/f1_sensor/translations/fi.json
+++ b/custom_components/f1_sensor/translations/fi.json
@@ -302,6 +302,9 @@
       "safety_car": {
         "name": "Turva-auto"
       },
+      "on_track_incident": {
+        "name": "Ratatapahtuma"
+      },
       "formation_start": {
         "name": "Lämmittelykierroksen alku"
       },

--- a/custom_components/f1_sensor/translations/fr.json
+++ b/custom_components/f1_sensor/translations/fr.json
@@ -161,6 +161,9 @@
       "on_track_incident": {
         "name": "Incident en piste"
       },
+      "possible_on_track_incident": {
+        "name": "Incident possible en piste"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/fr.json
+++ b/custom_components/f1_sensor/translations/fr.json
@@ -158,6 +158,9 @@
       "safety_car": {
         "name": "Voiture de sécurité"
       },
+      "on_track_incident": {
+        "name": "Incident en piste"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/it.json
+++ b/custom_components/f1_sensor/translations/it.json
@@ -5,6 +5,10 @@
       "race_week_ended": "Weekend di gara terminato",
       "safety_car_deployed": "Safety car in pista",
       "safety_car_cleared": "Safety car uscita dalla pista",
+      "possible_on_track_incident_detected": "Possibile incidente in pista rilevato",
+      "possible_on_track_incident_cleared": "Possibile incidente in pista risolto",
+      "on_track_incident_detected": "Incidente in pista rilevato",
+      "on_track_incident_cleared": "Incidente in pista risolto",
       "formation_start_ready": "Giro di formazione pronto",
       "overtake_mode_enabled": "Modalità Overtake attivata",
       "overtake_mode_disabled": "Modalità Overtake disattivata",
@@ -327,6 +331,9 @@
       },
       "on_track_incident": {
         "name": "Incidente in pista"
+      },
+      "possible_on_track_incident": {
+        "name": "Possibile incidente in pista"
       },
       "formation_start": {
         "name": "Giro di formazione"

--- a/custom_components/f1_sensor/translations/it.json
+++ b/custom_components/f1_sensor/translations/it.json
@@ -325,6 +325,9 @@
       "safety_car": {
         "name": "Safety car"
       },
+      "on_track_incident": {
+        "name": "Incidente in pista"
+      },
       "formation_start": {
         "name": "Giro di formazione"
       },

--- a/custom_components/f1_sensor/translations/nl.json
+++ b/custom_components/f1_sensor/translations/nl.json
@@ -161,6 +161,9 @@
       "on_track_incident": {
         "name": "Incident op de baan"
       },
+      "possible_on_track_incident": {
+        "name": "Mogelijk incident op de baan"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/nl.json
+++ b/custom_components/f1_sensor/translations/nl.json
@@ -158,6 +158,9 @@
       "safety_car": {
         "name": "Safety car"
       },
+      "on_track_incident": {
+        "name": "Incident op de baan"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/no.json
+++ b/custom_components/f1_sensor/translations/no.json
@@ -161,6 +161,9 @@
       "on_track_incident": {
         "name": "Hendelse på banen"
       },
+      "possible_on_track_incident": {
+        "name": "Mulig hendelse på banen"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/no.json
+++ b/custom_components/f1_sensor/translations/no.json
@@ -158,6 +158,9 @@
       "safety_car": {
         "name": "Sikkerhetsbil"
       },
+      "on_track_incident": {
+        "name": "Hendelse på banen"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/pt.json
+++ b/custom_components/f1_sensor/translations/pt.json
@@ -161,6 +161,9 @@
       "on_track_incident": {
         "name": "Incidente na pista"
       },
+      "possible_on_track_incident": {
+        "name": "Possível incidente na pista"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/pt.json
+++ b/custom_components/f1_sensor/translations/pt.json
@@ -158,6 +158,9 @@
       "safety_car": {
         "name": "Safety car"
       },
+      "on_track_incident": {
+        "name": "Incidente na pista"
+      },
       "formation_start": {
         "name": "Formation start"
       }

--- a/custom_components/f1_sensor/translations/sv.json
+++ b/custom_components/f1_sensor/translations/sv.json
@@ -335,6 +335,9 @@
       "safety_car": {
         "name": "Säkerhetsbil"
       },
+      "on_track_incident": {
+        "name": "Incident på banan"
+      },
       "formation_start": {
         "name": "Formationsstart"
       },

--- a/custom_components/f1_sensor/translations/sv.json
+++ b/custom_components/f1_sensor/translations/sv.json
@@ -5,6 +5,10 @@
       "race_week_ended": "Tävlingsveckan har avslutats",
       "safety_car_deployed": "Safety car utsänd",
       "safety_car_cleared": "Safety car indragen",
+      "possible_on_track_incident_detected": "Möjlig incident på banan upptäckt",
+      "possible_on_track_incident_cleared": "Möjlig incident på banan rensad",
+      "on_track_incident_detected": "Incident på banan upptäckt",
+      "on_track_incident_cleared": "Incident på banan rensad",
       "formation_start_ready": "Formationsstart redo",
       "overtake_mode_enabled": "Omkörningstillstånd aktiverat",
       "overtake_mode_disabled": "Omkörningstillstånd inaktiverat",
@@ -337,6 +341,9 @@
       },
       "on_track_incident": {
         "name": "Incident på banan"
+      },
+      "possible_on_track_incident": {
+        "name": "Möjlig incident på banan"
       },
       "formation_start": {
         "name": "Formationsstart"

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -12226,8 +12226,8 @@ class F1LiveSessionCard extends LitElement {
                 </div>
               ` : null}
               <div class="ls-weather-col">
-                <span class="ls-weather-label">Rain</span>
-                <span class="ls-weather-value">${weather.rainfall > 0 ? 'Yes' : 'No'}</span>
+                <span class="ls-weather-label">Weather</span>
+                <span class="ls-weather-value">${weather.rainfall > 0 ? 'Wet' : 'Dry'}</span>
               </div>
             </div>
           ` : null}

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -11195,71 +11195,202 @@ class F1LiveSessionCard extends LitElement {
       letter-spacing: 0.04em;
     }
 
-    .ls-time-value {
-      font-family: 'Formula1 Display', Arial, sans-serif;
-      font-weight: 700;
-      font-size: clamp(11px, 1.5vw, 13px);
-      color: var(--ls-text);
-    }
+	    .ls-time-value {
+	      font-family: 'Formula1 Display', Arial, sans-serif;
+	      font-weight: 700;
+	      font-size: clamp(11px, 1.5vw, 13px);
+	      color: var(--ls-text);
+	    }
 
-    @container (max-width: 400px) {
-      .ls-weather {
-        gap: clamp(6px, 1vw, 10px);
-      }
-      .ls-weather-col {
-        flex: 0 1 auto;
-      }
-      .ls-laps-group {
-        display: none;
-      }
-    }
+	    .ls-layout-compact {
+	      gap: 8px;
+	      padding: 10px 12px;
+	    }
 
-    @container (max-width: 760px) {
-      .ls-laps-group,
-      .ls-time-group {
-        margin-left: 0;
-        padding-left: 0;
-        border-left: none;
-        flex: 1 1 150px;
-      }
+	    .ls-layout-compact .ls-header {
+	      display: grid;
+	      grid-template-columns: minmax(0, 1fr) auto;
+	      align-items: center;
+	      gap: 8px 10px;
+	    }
 
-      .ls-status-group {
-        margin-left: 0;
-        width: 100%;
-        align-items: flex-start;
-      }
+	    .ls-layout-compact .ls-session-info {
+	      flex: 1 1 auto;
+	      width: auto;
+	    }
 
-      .ls-status-row {
-        justify-content: flex-start;
-      }
-    }
+	    .ls-layout-compact .ls-flag {
+	      width: 24px;
+	    }
 
-    @container (max-width: 520px) {
-      .ls-header {
-        flex-direction: column;
-      }
+	    .ls-layout-compact .ls-gp-name {
+	      font-size: 13px;
+	      line-height: 1.05;
+	    }
 
-      .ls-session-info,
-      .ls-laps-group,
-      .ls-time-group,
-      .ls-status-group {
-        width: 100%;
-      }
+	    .ls-layout-compact .ls-session-type {
+	      gap: 4px;
+	      font-size: 9px;
+	      line-height: 1.2;
+	    }
 
-      .ls-weather {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
+	    .ls-layout-compact .ls-laps-group,
+	    .ls-layout-compact .ls-time-group {
+	      margin-left: 0;
+	      padding-left: 0;
+	      border-left: none;
+	      width: auto;
+	    }
 
-      .ls-weather-col {
-        align-items: flex-start;
-      }
+	    .ls-layout-compact .ls-laps-group {
+	      grid-column: 1 / 2;
+	      flex: 1 1 auto;
+	    }
 
-      .ls-weather-value {
-        text-align: left;
-      }
-    }
-  `];
+	    .ls-layout-compact .ls-time-group {
+	      grid-column: 2 / 3;
+	      justify-self: end;
+	      align-items: flex-end;
+	      gap: 2px;
+	    }
+
+	    .ls-layout-compact .ls-time-row {
+	      gap: 4px;
+	    }
+
+	    .ls-layout-compact .ls-status-group {
+	      grid-column: 2 / 3;
+	      grid-row: 1;
+	      justify-self: end;
+	      margin-left: 0;
+	      width: auto;
+	      align-items: flex-end;
+	    }
+
+	    .ls-layout-compact .ls-status-row {
+	      justify-content: flex-end;
+	    }
+
+	    .ls-layout-compact .ls-status-pill {
+	      padding: 4px 8px;
+	      border-radius: 14px;
+	      font-size: 9px;
+	    }
+
+	    .ls-layout-compact .ls-aero-pill {
+	      padding: 2px 5px;
+	      font-size: 7px;
+	    }
+
+	    .ls-layout-compact .ls-weather {
+	      display: grid;
+	      grid-template-columns: repeat(3, minmax(0, 1fr));
+	      gap: 6px 8px;
+	      padding-top: 8px;
+	    }
+
+	    .ls-layout-compact .ls-weather-col {
+	      min-width: 0;
+	      align-items: flex-start;
+	      gap: 0;
+	    }
+
+	    .ls-layout-compact .ls-weather-label {
+	      font-size: 8px;
+	      line-height: 1.1;
+	    }
+
+	    .ls-layout-compact .ls-weather-value {
+	      font-size: 11px;
+	      line-height: 1.1;
+	      text-align: left;
+	      overflow-wrap: anywhere;
+	    }
+
+	    @container (max-width: 400px) {
+	      .ls-layout-full .ls-weather {
+	        gap: clamp(6px, 1vw, 10px);
+	      }
+	      .ls-layout-full .ls-weather-col {
+	        flex: 0 1 auto;
+	      }
+	      .ls-layout-full .ls-laps-group {
+	        display: none;
+	      }
+	    }
+
+	    @container (max-width: 760px) {
+	      .ls-layout-full .ls-laps-group,
+	      .ls-layout-full .ls-time-group {
+	        margin-left: 0;
+	        padding-left: 0;
+	        border-left: none;
+	        flex: 1 1 150px;
+	      }
+
+	      .ls-layout-full .ls-status-group {
+	        margin-left: 0;
+	        width: 100%;
+	        align-items: flex-start;
+	      }
+
+	      .ls-layout-full .ls-status-row {
+	        justify-content: flex-start;
+	      }
+	    }
+
+	    @container (max-width: 520px) {
+	      .ls-layout-full .ls-header {
+	        flex-direction: column;
+	      }
+
+	      .ls-layout-full .ls-session-info,
+	      .ls-layout-full .ls-laps-group,
+	      .ls-layout-full .ls-time-group,
+	      .ls-layout-full .ls-status-group {
+	        width: 100%;
+	      }
+
+	      .ls-layout-full .ls-weather {
+	        display: grid;
+	        grid-template-columns: repeat(2, minmax(0, 1fr));
+	      }
+
+	      .ls-layout-full .ls-weather-col {
+	        align-items: flex-start;
+	      }
+
+	      .ls-layout-full .ls-weather-value {
+	        text-align: left;
+	      }
+	    }
+
+	    @container (max-width: 360px) {
+	      .ls-layout-compact .ls-header {
+	        grid-template-columns: minmax(0, 1fr);
+	      }
+
+	      .ls-layout-compact .ls-laps-group,
+	      .ls-layout-compact .ls-time-group,
+	      .ls-layout-compact .ls-status-group {
+	        grid-column: 1 / -1;
+	        justify-self: start;
+	        align-items: flex-start;
+	      }
+
+	      .ls-layout-compact .ls-status-group {
+	        grid-row: auto;
+	      }
+
+	      .ls-layout-compact .ls-status-row {
+	        justify-content: flex-start;
+	      }
+
+	      .ls-layout-compact .ls-weather {
+	        grid-template-columns: repeat(2, minmax(0, 1fr));
+	      }
+	    }
+	  `];
 
   connectedCallback() {
     super.connectedCallback();
@@ -11272,12 +11403,13 @@ class F1LiveSessionCard extends LitElement {
     this._clearSessionClockTimer();
   }
 
-  setConfig(config) {
-    this.config = {
-      theme_mode: DEFAULT_F1_THEME_MODE,
-      show_flag: true,
-      show_lap_progress: true,
-      show_track_status: true,
+	  setConfig(config) {
+	    this.config = {
+	      theme_mode: DEFAULT_F1_THEME_MODE,
+	      layout_mode: 'auto',
+	      show_flag: true,
+	      show_lap_progress: true,
+	      show_track_status: true,
       show_weather: true,
       show_time_remaining: false,
       show_time_elapsed: false,
@@ -11301,11 +11433,12 @@ class F1LiveSessionCard extends LitElement {
       weather_entity: '',
       next_race_entity: '',
       session_time_remaining_entity: '',
-      session_time_elapsed_entity: '',
-      overtake_mode_entity: '',
-      straight_mode_entity: '',
-    };
-  }
+	      session_time_elapsed_entity: '',
+	      overtake_mode_entity: '',
+	      straight_mode_entity: '',
+	      layout_mode: 'auto',
+	    };
+	  }
 
   getCardSize() {
     return 2;
@@ -11855,17 +11988,30 @@ class F1LiveSessionCard extends LitElement {
     return '';
   }
 
-  _isCountdownImminent() {
-    const sessionStatus = this._getSessionStatusData();
-    const startValue = this._getSessionStartValue(sessionStatus);
-    const start = this._parseDateWithOffset(startValue, sessionStatus?.gmt_offset);
-    if (!start) return false;
-    const diffMs = start.getTime() - Date.now();
-    return diffMs > 0 && diffMs < 5 * 60 * 1000; // Less than 5 minutes
-  }
+	  _isCountdownImminent() {
+	    const sessionStatus = this._getSessionStatusData();
+	    const startValue = this._getSessionStartValue(sessionStatus);
+	    const start = this._parseDateWithOffset(startValue, sessionStatus?.gmt_offset);
+	    if (!start) return false;
+	    const diffMs = start.getTime() - Date.now();
+	    return diffMs > 0 && diffMs < 5 * 60 * 1000; // Less than 5 minutes
+	  }
 
-  render() {
-    if (!this.hass || !this.config) {
+	  _normalizeLayoutMode(value) {
+	    const mode = String(value || 'auto').trim().toLowerCase();
+	    if (mode === 'compact' || mode === 'full') return mode;
+	    return 'auto';
+	  }
+
+	  _getEffectiveLayoutMode() {
+	    const mode = this._normalizeLayoutMode(this.config?.layout_mode);
+	    if (mode !== 'auto') return mode;
+	    const width = this._responsiveCardWidth || measureRenderedCardWidth(this);
+	    return width > 0 && width <= 520 ? 'compact' : 'full';
+	  }
+
+	  render() {
+	    if (!this.hass || !this.config) {
       return html`<ha-card><div class="ls-card ls-unavailable">Loading...</div></ha-card>`;
     }
     const sessionEntityId = this._configuredEntityId(
@@ -11881,18 +12027,20 @@ class F1LiveSessionCard extends LitElement {
     const nextRace = (!session && !sessionStatus) ? this._getNextRaceData() : null;
     if (!session && !sessionStatus && !nextRace) {
       return html`<ha-card><div class="ls-card ls-unavailable">No session data</div></ha-card>`;
-    }
-    this._ensureCountdownTimer(sessionStatus, nextRace);
-    this._ensureSessionClockTimer();
+	    }
+	    this._ensureCountdownTimer(sessionStatus, nextRace);
+	    this._ensureSessionClockTimer();
+	    const layoutMode = this._getEffectiveLayoutMode();
+	    const compactLayout = layoutMode === 'compact';
 
-    if (nextRace) {
+	    if (nextRace) {
       const gpName = nextRace.race_name?.replace(' Grand Prix', ' GP') || nextRace.race_name || 'Next race';
       const countdown = this._getNextRaceCountdown(nextRace);
       const flagUrl = nextRace.country_flag_url;
-      return html`
-        <ha-card>
-          <div class="ls-card">
-            <div class="ls-header">
+	      return html`
+	        <ha-card>
+	          <div class="ls-card ls-layout-${layoutMode}">
+	            <div class="ls-header">
               ${this.config.show_flag !== false ? html`
                 <div class="ls-session-info">
                   ${flagUrl ? html`<img class="ls-flag" src="${flagUrl}" alt="${nextRace.circuit_country || ''}" />` : null}
@@ -11951,10 +12099,10 @@ class F1LiveSessionCard extends LitElement {
     const statusColor = trackStatusColors[trackStatus] || trackStatusColors.CLEAR;
     const statusLabel = TRACK_STATUS_LABELS[trackStatus] || 'Unknown';
 
-    return html`
-      <ha-card>
-        <div class="ls-card">
-          <div class="ls-header">
+	    return html`
+	      <ha-card>
+	        <div class="ls-card ls-layout-${layoutMode}">
+	          <div class="ls-header">
             ${this.config.show_flag !== false ? html`
               <div class="ls-session-info">
                 ${flagUrl ? html`<img class="ls-flag" src="${flagUrl}" alt="${data.meeting_country || ''}" />` : null}
@@ -12000,11 +12148,11 @@ class F1LiveSessionCard extends LitElement {
               const showElapsed = this.config.show_time_elapsed && clockData.elapsed;
               return (showRemaining || showElapsed) ? html`
                 <div class="ls-time-group">
-                  ${showRemaining ? html`
-                    <div class="ls-time-row">
-                      <span class="ls-time-label">Remaining</span>
-                      <span class="ls-time-value">${clockData.remaining}</span>
-                    </div>
+	                  ${showRemaining ? html`
+	                    <div class="ls-time-row">
+	                      <span class="ls-time-label">${compactLayout ? 'Left' : 'Remaining'}</span>
+	                      <span class="ls-time-value">${clockData.remaining}</span>
+	                    </div>
                   ` : null}
                   ${showElapsed ? html`
                     <div class="ls-time-row">
@@ -12192,10 +12340,11 @@ class F1LiveSessionCardEditor extends LitElement {
     this._activeTab = 'sources';
   }
 
-  setConfig(config) {
-    this._config = {
-      show_flag: true,
-      show_lap_progress: true,
+	  setConfig(config) {
+	    this._config = {
+	      layout_mode: 'auto',
+	      show_flag: true,
+	      show_lap_progress: true,
       show_track_status: true,
       show_weather: true,
       show_time_remaining: false,
@@ -12321,9 +12470,14 @@ class F1LiveSessionCardEditor extends LitElement {
 
   _renderDisplayTab() {
     return html`
-      <div class="display-section">
-        ${renderThemeModeSelect(this)}
-        ${this._renderSwitch('show_flag', 'Show country flag')}
+	      <div class="display-section">
+	        ${renderThemeModeSelect(this)}
+	        ${renderEditorSelect(this, 'layout_mode', 'Layout mode', [
+	          { value: 'auto', label: 'Auto compact on narrow cards' },
+	          { value: 'compact', label: 'Compact' },
+	          { value: 'full', label: 'Full' },
+	        ], 'Auto keeps the full desktop layout and condenses the card on narrow mobile or Sections layouts.')}
+	        ${this._renderSwitch('show_flag', 'Show country flag')}
         ${this._renderSwitch('show_lap_progress', 'Show lap progress')}
         ${this._renderSwitch('show_track_status', 'Show track status pill')}
         ${this._renderSwitch('show_weather', 'Show weather data')}

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -8292,7 +8292,7 @@ class F1LastRaceResultsCard extends LitElement {
     .cpd-cell.points-secondary {
       color: var(--ts-muted);
     }
-
+    
     .cpd-cell.align {
       justify-content: center;
       text-align: center;

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -42,6 +42,7 @@ Take your setup to the next level:
 - [**Live Delay**](/features/live-delay) – Sync live data with your TV broadcast
 - [**Replay Mode**](/features/replay-mode) – Relive historical sessions with full Home Assistant integration and experimental 30-second catch-up controls
 - [**No Spoiler Mode**](/features/no-spoiler-mode) – Freeze your dashboard until you are ready to watch
+- **On-track incident alerts** – Detect likely stopped cars or on-track incidents during live and replayed sessions without treating them as guaranteed crash detection
 
 ### Showcase
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -208,3 +208,60 @@ action:
 mode: queued
 max: 10
 ```
+
+---
+
+### Possible on-track incident notification
+
+Uses the [`f1_sensor_incident` event](/entities/events#on-track-incident) to notify only for confirmed medium or high confidence incidents during race, sprint, or qualifying sessions.
+
+:::tip[Sync with your TV]
+Incident events respect Live Delay, so set [Live Delay](/features/live-delay) to match your broadcast if you want notifications to line up with the pictures.
+:::
+
+```yaml
+alias: F1 - Possible on-track incident
+description: Notify for confirmed likely stopped cars or on-track incidents
+trigger:
+  - platform: event
+    event_type: f1_sensor_incident
+condition:
+  - condition: template
+    value_template: "{{ trigger.event.data.phase == 'confirmed' }}"
+  - condition: template
+    value_template: "{{ trigger.event.data.confidence in ['medium', 'high'] }}"
+  - condition: template
+    value_template: "{{ trigger.event.data.session.session_type in ['race', 'sprint', 'qualifying'] }}"
+action:
+  - service: notify.mobile_app_your_phone
+    data:
+      title: "Possible F1 incident"
+      message: >
+        {{ trigger.event.data.driver.tla }} may have stopped on track
+        during {{ trigger.event.data.session.session_name }}.
+mode: queued
+max: 5
+```
+
+The wording is intentionally neutral. F1 Sensor detects likely stopped cars and on-track incidents, not guaranteed crashes.
+
+---
+
+### Dashboard trigger for active incidents
+
+Use the [On-track Incident binary sensor](/entities/live-data#on-track-incident) when you only need to know whether any confirmed incident is currently active.
+
+```yaml
+alias: F1 - Incident indicator on
+description: Turn on a scene while a confirmed incident is active
+trigger:
+  - platform: state
+    entity_id: binary_sensor.f1_on_track_incident
+    to: "on"
+condition: []
+action:
+  - service: scene.turn_on
+    target:
+      entity_id: scene.f1_caution
+mode: single
+```

--- a/docs/blueprints/incident-notifications.md
+++ b/docs/blueprints/incident-notifications.md
@@ -1,0 +1,93 @@
+---
+id: incident-notifications
+title: Incident Notifications
+---
+
+# Incident Notifications
+
+Get notifications for likely stopped cars and on-track incidents without writing YAML. The blueprint listens to `f1_sensor_incident` events and uses conservative defaults so normal practice running and early candidate signals do not create noisy alerts.
+
+:::warning[Not crash detection]
+These notifications mean F1 Sensor detected a likely stopped car or on-track incident. They do not guarantee that a crash happened.
+:::
+
+:::tip[Sync with your TV]
+For notifications to arrive at the right moment, configure [Live Delay](/features/live-delay) to match your broadcast offset.
+:::
+
+---
+
+## Import the Blueprint
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FNicxe%2Ff1_sensor%2Fmain%2Fblueprints%2Ff1_incident_notifications.yaml)
+
+Or go to **Settings > Automations & Scenes > Blueprints** and import manually using the URL:
+
+```text
+https://raw.githubusercontent.com/Nicxe/f1_sensor/main/blueprints/f1_incident_notifications.yaml
+```
+
+---
+
+## Requirements
+
+- F1 Sensor integration installed with live data enabled
+- At least one notification service available in Home Assistant
+- The `f1_sensor_incident` event stream available during live or replay sessions
+
+---
+
+## Step-by-step Setup
+
+### Step 1 - Create an automation from the blueprint
+
+1. Go to **Settings > Automations & Scenes > Blueprints**
+2. Find **F1 Sensor - Incident Notifications**
+3. Click **Create Automation**
+
+### Step 2 - Choose notification actions
+
+Add one or more Home Assistant notification actions. Mobile app notifications and persistent notifications both work.
+
+```yaml
+- service: notify.mobile_app_your_phone
+  data:
+    title: "{{ notification_title }}"
+    message: "{{ notification_message }}"
+```
+
+### Step 3 - Review filters
+
+The default filters are intentionally conservative.
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| **Minimum confidence** | `medium` | Notify for `medium` and `high` incidents |
+| **Allowed phases** | `confirmed`, `updated` | Ignore early `candidate` events by default |
+| **Allowed sessions** | Race, Sprint, Qualifying | Practice is excluded by default to reduce noisy alerts |
+| **Notify when cleared** | Off | Cleared updates are available but not sent by default |
+| **Notification tag** | `incident_id` | Lets supported notify targets update the same notification for later updates |
+
+Practice sessions can include installation laps, garage work, slow running, and testing procedures. Enable Practice only if you are comfortable with more alerts, or require `high` confidence for Practice.
+
+---
+
+## Notification wording
+
+Blueprint messages use neutral wording such as:
+
+```text
+Possible on-track incident: GAS stopped
+Session: Race
+```
+
+Avoid wording such as "crash" unless Race Control explicitly uses that term in the message you send.
+
+---
+
+## Related
+
+- [On-track Incident binary sensor](/entities/live-data#on-track-incident)
+- [Incident event stream](/entities/events#on-track-incident)
+- [Race Control Notifications](/blueprints/race-control-notifications)
+- [Live Delay](/features/live-delay)

--- a/docs/blueprints/incident-notifications.md
+++ b/docs/blueprints/incident-notifications.md
@@ -70,6 +70,8 @@ The default filters are intentionally conservative.
 
 Practice sessions can include installation laps, garage work, slow running, and testing procedures. Enable Practice only if you are comfortable with more alerts, or require `high` confidence for Practice.
 
+If you enable Candidate events, some alerts can come from F1TV Auth `CarData.z` low-speed telemetry correlated with yellow flag, Virtual Safety Car, Safety Car, or red flag context. Keep these alerts conservative because they are earlier than confirmed public timing or Race Control evidence.
+
 ---
 
 ## Notification wording

--- a/docs/blueprints/race-control-notifications.md
+++ b/docs/blueprints/race-control-notifications.md
@@ -11,6 +11,9 @@ This blueprint listens to the [Race Control sensor](/entities/live-data#race-con
 :::tip[Sync with your TV]
 For notifications to arrive at the right moment, configure the [Live Delay](/features/live-delay) to match your broadcast offset.
 :::
+:::info[Race Control vs incident alerts]
+Race Control Notifications forward official messages. For neutral likely stopped-car alerts with confidence and incident phases, use the [Incident Notifications](/blueprints/incident-notifications) blueprint.
+:::
 
 ---
 
@@ -220,5 +223,6 @@ Enable **Filter Out Blue Flags** if you want to keep Race Control notifications 
 
 - [Race Control sensor](/entities/live-data#race-control)
 - [Session Status sensor](/entities/live-data#session-status)
+- [Incident Notifications blueprint](/blueprints/incident-notifications)
 - [Live Delay](/features/live-delay)
 - [Track Status Light blueprint](/blueprints/track-status-light)

--- a/docs/entities/diagnostics.md
+++ b/docs/entities/diagnostics.md
@@ -5,6 +5,8 @@ title: Diagnostics
 
 Diagnostic entities are intended for troubleshooting and advanced automations. Some entities are only created when the corresponding feature is enabled during configuration.
 
+Downloaded diagnostics from **Settings > Devices & Services > F1 Sensor > Diagnostics** include a small runtime summary for live timing and incident detection. The diagnostics output is intended for support and does not include raw high-frequency telemetry, authorization headers, cookies, or tokens.
+
 ## Entities Summary
 
 | Entity | Info |
@@ -14,6 +16,32 @@ Diagnostic entities are intended for troubleshooting and advanced automations. S
 | [sensor.f1_replay_status](#replay-status) | Replay state and progress |
 | [sensor.f1_f1tv_token_status](#f1tv-token-status) | Redacted F1TV token health status |
 | [sensor.f1_f1tv_token_expires_at](#f1tv-token-expires-at) | Expiry time for the saved F1TV live timing token |
+
+---
+
+## Incident Detection Diagnostics
+
+When incident detection is available, the downloaded diagnostics file includes an `incident_detection` runtime summary.
+
+**Fields**
+
+| Field | Type | Description |
+| --- | --- | --- |
+| active_count | number | Number of currently active incident records |
+| highest_confidence | string | Highest active confidence, such as `medium` or `high` |
+| latest_incident_id | string | Stable identifier for the most recent incident update |
+| latest_driver_number | string | Car number for the latest incident update |
+| latest_driver_tla | string | Driver abbreviation for the latest incident update |
+| latest_reason | string | Neutral reason code for the latest update |
+| latest_phase | string | Latest incident phase |
+| session_type | string | Lowercase session type, such as `race`, `sprint`, `qualifying`, or `practice` |
+| session_name | string | Human-readable session name |
+| data_quality | string | Data source quality, such as `live`, `replay`, or `bootstrap` |
+| available | boolean | Whether the incident coordinator is currently available |
+
+:::info
+Diagnostics intentionally show counts and latest metadata only. Use the [`f1_sensor_incident` event](/entities/events#on-track-incident) when you need the full event payload for automations or troubleshooting.
+:::
 
 ---
 

--- a/docs/entities/events.md
+++ b/docs/entities/events.md
@@ -22,6 +22,8 @@ Use this event for notifications and automations that should react immediately t
 The event describes a likely stopped car or on-track incident. It does not guarantee that a crash happened. Keep notification wording neutral unless Race Control explicitly says more.
 :::
 
+When F1TV Auth is configured and the authenticated live timing stream is available, F1 Sensor can also publish earlier `candidate` events from `CarData.z` low-speed telemetry correlated with yellow flag, Virtual Safety Car, Safety Car, or red flag context. These candidates are useful for advanced automations, but they are not confirmed incidents until public timing or Race Control provides stronger evidence.
+
 **Phases**
 
 | Phase | Meaning |
@@ -36,7 +38,7 @@ The event describes a likely stopped car or on-track incident. It does not guara
 | Confidence | Meaning |
 | --- | --- |
 | `low` | Weak or early signal, normally not user-facing |
-| `medium` | Reasonable incident candidate, such as a stopped car that is not in pit lane |
+| `medium` | Reasonable incident candidate, such as a stopped car that is not in pit lane or an auth-based low-speed candidate with flag context |
 | `high` | Strong context, such as stopped timing data combined with yellow flag, Safety Car, red flag, or Race Control context |
 
 #### Example payload

--- a/docs/entities/events.md
+++ b/docs/entities/events.md
@@ -13,6 +13,73 @@ For a general introduction to how events work in Home Assistant, see:
 
 ## Event Streams
 
+### On-track Incident
+
+F1 Sensor publishes likely stopped-car and on-track incident changes under the event type `f1_sensor_incident`.
+Use this event for notifications and automations that should react immediately to incident lifecycle changes.
+
+:::warning[Not crash detection]
+The event describes a likely stopped car or on-track incident. It does not guarantee that a crash happened. Keep notification wording neutral unless Race Control explicitly says more.
+:::
+
+**Phases**
+
+| Phase | Meaning |
+| --- | --- |
+| `candidate` | Early possible incident. Normally useful for advanced automations, not default push alerts |
+| `confirmed` | Strong enough evidence for an on-track incident alert |
+| `updated` | New information for the same `incident_id`, such as higher confidence |
+| `cleared` | The incident appears to be over |
+
+**Confidence**
+
+| Confidence | Meaning |
+| --- | --- |
+| `low` | Weak or early signal, normally not user-facing |
+| `medium` | Reasonable incident candidate, such as a stopped car that is not in pit lane |
+| `high` | Strong context, such as stopped timing data combined with yellow flag, Safety Car, red flag, or Race Control context |
+
+#### Example payload
+
+```yaml
+event_type: f1_sensor_incident
+data:
+  entry_id: "abc123"
+  incident_id: "2026-miami-race-10-2026-05-03T20:14:22Z"
+  phase: "confirmed"
+  confidence: "high"
+  reason: "timing_stopped_with_race_control"
+  driver:
+    racing_number: "10"
+    tla: "GAS"
+    name: "Pierre Gasly"
+    team: "Alpine"
+  session:
+    meeting_name: "Miami Grand Prix"
+    session_name: "Race"
+    session_type: "race"
+    session_key: "2026-miami-race"
+  track_status:
+    status: "YELLOW"
+    message: "Yellow"
+  race_control:
+    message: "DOUBLE YELLOW IN TURN 7"
+    category: "Flag"
+    flag: "DOUBLE YELLOW"
+  signals:
+    - "timing_stopped"
+    - "race_control_yellow"
+  started_at: "2026-05-03T20:14:22Z"
+  updated_at: "2026-05-03T20:14:28Z"
+  data_quality: "live"
+```
+
+Use `phase`, `confidence`, `session.session_type`, and `driver.tla` as the main automation fields. `session.session_type` uses lowercase values such as `race`, `sprint`, `qualifying`, `practice`, `testing`, or `unknown`. The payload uses neutral names so it can represent stopped cars, spins, technical failures, and other likely on-track incidents without calling them crashes.
+
+### Event vs sensor
+
+Use `f1_sensor_incident` when you want one notification per incident update. Use [`binary_sensor.f1_on_track_incident`](/entities/live-data#on-track-incident) when you want a dashboard indicator or a simple state trigger while any confirmed incident is active.
+
 ### Race Control
 
 Race Control messages are available both as a **sensor** and as **events** in Home Assistant.  
@@ -61,6 +128,10 @@ The event stream remains available as a complementary, low-latency feed alongsid
 
 For example automations using these events, see the [Automation](/automation) page.
 :::
+
+### Race Control vs incident events
+
+Race Control events forward official messages as they arrive. Incident events combine stopped-car and track context into a neutral alert lifecycle with phases and confidence.
 
 ## Future Event Streams
 

--- a/docs/entities/live_data.md
+++ b/docs/entities/live_data.md
@@ -125,6 +125,7 @@ Use this section to understand the possible values for enum-type states and attr
 | [sensor.f1_race_three_hour_limit](#race-three-hour-limit) | Time remaining until the FIA 3-hour race duration cap `(beta)` |
 | [sensor.f1_track_status](#track-status)               | Current track status |
 | [binary_sensor.f1_safety_car](#safety-car)            | Safety Car (SC) or Virtual Safety Car (VSC) is active|  
+| [binary_sensor.f1_on_track_incident](#on-track-incident) | Likely stopped car or on-track incident is active |
 | [sensor.f1_race_lap_count](#race-lap)                 | Current race lap number|
 | [sensor.f1_track_weather](#track-weather)             | Current on-track weather (air temp, track temp, rainfall, wind speed, etc.)|
 | [sensor.f1_driver_list](#driver-list)                 | Show list and details on all drivers, including team color, headshot URL etc| 
@@ -384,6 +385,47 @@ on
 | Attribute | Type | Description |
 | --- | --- | --- |
 | track_status | string | Normalized track status (`CLEAR`, `YELLOW`, `VSC`, `SC`, `RED`) |
+
+---
+
+## On-track Incident
+
+`binary_sensor.f1_on_track_incident` - On while F1 Sensor has a confirmed likely stopped car or on-track incident for the active session.
+
+:::warning[Not crash detection]
+This entity detects likely stopped cars and on-track incidents from live timing, track status, and Race Control context. It does not prove that a crash happened, and it may also represent a technical failure, spin, red flag stop, or another neutral on-track situation.
+:::
+
+**State (on/off)**
+- `on` when at least one confirmed incident is active.
+- `off` when no confirmed incident is active.
+- `unavailable` when live or replay data is not available enough to report a reliable state.
+
+**Example**
+```text
+on
+```
+
+**Attributes**
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| active_count | number | Number of confirmed active incidents |
+| highest_confidence | string | Highest active confidence: `medium` or `high` |
+| latest_incident_id | string | Stable identifier for the most recent incident update |
+| latest_driver_number | string | Car number for the latest incident update |
+| latest_driver_tla | string | Driver abbreviation for the latest incident update |
+| latest_reason | string | Neutral reason code for the latest update |
+| latest_phase | string | Latest phase: `candidate`, `confirmed`, `updated`, or `cleared` |
+| session_type | string | Lowercase session type, such as `race`, `sprint`, `qualifying`, or `practice` |
+| session_name | string | Human-readable session name |
+| data_quality | string | Data source quality, such as `live`, `replay`, `stale`, or `bootstrap` |
+
+The entity intentionally keeps attributes small and stable. Use the [`f1_sensor_incident` event](/entities/events#on-track-incident) for detailed automation triggers and notification text.
+
+:::info[Session support]
+Incident detection is designed for race, sprint, qualifying, and practice sessions. Practice alerts are more conservative because practice sessions naturally contain more slow running, pit activity, and testing-style behavior.
+:::
 
 ---
 

--- a/docs/features/live-delay.md
+++ b/docs/features/live-delay.md
@@ -40,6 +40,12 @@ This method is simple and reliable. The guided calibration below is optional.
 During the broadcast, they always show the moment the race clock flips to the start time, for example 15:00:00. If you look up an [atomic clock online](https://time.is/), you'll have an exact reference. Watch the time when the broadcast clock hits the start. So when the broadcast clock shows 15:00:00 and the race actually starts, the atomic clock reads 15:00:30. Then set a 30-second delay in the configuration.
 :::
 
+## Incident alerts and notifications
+
+Live Delay also applies to likely on-track incident updates. This means `f1_sensor_incident` events, the On-track Incident binary sensor, and notification blueprints can be delayed to match what you see on TV.
+
+Use this when you want a possible stopped-car notification to arrive with the broadcast pictures instead of ahead of them.
+
 
 ---
 

--- a/docs/features/no-spoiler-mode.md
+++ b/docs/features/no-spoiler-mode.md
@@ -46,8 +46,11 @@ Not all data is blocked. Schedule and calendar data is always kept up to date so
 - Championship predictions
 - FIA documents and race control messages
 - Pit stop data
+- On-track incident detection and incident notifications while the mode is active
 
 When you deactivate the mode, all frozen data is refreshed immediately and delivered to your entities at once. If any FIA documents were published during the blackout, they all appear at the same time.
+
+Incident alerts are treated as spoiler-sensitive. While No Spoiler Mode is active, new live incident events are blocked from dashboards and notification automations. They are not sent later as push notifications from the live session; use [Replay Mode](/features/replay-mode) when you are ready to watch the session with incident alerts.
 
 ---
 

--- a/docs/features/replay-mode.md
+++ b/docs/features/replay-mode.md
@@ -6,6 +6,7 @@ title: Replay Mode
 Replay Mode lets you watch historical F1 sessions with full Home Assistant integration. When you play back a recorded race or qualifying from F1 TV or another service, your automations and dashboards can follow the session in a way that is much closer to a live broadcast.
 
 Your lights can react to a red flag. Your dashboard can show live timing. Race Control messages can still drive notifications while you watch the session later.
+Likely on-track incident detection can also follow replayed sessions, so incident notifications and the On-track Incident binary sensor can behave like they do during live timing.
 :::warning[Experimental replay catch-up]
 Replay Mode now includes experimental 30-second catch-up controls in Version 1. The feature is being tested in real setups, and additional refinement may still be needed in later updates.
 :::
@@ -270,4 +271,5 @@ For full details on each entity, see the [Live Data reference](/entities/live-da
 - The live delay calibration feature is disabled during replay.
 - The experimental catch-up controls currently support fixed 30-second jumps only.
 - Rewinding can replay historical events again, so replay-driven automations and notifications may run again.
+- Rewinding can also replay historical incident events again, including possible on-track incident notifications.
 - Replay Mode does not protect you from spoilers on its own. Use [No Spoiler Mode](/features/no-spoiler-mode) to keep your dashboard frozen until you are ready to watch.

--- a/docs/help/beta-tester.md
+++ b/docs/help/beta-tester.md
@@ -129,3 +129,19 @@ Screenshots, screen recordings, or dashboard examples are helpful when they show
 
 As a beta tester, you may be asked to test a proposed fix, verify a new release, or provide more details.
 Following up on your own issues helps close them faster.
+
+## Test incident detection
+
+When testing likely on-track incident detection, focus on whether the wording, confidence, and timing make sense from a user perspective.
+
+For each report, note:
+
+1. Session type: Race, Sprint, Qualifying, Practice, or Testing.
+2. Driver or car number.
+3. Whether the alert was `candidate`, `confirmed`, `updated`, or `cleared`.
+4. Confidence value: `low`, `medium`, or `high`.
+5. Track Status and Race Control context at the time.
+6. Whether the driver was in pit lane, leaving the pit lane, or stopped on track.
+7. Whether Live Delay, Replay Mode, No Spoiler Mode, or experimental F1TV Auth was active.
+
+Use neutral language in reports. The feature is intended to detect likely stopped cars and on-track incidents, not guaranteed crashes.

--- a/docs/help/debug-logging.md
+++ b/docs/help/debug-logging.md
@@ -61,6 +61,20 @@ After Home Assistant restarts:
 
 These details make it easier to match log entries to the behavior you saw.
 
+## Incident detection reports
+
+For false positive or missing on-track incident reports, include the same basic log package plus:
+
+1. Session type and session name.
+2. Driver or car number involved.
+3. Approximate real-world time and, if relevant, broadcast time.
+4. Current `sensor.f1_track_status` state.
+5. Latest Race Control message around the incident.
+6. The `f1_sensor_incident` event payload, if one fired.
+7. Whether Live Delay, Replay Mode, No Spoiler Mode, or experimental F1TV Auth was active.
+
+Do not include raw F1TV tokens, authorization headers, browser session data, or large telemetry dumps.
+
 ## Find raw logs
 
 Use Home Assistant raw logs if you need to copy a smaller log excerpt manually.

--- a/docs/help/experimental-testing.md
+++ b/docs/help/experimental-testing.md
@@ -70,7 +70,7 @@ If the token is missing, expired, or rejected, auth-gated live data should becom
 
 Likely on-track incident detection works with public live timing and does not require F1TV Auth.
 
-Experimental F1TV Auth can help test future early-warning signals from `CarData.z`, such as very low speed before a car is officially marked as stopped. These signals should be treated as candidates, not proof of a crash, and public live timing must continue to work if the token is missing, expired, or rejected.
+Experimental F1TV Auth can also test early-warning `candidate` signals from `CarData.z`, such as very low speed before a car is officially marked as stopped. These signals are correlated with flag or Safety Car context and should be treated as candidates, not proof of a crash. Public live timing must continue to work if the token is missing, expired, or rejected.
 
 ## Prerequisites
 

--- a/docs/help/experimental-testing.md
+++ b/docs/help/experimental-testing.md
@@ -66,6 +66,12 @@ If the token is missing, expired, or rejected, auth-gated live data should becom
 
 `Position.z` has been observed as auth-gated, but it is intentionally excluded from the first test build because it is high frequency and the integration does not currently use it.
 
+## Incident detection and F1TV Auth
+
+Likely on-track incident detection works with public live timing and does not require F1TV Auth.
+
+Experimental F1TV Auth can help test future early-warning signals from `CarData.z`, such as very low speed before a car is officially marked as stopped. These signals should be treated as candidates, not proof of a crash, and public live timing must continue to work if the token is missing, expired, or rejected.
+
 ## Prerequisites
 
 Before you start, make sure you have:

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -171,6 +171,30 @@ Yes. The F1 Sensor integration has live sensors for track flags and safety car s
 Additionally, `binary_sensor.f1_safety_car` turns on whenever a Safety Car or Virtual Safety Car is active on track. These live sensors let you react to yellow/red flags or safety car deployments in your Home Assistant automations (for example, changing lights to red on a red flag).
 </details>
 
+<details>
+<summary>Is on-track incident detection the same as crash detection?</summary>
+
+No. F1 Sensor detects likely stopped cars and on-track incidents from live timing, track status, and Race Control context. It does not prove that a crash happened.
+
+Use neutral wording in automations, such as "Possible on-track incident" or "Driver may have stopped on track." The same alert can represent a spin, technical failure, stopped car, red flag stop, or another situation.
+</details>
+
+<details>
+<summary>Does on-track incident detection work in qualifying and practice?</summary>
+
+Yes. It is designed for race, sprint, qualifying, and practice sessions.
+
+The default notification behavior is more conservative for practice because practice sessions include more slow running, pit activity, installation laps, and testing. If you enable practice notifications, consider requiring `high` confidence.
+</details>
+
+<details>
+<summary>Why did I receive a possible incident alert without a yellow flag?</summary>
+
+A yellow flag is helpful context, but it is not required in every case. A driver can be marked as stopped before Track Status or Race Control updates arrive.
+
+F1 Sensor uses confidence levels to handle this. A stopped car that is not in the pit lane can create a `medium` confidence alert, while matching yellow flag, Safety Car, red flag, or Race Control context can raise it to `high`.
+</details>
+
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16501,9 +16501,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
-      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.15.0.tgz",
+      "integrity": "sha512-+k0tk7lRnpMUPnC7kTuU/yrV/mnFoPhJQ75VfLtZ6fwbzOVXaPsTE/Il9Pn1DHi482byMyqkHv/XsQ76mNjXLw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -16582,8 +16582,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.1",
-        "@npmcli/config": "^10.7.1",
+        "@npmcli/arborist": "^9.6.0",
+        "@npmcli/config": "^10.9.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -16591,37 +16591,37 @@
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.4",
-        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/tuf": "^4.0.2",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.3",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.4",
-        "libnpmexec": "^10.2.4",
-        "libnpmfund": "^7.0.18",
+        "libnpmdiff": "^8.1.8",
+        "libnpmexec": "^10.2.8",
+        "libnpmfund": "^7.0.22",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.4",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.8",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.4",
-        "minimatch": "^10.2.4",
+        "make-fetch-happen": "^15.0.5",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.3.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -16636,11 +16636,11 @@
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.0",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -16668,24 +16668,12 @@
       }
     },
     "node_modules/npm/node_modules/@gar/promise-retry": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "retry": "^0.13.1"
-      },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@gar/promise-retry/node_modules/retry": {
-      "version": "0.13.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -16723,7 +16711,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.1",
+      "version": "9.6.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -16771,7 +16759,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.7.1",
+      "version": "10.9.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -16965,7 +16953,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.1.0",
+      "version": "3.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -16974,7 +16962,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -16983,24 +16971,24 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.3",
-        "proc-log": "^6.1.0",
-        "promise-retry": "^2.0.1"
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -17088,7 +17076,7 @@
       }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17116,7 +17104,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -17128,7 +17116,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "20.0.3",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17142,8 +17130,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^13.0.0",
-        "unique-filename": "^5.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -17186,7 +17173,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -17242,7 +17229,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -17258,12 +17245,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -17316,7 +17297,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17388,15 +17369,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
     "node_modules/npm/node_modules/ini": {
       "version": "6.0.0",
       "dev": true,
@@ -17424,7 +17396,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -17433,12 +17405,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -17506,12 +17478,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.4",
+      "version": "8.1.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.6.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -17525,13 +17497,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.4",
+      "version": "10.2.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.6.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -17548,12 +17520,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.18",
+      "version": "7.0.22",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1"
+        "@npmcli/arborist": "^9.6.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -17573,12 +17545,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.4",
+      "version": "9.1.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.6.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -17588,7 +17560,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17648,7 +17620,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.6",
+      "version": "11.5.0",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -17657,13 +17629,14 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.4",
+      "version": "15.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
@@ -17679,12 +17652,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -17732,34 +17705,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -17840,7 +17795,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -17848,12 +17803,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -18126,19 +18081,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
       "dev": true,
@@ -18180,15 +18122,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
       "dev": true,
@@ -18197,7 +18130,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18248,12 +18181,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -18322,7 +18255,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.15",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -18350,13 +18283,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -18383,7 +18316,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -18417,28 +18350,13 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "5.0.0",
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.25.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^6.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -20907,9 +20825,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -24350,12 +24268,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -24548,6 +24470,27 @@
         "node": ">= 10"
       }
     },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-dev-middleware": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
@@ -24696,27 +24639,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/webpack-merge": {
@@ -24947,16 +24869,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,12 @@
     "brace-expansion": "^2.0.3",
     "minimatch": "^3.1.4",
     "serialize-javascript": ">=7.0.5",
-    "picomatch": ">=4.0.4"
+    "picomatch": ">=4.0.4",
+    "ip-address": "^10.1.1",
+    "qs": "^6.15.2",
+    "uuid": "^11.1.1",
+    "webpack-dev-server": {
+      "ws": "^8.20.1"
+    }
   }
 }

--- a/sidebars.js
+++ b/sidebars.js
@@ -32,7 +32,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Blueprints',
-      items: ['blueprints/track-status-light', 'blueprints/race-control-notifications', 'blueprints/replay-sync'],
+      items: ['blueprints/track-status-light', 'blueprints/race-control-notifications', 'blueprints/incident-notifications', 'blueprints/replay-sync'],
     },
 
     {


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

The change is really simple: in the live session card, the weather section shows Rain: Yes/No. I think that it looks kinda bad, so I replaced it with Weather: Wet/Dry, which looks a lot better for me

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Like I wrote before, it isn’t really needed, it’s just a nice little touch that I think would make the card feel better

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [X] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [X] Tested locally with a real Home Assistant instance
- [X] Existing automations and dashboards still work as expected after the change

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [X] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [X] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [X] Tests have been added or updated and pass locally — if applicable
- [X] Translations updated if new UI strings were added — if applicable
- [X] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
