### PR TITLE
Dev

### DIFF
--- a/custom_components/f1_sensor/tests/test_track_map_card_config.py
+++ b/custom_components/f1_sensor/tests/test_track_map_card_config.py
@@ -130,6 +130,7 @@ const result = {
   labelNumber: card._driverLabel({ tla: "VER", racing_number: "1" }, "number"),
   labelOff: card._driverLabel({ tla: "VER", racing_number: "1" }, "off"),
   emptyState: card._emptyState(),
+  presentation: card._presentationState(),
   layoutMode: card._effectiveLayoutMode(),
   visibleDrivers: card._visibleDrivers(payload.drivers || []).map((driver) => driver.racing_number),
   displayDrivers: card._displayDrivers(payload.drivers || []).map((driver) => driver.racing_number),
@@ -368,6 +369,46 @@ def test_track_map_card_keeps_live_driver_motion_active_until_latest_sample() ->
     assert active_live["hasActiveDriverMotion"] is True
     assert stale_live["hasActiveDriverMotion"] is False
     assert paused_replay["hasActiveDriverMotion"] is False
+
+
+def test_track_map_card_hides_stale_live_positions() -> None:
+    """Stale live snapshots should not leave old cars visible on the map."""
+    result = _run_probe(
+        {
+            "snapshot": {
+                "source": "live",
+                "status": "stale",
+                "stale": True,
+                "session": {
+                    "meeting_name": "Monaco Grand Prix",
+                    "session_name": "Qualifying",
+                },
+                "drivers": [
+                    {"racing_number": "1", "status": "OnTrack"},
+                    {"racing_number": "4", "status": "OnTrack"},
+                ],
+                "track": {"points": [[0, 0], [1, 1]]},
+            },
+            "drivers": [
+                {"racing_number": "1", "status": "OnTrack"},
+                {"racing_number": "4", "status": "OnTrack"},
+            ],
+        }
+    )
+
+    assert result["emptyState"]["title"] == "No active live session"
+    assert result["emptyState"]["detail"] == (
+        "Live timing is waiting for the next active session."
+    )
+    assert result["presentation"] == {
+        "hide_live_metadata": True,
+        "session": {},
+        "show_badges": False,
+        "show_footer": False,
+        "show_session_info": False,
+    }
+    assert result["visibleDrivers"] == []
+    assert result["displayDrivers"] == []
 
 
 def test_track_map_card_hides_retired_drivers() -> None:

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -25926,20 +25926,20 @@ class F1PracticeTimingCard extends LitElement {
     let rows = [];
     let title = this._buildTitle(sessionState);
     const positionsMissing = !positionsState;
-    if (positionsState && !isUnavailableLikeEntityState(positionsState)) {
+    if (positionsState && this._hasUsableDriversEntity(positionsState)) {
       const positionDrivers = this._asDriversList(positionsState?.attributes?.drivers);
 
       const tyresState = this.config.tyres_entity
         ? getEntityStateWithFallback(this.hass, this.config.tyres_entity)
         : null;
-      const tyresDrivers = tyresState && !isUnavailableLikeEntityState(tyresState)
+      const tyresDrivers = tyresState && this._hasUsableDriversEntity(tyresState)
         ? this._asDriversList(tyresState?.attributes?.drivers)
         : [];
 
       const driversState = this.config.drivers_entity
         ? getEntityStateWithFallback(this.hass, this.config.drivers_entity)
         : null;
-      const driverList = driversState && !isUnavailableLikeEntityState(driversState)
+      const driverList = driversState && this._hasUsableDriversEntity(driversState)
         ? this._asDriversList(driversState?.attributes?.drivers)
         : [];
 
@@ -26329,6 +26329,16 @@ class F1PracticeTimingCard extends LitElement {
     if (Array.isArray(value)) return value;
     if (!value || typeof value !== 'object') return [];
     return Object.values(value).filter((entry) => entry && typeof entry === 'object');
+  }
+
+  _hasUsableDriversEntity(entityState) {
+    return Boolean(
+      entityState
+        && (
+          !isUnavailableLikeEntityState(entityState)
+          || this._asDriversList(entityState?.attributes?.drivers).length > 0
+        ),
+    );
   }
 
   _buildLapSnapshot(positionInfo) {

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -25926,20 +25926,20 @@ class F1PracticeTimingCard extends LitElement {
     let rows = [];
     let title = this._buildTitle(sessionState);
     const positionsMissing = !positionsState;
-    if (positionsState && this._hasUsableDriversEntity(positionsState)) {
+    if (positionsState && !isUnavailableLikeEntityState(positionsState)) {
       const positionDrivers = this._asDriversList(positionsState?.attributes?.drivers);
 
       const tyresState = this.config.tyres_entity
         ? getEntityStateWithFallback(this.hass, this.config.tyres_entity)
         : null;
-      const tyresDrivers = tyresState && this._hasUsableDriversEntity(tyresState)
+      const tyresDrivers = tyresState && !isUnavailableLikeEntityState(tyresState)
         ? this._asDriversList(tyresState?.attributes?.drivers)
         : [];
 
       const driversState = this.config.drivers_entity
         ? getEntityStateWithFallback(this.hass, this.config.drivers_entity)
         : null;
-      const driverList = driversState && this._hasUsableDriversEntity(driversState)
+      const driverList = driversState && !isUnavailableLikeEntityState(driversState)
         ? this._asDriversList(driversState?.attributes?.drivers)
         : [];
 
@@ -26329,16 +26329,6 @@ class F1PracticeTimingCard extends LitElement {
     if (Array.isArray(value)) return value;
     if (!value || typeof value !== 'object') return [];
     return Object.values(value).filter((entry) => entry && typeof entry === 'object');
-  }
-
-  _hasUsableDriversEntity(entityState) {
-    return Boolean(
-      entityState
-        && (
-          !isUnavailableLikeEntityState(entityState)
-          || this._asDriversList(entityState?.attributes?.drivers).length > 0
-        ),
-    );
   }
 
   _buildLapSnapshot(positionInfo) {
@@ -29980,6 +29970,7 @@ class F1TrackMapCard extends LitElement {
     this._snapshotIntervalMs = 0;
     this._driverSampleIntervalMs = 0;
     this._renderClockAt = 0;
+    this._staleTimer = 0;
   }
 
   setConfig(config) {
@@ -30019,6 +30010,7 @@ class F1TrackMapCard extends LitElement {
       this._resizeObserver.disconnect();
       this._resizeObserver = null;
     }
+    this._clearStaleTimer();
   }
 
   firstUpdated() {
@@ -30194,6 +30186,7 @@ class F1TrackMapCard extends LitElement {
     this._snapshotIntervalMs = 0;
     this._driverSampleIntervalMs = 0;
     this._renderClockAt = 0;
+    this._clearStaleTimer();
   }
 
   _callUnsubscribe(unsubscribe) {
@@ -30216,6 +30209,7 @@ class F1TrackMapCard extends LitElement {
     this._status = message?.status || this._snapshot?.status || 'not_loaded';
     this._error = null;
     this._ingestDriverSamples(snapshot);
+    this._scheduleStaleTransition(snapshot);
     this.requestUpdate();
     this._scheduleDraw();
   }
@@ -30225,6 +30219,7 @@ class F1TrackMapCard extends LitElement {
     if (replayState === 'paused') return 'Paused';
     if (replayState === 'seeking') return 'Seeking';
     if (replayState === 'playing') return 'Replay';
+    if (this._liveSnapshotIsStale()) return 'No session';
     const sourceLabel = this._sourceLabel(this._snapshot);
     const labels = {
       active: sourceLabel,
@@ -30241,6 +30236,7 @@ class F1TrackMapCard extends LitElement {
   _visualStatusState() {
     const replayState = String(this._snapshot?.replay_state || '').toLowerCase();
     if (['playing', 'paused', 'seeking'].includes(replayState)) return replayState;
+    if (this._liveSnapshotIsStale()) return 'no_session';
     return this._status || 'not_loaded';
   }
 
@@ -30262,6 +30258,12 @@ class F1TrackMapCard extends LitElement {
       };
     }
     const isLive = this._snapshot.source === 'live';
+    if (this._liveSnapshotIsStale(this._snapshot)) {
+      return {
+        title: 'No active live session',
+        detail: 'Live timing is waiting for the next active session.',
+      };
+    }
     if (!this._snapshot.session) {
       return {
         title: isLive ? 'No live timing session loaded' : 'No replay session loaded',
@@ -30297,15 +30299,16 @@ class F1TrackMapCard extends LitElement {
 
   render() {
     const snapshot = this._snapshot;
+    const presentation = this._presentationState(snapshot);
     const drivers = this._visibleDrivers(snapshot?.drivers);
-    const session = snapshot?.session || {};
+    const session = presentation.session;
     const title = this.config?.title || 'F1 Track Map';
     const sessionText = this._sessionText(session);
     const footer = this._footerText(snapshot, drivers.length);
     const empty = this._emptyState();
     const layoutMode = this._effectiveLayoutMode();
-    const trackStatus = this._trackStatusInfo();
-    const lapData = this._lapData();
+    const trackStatus = presentation.show_badges ? this._trackStatusInfo() : null;
+    const lapData = presentation.show_badges ? this._lapData() : null;
     const visualStatus = this._visualStatusState();
     const driverCountText = this.config.show_driver_count !== false
       ? `${drivers.length} ${drivers.length === 1 ? 'car' : 'cars'}`
@@ -30324,20 +30327,20 @@ class F1TrackMapCard extends LitElement {
             <div class="tm-header">
               <div class="tm-title-block">
                 <div class="tm-title">${title}</div>
-                ${this.config.show_session_info !== false ? html`
+                ${presentation.show_session_info ? html`
                   <div class="tm-subtitle">
                     <span>${sessionText}</span>
                     ${driverCountText ? html`<span>${driverCountText}</span>` : null}
                   </div>
                 ` : null}
               </div>
-              <div class="tm-badges">
+              ${presentation.show_badges ? html`<div class="tm-badges">
                 <span class="tm-status">${this._statusLabel()}</span>
                 ${trackStatus && this.config.show_track_status !== false ? html`
                   <span class="tm-status track ${trackStatus.alert ? 'alert' : ''}">${trackStatus.label}</span>
                 ` : null}
                 ${lapData && this.config.show_lap_progress !== false ? this._renderLapBadge(lapData) : null}
-              </div>
+              </div>` : null}
             </div>
           ` : null}
           <div class="tm-canvas-frame">
@@ -30349,7 +30352,7 @@ class F1TrackMapCard extends LitElement {
               </div>
             ` : null}
           </div>
-          ${this.config.show_footer !== false ? html`<div class="tm-footer">
+          ${presentation.show_footer ? html`<div class="tm-footer">
             <span>${sessionText}</span>
             <span>${footer}</span>
           </div>` : null}
@@ -30381,8 +30384,8 @@ class F1TrackMapCard extends LitElement {
   }
 
   _footerText(snapshot, driverCount) {
+    if (this._liveSnapshotIsStale(snapshot)) return '';
     const parts = [this._sourceLabel(snapshot)];
-    if (snapshot?.stale === true) parts.push('Stale');
     if (snapshot?.stream_timestamp) parts.push(`Updated ${this._formatShortTime(snapshot.stream_timestamp)}`);
     parts.push(`${driverCount} ${driverCount === 1 ? 'car' : 'cars'}`);
     return parts.join(' / ');
@@ -30485,6 +30488,50 @@ class F1TrackMapCard extends LitElement {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
   }
 
+  _liveSnapshotIsStale(snapshot = this._snapshot) {
+    if (String(snapshot?.source || '').trim().toLowerCase() !== 'live') return false;
+    const status = String(snapshot?.status || this._status || '').trim().toLowerCase();
+    if (snapshot?.stale === true || status === 'stale') return true;
+    const streamTimestamp = Date.parse(String(snapshot?.stream_timestamp || ''));
+    const staleAfterSeconds = Number(snapshot?.stale_after_seconds);
+    if (!Number.isFinite(streamTimestamp) || !Number.isFinite(staleAfterSeconds)) return false;
+    return Date.now() >= streamTimestamp + (Math.max(0, staleAfterSeconds) * 1000);
+  }
+
+  _presentationState(snapshot = this._snapshot) {
+    const hideLiveMetadata = this._liveSnapshotIsStale(snapshot);
+    return {
+      hide_live_metadata: hideLiveMetadata,
+      session: hideLiveMetadata ? {} : (snapshot?.session || {}),
+      show_badges: !hideLiveMetadata,
+      show_footer: !hideLiveMetadata && this.config?.show_footer !== false,
+      show_session_info: !hideLiveMetadata && this.config?.show_session_info !== false,
+    };
+  }
+
+  _scheduleStaleTransition(snapshot) {
+    this._clearStaleTimer();
+    if (String(snapshot?.source || '').trim().toLowerCase() !== 'live') return;
+    if (this._liveSnapshotIsStale(snapshot)) return;
+    const streamTimestamp = Date.parse(String(snapshot?.stream_timestamp || ''));
+    const staleAfterSeconds = Number(snapshot?.stale_after_seconds);
+    if (!Number.isFinite(streamTimestamp) || !Number.isFinite(staleAfterSeconds)) return;
+    const delay = streamTimestamp + (Math.max(0, staleAfterSeconds) * 1000) - Date.now();
+    if (delay <= 0) return;
+    this._staleTimer = window.setTimeout(() => {
+      this._staleTimer = 0;
+      this._driverSamples.clear();
+      this.requestUpdate();
+      this._scheduleDraw();
+    }, delay + 25);
+  }
+
+  _clearStaleTimer() {
+    if (!this._staleTimer) return;
+    window.clearTimeout(this._staleTimer);
+    this._staleTimer = 0;
+  }
+
   _scheduleDraw() {
     if (this._drawRaf) return;
     this._drawRaf = requestAnimationFrame(() => {
@@ -30514,6 +30561,7 @@ class F1TrackMapCard extends LitElement {
     this._drawGrid(ctx, rect.width, rect.height);
 
     const snapshot = this._snapshot;
+    if (this._liveSnapshotIsStale(snapshot)) return;
     const presentation = this._presentationTransform(snapshot?.track);
     const bounds = this._drawableBounds(snapshot, presentation);
     if (!snapshot || !bounds) return;
@@ -30646,8 +30694,9 @@ class F1TrackMapCard extends LitElement {
     return String(driver?.tla || driver?.racing_number || '').slice(0, 3);
   }
 
-  _visibleDrivers(drivers) {
+  _visibleDrivers(drivers, snapshot = this._snapshot) {
     if (!Array.isArray(drivers)) return [];
+    if (this._liveSnapshotIsStale(snapshot)) return [];
     const retiredKeys = this._retiredDriverKeys();
     return drivers.filter((driver) => !this._isRetiredDriver(driver, retiredKeys));
   }
@@ -30712,7 +30761,7 @@ class F1TrackMapCard extends LitElement {
 
   _noteSnapshotArrival(snapshot) {
     const replayState = String(snapshot?.replay_state || '').toLowerCase();
-    const drivers = this._visibleDrivers(snapshot?.drivers);
+    const drivers = this._visibleDrivers(snapshot?.drivers, snapshot);
     if (!drivers.length || replayState === 'paused' || replayState === 'seeking') {
       this._lastSnapshotAt = 0;
       this._renderClockAt = 0;
@@ -30731,7 +30780,7 @@ class F1TrackMapCard extends LitElement {
   }
 
   _ingestDriverSamples(snapshot) {
-    const drivers = this._visibleDrivers(snapshot?.drivers);
+    const drivers = this._visibleDrivers(snapshot?.drivers, snapshot);
     if (!drivers.length) {
       this._driverSamples.clear();
       return;
@@ -30895,7 +30944,7 @@ class F1TrackMapCard extends LitElement {
         || trackBounds;
     }
 
-    const drivers = this._visibleDrivers(snapshot?.drivers);
+    const drivers = this._visibleDrivers(snapshot?.drivers, snapshot);
     const driverBounds = this._boundsFromDrivers(drivers, presentation);
     if (!driverBounds) return null;
     return this._stableViewportBounds(driverBounds);


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [X] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
