### PR TITLE
v5.1.0-beta.3

### DIFF
--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -813,6 +813,8 @@ class F1NextRaceSensor(_NextRaceMixin, F1BaseEntity, SensorEntity):
         super().__init__(coordinator, unique_id, entry_id, device_name)
         self._attr_icon = "mdi:flag-checkered"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_native_value = None
+        self._attr_extra_state_attributes = {}
         self._history_coordinator = None
 
     async def async_added_to_hass(self):
@@ -824,29 +826,23 @@ class F1NextRaceSensor(_NextRaceMixin, F1BaseEntity, SensorEntity):
                 self._handle_history_update
             )
             self.async_on_remove(removal)
+        self._refresh_cached_state()
 
     @callback
     def _handle_history_update(self) -> None:
+        self._refresh_cached_state()
         self._safe_write_ha_state()
 
     def _history_attributes(self) -> dict:
         data = getattr(self._history_coordinator, "data", None)
         return data if isinstance(data, dict) else {}
 
-    @property
-    def state(self):
-        next_race = self._get_next_race()
-        if not next_race:
-            return None
-        return _combine_date_time(
-            next_race.get("date"), next_race.get("time"), force_utc=True
-        )
-
-    @property
-    def extra_state_attributes(self):
+    def _refresh_cached_state(self) -> None:
         race = self._get_next_race()
         if not race:
-            return {}
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
 
         circuit = race.get("Circuit", {})
         loc = circuit.get("Location", {})
@@ -918,7 +914,21 @@ class F1NextRaceSensor(_NextRaceMixin, F1BaseEntity, SensorEntity):
         _populate("sprint_start", sprint_start)
         attrs.update(self._history_attributes())
 
-        return attrs
+        self._attr_native_value = race_start
+        self._attr_extra_state_attributes = attrs
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._refresh_cached_state()
+        self._safe_write_ha_state()
+
+    @property
+    def state(self):
+        return self._attr_native_value
+
+    @property
+    def extra_state_attributes(self):
+        return self._attr_extra_state_attributes
 
 
 class F1TrackTimeSensor(_NextRaceMixin, F1BaseEntity, SensorEntity):

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -1301,6 +1301,63 @@ async def test_next_race_sensor_uses_2026_detailed_circuit_map(
 
 
 @pytest.mark.asyncio
+async def test_next_race_sensor_caches_state_attributes(hass, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.helpers.dt_util.utcnow",
+        lambda: datetime(2026, 3, 10, tzinfo=UTC),
+    )
+    timezone_calls = 0
+
+    def _fake_timezone(_lat, _lon):
+        nonlocal timezone_calls
+        timezone_calls += 1
+        return "Australia/Melbourne"
+
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.sensor._timezone_from_location",
+        _fake_timezone,
+    )
+    coordinator = _build_coordinator(
+        hass,
+        {"MRData": {"RaceTable": {"Races": [_build_race(date="2026-03-15")]}}},
+    )
+    entry_id = "test_entry_next_race_cache"
+    _set_entry_context(hass, entry_id)
+
+    sensor = F1NextRaceSensor(
+        coordinator,
+        f"{entry_id}_next_race",
+        entry_id,
+        "F1",
+    )
+    state = await _add_sensor_and_get_state(hass, sensor)
+
+    assert timezone_calls == 1
+    assert state.attributes["circuit_timezone"] == "Australia/Melbourne"
+
+    assert sensor.state == "2026-03-15T04:00:00+00:00"
+    assert sensor.extra_state_attributes["circuit_timezone"] == "Australia/Melbourne"
+    sensor.async_write_ha_state()
+    await hass.async_block_till_done()
+
+    assert timezone_calls == 1
+
+    coordinator.async_set_updated_data(
+        {
+            "MRData": {
+                "RaceTable": {"Races": [_build_race(round_="2", date="2026-03-22")]}
+            }
+        }
+    )
+    await hass.async_block_till_done()
+
+    assert timezone_calls == 2
+    updated_state = hass.states.get(sensor.entity_id)
+    assert updated_state is not None
+    assert updated_state.state == "2026-03-22T04:00:00+00:00"
+
+
+@pytest.mark.asyncio
 async def test_track_time_sensor_exposes_machine_readable_datetimes(
     hass, monkeypatch
 ) -> None:


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #553 

## Type of change

- [X] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
