### PR TITLE
Dev

### DIFF
--- a/blueprints/f1_incident_notifications.yaml
+++ b/blueprints/f1_incident_notifications.yaml
@@ -10,7 +10,7 @@ blueprint:
     so supported notify targets update an existing incident notification instead of
     creating duplicates for the same incident.
   domain: automation
-  source_url: https://github.com/Nicxe/f1_sensor
+  source_url: https://github.com/Nicxe/f1_sensor/blob/main/blueprints/f1_incident_notifications.yaml
   author: Nicxe
   input:
     notification_targets:

--- a/blueprints/f1_track_status.yaml
+++ b/blueprints/f1_track_status.yaml
@@ -825,6 +825,12 @@ variables:
     {% else %}
       {{ '' }}
     {% endif %}
+  trigger_from_track_state: >-
+    {% if trigger is defined and trigger.from_state is defined and trigger.from_state is not none %}
+      {{ trigger.from_state.state | upper }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
   current_session_now: >-
     {% if current_session_entity | string | length > 0 %}
       {{ states(current_session_entity) | string }}
@@ -850,12 +856,7 @@ variables:
     {% elif current_session_entity | string | length == 0 %}
       false
     {% else %}
-      {% set now_label = current_session_now | trim %}
-      {% if now_label in ['', 'unknown', 'unavailable', 'none', 'None'] %}
-        false
-      {% else %}
-        {{ now_label in allowed_current_sessions }}
-      {% endif %}
+      {{ (current_session_effective | trim) in allowed_current_sessions }}
     {% endif %}
   session_scope_ok: >-
     {% if not current_session_filter_enabled %}
@@ -1109,7 +1110,13 @@ actions:
         sequence:
           - if:
               - condition: template
-                value_template: "{{ snapshot_before_alert_enabled and trigger.id == 'track_update' and track_state in ['YELLOW', 'RED', 'SC', 'VSC'] }}"
+                value_template: >-
+                  {{
+                    snapshot_before_alert_enabled
+                    and trigger.id == 'track_update'
+                    and track_state in ['YELLOW', 'RED', 'SC', 'VSC']
+                    and trigger_from_track_state not in ['YELLOW', 'RED', 'SC', 'VSC']
+                  }}
             then:
               - continue_on_error: true
                 action: scene.create

--- a/custom_components/f1_sensor/tests/fixtures/f1_track_status.yaml
+++ b/custom_components/f1_sensor/tests/fixtures/f1_track_status.yaml
@@ -825,6 +825,12 @@ variables:
     {% else %}
       {{ '' }}
     {% endif %}
+  trigger_from_track_state: >-
+    {% if trigger is defined and trigger.from_state is defined and trigger.from_state is not none %}
+      {{ trigger.from_state.state | upper }}
+    {% else %}
+      {{ '' }}
+    {% endif %}
   current_session_now: >-
     {% if current_session_entity | string | length > 0 %}
       {{ states(current_session_entity) | string }}
@@ -850,12 +856,7 @@ variables:
     {% elif current_session_entity | string | length == 0 %}
       false
     {% else %}
-      {% set now_label = current_session_now | trim %}
-      {% if now_label in ['', 'unknown', 'unavailable', 'none', 'None'] %}
-        false
-      {% else %}
-        {{ now_label in allowed_current_sessions }}
-      {% endif %}
+      {{ (current_session_effective | trim) in allowed_current_sessions }}
     {% endif %}
   session_scope_ok: >-
     {% if not current_session_filter_enabled %}
@@ -1109,7 +1110,13 @@ actions:
         sequence:
           - if:
               - condition: template
-                value_template: "{{ snapshot_before_alert_enabled and trigger.id == 'track_update' and track_state in ['YELLOW', 'RED', 'SC', 'VSC'] }}"
+                value_template: >-
+                  {{
+                    snapshot_before_alert_enabled
+                    and trigger.id == 'track_update'
+                    and track_state in ['YELLOW', 'RED', 'SC', 'VSC']
+                    and trigger_from_track_state not in ['YELLOW', 'RED', 'SC', 'VSC']
+                  }}
             then:
               - continue_on_error: true
                 action: scene.create

--- a/custom_components/f1_sensor/tests/test_track_status_blueprint.py
+++ b/custom_components/f1_sensor/tests/test_track_status_blueprint.py
@@ -377,6 +377,101 @@ async def test_blueprint_uses_native_snapshot_entity_list_for_pre_alert_scene(
 
 
 @pytest.mark.asyncio
+async def test_blueprint_preserves_snapshot_across_consecutive_alerts(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_services(hass)
+    await _set_states(
+        hass,
+        {
+            "light.test_track_status": "off",
+            "sensor.test_track_status": "CLEAR",
+            "sensor.test_session_status": "live",
+        },
+    )
+
+    assert await _setup_blueprint_automation(
+        hass,
+        extra_inputs={
+            "snapshot_before_alert": True,
+            "clear_behavior_mode": "restore_immediately",
+        },
+    )
+    calls.clear()
+
+    await _set_states(hass, {"sensor.test_track_status": "YELLOW"})
+
+    assert calls[0] == (
+        "scene.create",
+        {
+            "scene_id": "automation_track_status_blueprint_test_pre_alert",
+            "snapshot_entities": ["light.test_track_status"],
+        },
+    )
+
+    calls.clear()
+    await _set_states(hass, {"sensor.test_track_status": "RED"})
+
+    assert all(service != "scene.create" for service, _ in calls)
+
+    calls.clear()
+    await _set_states(hass, {"sensor.test_track_status": "CLEAR"})
+
+    assert calls == [
+        (
+            "scene.turn_on",
+            {
+                "entity_id": "scene.automation_track_status_blueprint_test_pre_alert",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_blueprint_uses_last_session_label_while_suspended(
+    hass: HomeAssistant,
+) -> None:
+    await _install_blueprint(hass)
+    calls = _register_services(hass)
+    await _set_states(
+        hass,
+        {
+            "sensor.test_current_session": (
+                "unknown",
+                {"last_label": "Race"},
+            ),
+            "sensor.test_track_status": "CLEAR",
+            "sensor.test_session_status": "suspended",
+        },
+    )
+
+    assert await _setup_blueprint_automation(
+        hass,
+        extra_inputs={
+            "enable_current_session_filter": True,
+            "current_session_entity": "sensor.test_current_session",
+            "allowed_current_sessions": ["Race"],
+        },
+    )
+    calls.clear()
+
+    await _set_states(hass, {"sensor.test_track_status": "YELLOW"})
+
+    assert calls == [
+        (
+            "light.turn_on",
+            {
+                "entity_id": ["light.test_track_status"],
+                "brightness_pct": 100,
+                "rgb_color": [44, 55, 66],
+                "transition": 0,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_blueprint_prefers_wled_playlist_over_preset_for_track_status(
     hass: HomeAssistant,
 ) -> None:

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -18,7 +18,20 @@ It works without F1TV Auth. Public live timing powers core live entities such as
 
 Start with the [installation guide](/getting-started/installation), then use [configuration](/getting-started/add-integration) to add F1 Sensor to Home Assistant.
 
-If you are preparing for beta testing, read [Release Channels](/getting-started/release-channels) first. Stable is for normal use, beta is for validating the next release, and `dev` contains all active unreleased work.
+Most users should install the stable release. See [Release Channels](/getting-started/release-channels) before using beta or `dev` builds.
+
+## Version 5.1
+
+Version 5.1 expands live, replay, dashboard, and automation support:
+
+- [Track Map](/features/track-map) adds live and replay circuit maps with driver markers
+- [Incident Detection](/features/incident-detection) adds neutral stopped-car and on-track incident alerts
+- [Incident Notifications](/blueprints/incident-notifications) adds a ready-made notification blueprint with conservative defaults
+- [F1TV Auth](/features/f1tv-auth) becomes a standard optional feature for supported extra live timing data
+- [Replay Mode](/features/replay-mode) adds a draggable seek bar and improved replay state restoration
+- [Live Data Cards](/cards/cards-overview) add lap position and championship progression charts, Track Map, and compact layouts
+
+Version 5.1 also includes reliability fixes for replay controls, practice timing, pit stop and tyre data, next-race updates, expired F1TV access, and consecutive Track Status blueprint alerts.
 
 ## Features
 
@@ -31,11 +44,9 @@ Take your setup further with focused feature pages:
 - [Track Map](/features/track-map) - Show car markers on a circuit map during live or replay sessions
 - [Incident Detection](/features/incident-detection) - Detect likely stopped cars or on-track incidents with neutral alerts
 
-## Beta testing
+## Blueprints
 
-The first beta release is the point where changes promoted from `dev` become a testable pre-release. Use the beta channel when you want to validate new behavior before it reaches stable, and use the dev branch only for maintainer-led development testing.
-
-For the recommended testing workflow, see [Beta Testing](/help/beta-tester).
+Use ready-made blueprints for [Track Status lights](/blueprints/track-status-light), [Race Control notifications](/blueprints/race-control-notifications), [Incident Notifications](/blueprints/incident-notifications), and [Replay Sync](/blueprints/replay-sync).
 
 ## Timing modes
 

--- a/docs/blueprints/incident-notifications.md
+++ b/docs/blueprints/incident-notifications.md
@@ -3,8 +3,6 @@ id: incident-notifications
 title: Incident Notifications
 ---
 
-# Incident Notifications
-
 Get notifications for likely stopped cars and on-track incidents without writing YAML. The blueprint listens to `f1_sensor_incident` events and uses conservative defaults so normal practice running and early candidate signals do not create noisy alerts.
 
 For the full feature behavior, see [Incident Detection](/features/incident-detection).
@@ -19,7 +17,7 @@ For notifications to arrive at the right moment, configure [Live Delay](/feature
 
 ---
 
-## Import the Blueprint
+## Import the blueprint
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FNicxe%2Ff1_sensor%2Fmain%2Fblueprints%2Ff1_incident_notifications.yaml)
 
@@ -39,7 +37,7 @@ https://raw.githubusercontent.com/Nicxe/f1_sensor/main/blueprints/f1_incident_no
 
 ---
 
-## Step-by-step Setup
+## Step-by-step setup
 
 ### Step 1 - Create an automation from the blueprint
 
@@ -47,16 +45,16 @@ https://raw.githubusercontent.com/Nicxe/f1_sensor/main/blueprints/f1_incident_no
 2. Find **F1 Sensor - Incident Notifications**
 3. Click **Create Automation**
 
-### Step 2 - Choose notification actions
+### Step 2 - Choose notification targets
 
-Add one or more Home Assistant notification actions. Mobile app notifications and persistent notifications both work.
+Configure at least one target in the **Notification Targets** section.
 
-```yaml
-- service: notify.mobile_app_your_phone
-  data:
-    title: "{{ notification_title }}"
-    message: "{{ notification_message }}"
-```
+| Setting | Example | Description |
+| --- | --- | --- |
+| **Notify Services** | `notify.mobile_app_your_phone` | Enter one or more service names separated by commas or semicolons |
+| **Notify Entity Targets** | `notify.your_device` | Select one or more notify entities that support `notify.send_message` |
+
+You can use either method or combine them. The automation does not send anything until at least one notification target is configured.
 
 ### Step 3 - Review filters
 
@@ -64,11 +62,11 @@ The default filters are intentionally conservative.
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| **Minimum confidence** | `medium` | Notify for `medium` and `high` incidents |
-| **Allowed phases** | `confirmed`, `updated` | Ignore early `candidate` events by default |
-| **Allowed sessions** | Race, Sprint, Qualifying | Practice is excluded by default to reduce noisy alerts |
-| **Notify when cleared** | Off | Cleared updates are available but not sent by default |
-| **Notification tag** | `incident_id` | Lets supported notify targets update the same notification for later updates |
+| **Minimum Confidence** | Medium | Notify for medium- and high-confidence incidents |
+| **Session Types** | Race, Sprint, Qualifying | Exclude Practice, Testing, and Unknown sessions |
+| **Notify Candidate Events** | Off | Ignore earlier and less certain candidate events |
+| **Notify When Cleared** | Off | Do not send a separate update when the incident clears |
+| **Title Prefix** | `F1 Incident Alert` | Set the notification title shown before the confidence level |
 
 Practice sessions can include installation laps, garage work, slow running, and testing procedures. Enable Practice only if you are comfortable with more alerts, or require `high` confidence for Practice.
 
@@ -78,7 +76,7 @@ When Track Map location data is available, the event can include an optional loc
 
 Public confirmed incident alerts work without F1TV Auth. F1TV Auth can improve candidate signals, and Track Map can improve location context when fresh position data exists.
 
----
+Supported notification services receive a stable tag based on `incident_id`. This lets later updates replace the existing notification instead of creating a duplicate.
 
 ## Notification wording
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,18 +3,16 @@ id: installation
 title: Installation & Configuration
 ---
 
-# Installation & Configuration
-
 Get up and running with F1 Sensor in just a few minutes.  
 This guide walks you through installation and configuration in Home Assistant, step by step.
 
 :::info[Choose the right release channel]
-Most users should install the latest stable release. If you want to test the first beta release or follow active development builds, read [Release Channels](/getting-started/release-channels) before installing.
+Most users should install the latest stable release. If you want to test a beta release or follow active development builds, read [Release Channels](/getting-started/release-channels) before installing.
 :::
 
 
 
-## Overview, how it works
+## How it works
 
 
 

--- a/docs/help/beta-tester.md
+++ b/docs/help/beta-tester.md
@@ -58,16 +58,16 @@ The `dev` branch contains all active unreleased work. It can include changes tha
 
 If you need a reliable fallback, switch back to the latest stable release through HACS by using **Redownload** and selecting the latest non-beta version.
 
-## What to focus on in this beta
+## What to test
 
-When validating the first beta release, focus on behavior that affects real dashboards, automations, and update flows:
+When validating a beta release, focus on the changed areas listed in its release notes and the behavior that affects real dashboards, automations, and update flows:
 
 1. Installing and switching between stable and beta through HACS.
 2. Public live timing without F1TV Auth.
 3. Optional F1TV Auth setup and renewal through the Token Helper.
 4. Track Map behavior in live sessions and Replay Mode.
 5. Incident Detection wording, confidence, and notification timing.
-6. Replay Mode controls, including the 30-second catch-up buttons.
+6. Replay Mode controls, including the seek bar and 30-second buttons.
 7. Bundled Live Data Cards after restart and browser reload.
 
 ## Enable debug logging

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -142,9 +142,9 @@ This is expected behavior. The live sensors only update shortly before, during, 
 
 Yes. The integration includes [**Replay Mode**](/features/replay-mode), which lets you play back historical sessions with full Home Assistant integration. When you watch a recorded race from F1 TV or another service, your automations and dashboards can follow the replay much more like a live broadcast.
 
-Replay Mode now also includes experimental 30-second catch-up controls in Version 1. You can use **Back 30 seconds** and **Forward 30 seconds** to manually line up the replay with your broadcaster if the timing drifts.
+Replay Mode includes a draggable seek bar and **Back 30 seconds** and **Forward 30 seconds** controls. Use them to line up Home Assistant with your broadcaster if the timing drifts.
 
-This catch-up feature is still experimental, so more refinement may be needed as development continues.
+Seeking backward can replay historical state changes, so replay-driven automations, notifications, and incident alerts may run again.
 
 If you want to avoid spoilers before watching, turn on [**No Spoiler Mode**](/features/no-spoiler-mode) before the session starts. Your dashboard stays frozen until you are ready. Then load the session in Replay Mode and experience everything as if it were live.
 


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
