### PR TITLE
Feature/font style

### DIFF
--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -998,7 +998,7 @@ const renderFontStyleSelect = (editor) => renderEditorSelect(
     value: option.value,
     label: option.label,
   })),
-  'Controls card typography. Wide keeps the original look; Balanced improves compact/mobile readability; System uses the Home Assistant font.',
+  'Controls card typography. Wide uses F1 wide styling. Balanced reduces wide-font usage. System uses Home Assistant font.',
 );
 
 const renderThemeModeSelect = (editor) => html`

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -17881,7 +17881,7 @@ class F1NextRaceCard extends LitElement {
 
     .nr-countdown-inline {
       font-size: clamp(13px, 1.7vw, 17px);
-      letter-spacing: var(--f1-card-display-letter-spacing, 0.03em);
+      letter-spacing: var(--f1-card-display-letter-spacing, normal);
     }
 
     .nr-countdown-meta,
@@ -18012,7 +18012,7 @@ class F1NextRaceCard extends LitElement {
       font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(15px, 2vw, 19px);
       line-height: 1.05;
-      letter-spacing: var(--f1-card-display-letter-spacing, 0.03em);
+      letter-spacing: var(--f1-card-display-letter-spacing, normal);
       color: var(--nr-text);
       white-space: nowrap;
     }

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -38,17 +38,53 @@ const ensureF1Fonts = () => {
 
 const F1_THEME_MODES = ['dark', 'light', 'auto'];
 const DEFAULT_F1_THEME_MODE = 'dark';
+const DEFAULT_FONT_STYLE = 'wide';
+const FONT_STYLE_OPTIONS = [
+  {
+    value: 'wide',
+    label: 'Wide',
+    description: 'Original F1 Sensor typography.',
+  },
+  {
+    value: 'balanced',
+    label: 'Balanced',
+    description: 'F1-inspired style with improved readability on compact/mobile layouts.',
+  },
+  {
+    value: 'system',
+    label: 'System',
+    description: 'Use the Home Assistant/system font.',
+  },
+];
+const VALID_FONT_STYLES = new Set(FONT_STYLE_OPTIONS.map((option) => option.value));
 
 const normalizeThemeMode = (mode) => {
   const value = String(mode || DEFAULT_F1_THEME_MODE).toLowerCase();
   return F1_THEME_MODES.includes(value) ? value : DEFAULT_F1_THEME_MODE;
 };
 
+const normalizeFontStyle = (value) => {
+  const normalized = String(value || '').trim().toLowerCase();
+  return VALID_FONT_STYLES.has(normalized) ? normalized : DEFAULT_FONT_STYLE;
+};
+
+const normalizeSharedCardConfig = (config = {}) => ({
+  ...config,
+  font_style: normalizeFontStyle(config?.font_style),
+});
+
 const applyF1ThemeMode = (element, config, hass = null) => {
   const mode = normalizeThemeMode(config?.theme_mode);
   if (config) config.theme_mode = mode;
   element.dataset.themeMode = mode;
   element.dataset.effectiveTheme = isEffectiveLightTheme(hass, config) ? 'light' : 'dark';
+};
+
+const applyFontStyleAttribute = (element, config) => {
+  const fontStyle = normalizeFontStyle(config?.font_style);
+  if (element.getAttribute('data-font-style') !== fontStyle) {
+    element.setAttribute('data-font-style', fontStyle);
+  }
 };
 
 const isEffectiveLightTheme = (hass, config) => {
@@ -232,6 +268,31 @@ const F1_THEME_STYLES = css`
     --f1-timing-personal-fastest-text: #86efac;
     --f1-timing-timed-bg: rgba(234, 179, 8, 0.14);
     --f1-timing-timed-text: #fde047;
+    --f1-font-system: var(--primary-font-family, Roboto, Arial, sans-serif);
+    --f1-font-brand-display: "Formula1 Display", "Titillium Web", var(--f1-font-system);
+    --f1-font-brand-wide: "Formula1 Wide", "Formula1 Display", "Titillium Web", var(--f1-font-system);
+  }
+
+  :host([data-font-style='balanced']) {
+    --f1-card-body-font-family: var(--f1-font-system);
+    --f1-card-heading-font-family: var(--f1-font-brand-display);
+    --f1-card-display-font-family: var(--f1-font-brand-display);
+    --f1-card-table-font-family: var(--f1-font-system);
+    --f1-card-label-font-family: var(--f1-font-system);
+    --f1-card-heading-letter-spacing: 0.03em;
+    --f1-card-display-letter-spacing: 0.01em;
+    --f1-card-label-letter-spacing: 0.04em;
+  }
+
+  :host([data-font-style='system']) {
+    --f1-card-body-font-family: var(--f1-font-system);
+    --f1-card-heading-font-family: var(--f1-font-system);
+    --f1-card-display-font-family: var(--f1-font-system);
+    --f1-card-table-font-family: var(--f1-font-system);
+    --f1-card-label-font-family: var(--f1-font-system);
+    --f1-card-heading-letter-spacing: normal;
+    --f1-card-display-letter-spacing: normal;
+    --f1-card-label-letter-spacing: normal;
   }
 
   :host([data-theme-mode='light']) {
@@ -375,7 +436,7 @@ const F1_THEME_STYLES = css`
   .f1-no-spoiler-title {
     max-width: 300px;
     color: var(--f1-card-text);
-    font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+    font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
     font-size: 16px;
     font-weight: 700;
     letter-spacing: 0;
@@ -929,17 +990,69 @@ const renderEditorSelect = (editor, name, label, options, helper = null) => {
   `;
 };
 
-const renderThemeModeSelect = (editor) => renderEditorSelect(
+const renderFontStyleSelect = (editor) => renderEditorSelect(
   editor,
-  'theme_mode',
-  'Theme mode',
-  [
-    { value: 'dark', label: 'Dark (default)' },
-    { value: 'light', label: 'Light' },
-    { value: 'auto', label: 'Follow Home Assistant theme' },
-  ],
-  'Default keeps the current dark F1 style for existing cards.',
+  'font_style',
+  'Font style',
+  FONT_STYLE_OPTIONS.map((option) => ({
+    value: option.value,
+    label: option.label,
+  })),
+  'Controls card typography. Wide keeps the original look; Balanced improves compact/mobile readability; System uses the Home Assistant font.',
 );
+
+const renderThemeModeSelect = (editor) => html`
+  ${renderEditorSelect(
+    editor,
+    'theme_mode',
+    'Theme mode',
+    [
+      { value: 'dark', label: 'Dark (default)' },
+      { value: 'light', label: 'Light' },
+      { value: 'auto', label: 'Follow Home Assistant theme' },
+    ],
+    'Default keeps the current dark F1 style for existing cards.',
+  )}
+  ${renderFontStyleSelect(editor)}
+`;
+
+const installFontStyleSupport = (CardClass) => {
+  if (!CardClass?.prototype || CardClass.prototype._f1FontStyleSupportInstalled) {
+    return;
+  }
+
+  const proto = CardClass.prototype;
+  const originalSetConfig = proto.setConfig;
+  const originalConnectedCallback = proto.connectedCallback;
+  const originalUpdated = proto.updated;
+
+  proto.setConfig = function setConfig(config = {}) {
+    const normalizedConfig = normalizeSharedCardConfig(config);
+    if (typeof originalSetConfig === 'function') {
+      originalSetConfig.call(this, normalizedConfig);
+    } else {
+      this.config = normalizedConfig;
+    }
+    this.config = normalizeSharedCardConfig(this.config || normalizedConfig);
+    applyFontStyleAttribute(this, this.config);
+  };
+
+  proto.connectedCallback = function connectedCallback(...args) {
+    if (typeof originalConnectedCallback === 'function') {
+      originalConnectedCallback.call(this, ...args);
+    }
+    applyFontStyleAttribute(this, this.config);
+  };
+
+  proto.updated = function updated(changed, ...args) {
+    if (typeof originalUpdated === 'function') {
+      originalUpdated.call(this, changed, ...args);
+    }
+    applyFontStyleAttribute(this, this.config);
+  };
+
+  proto._f1FontStyleSupportInstalled = true;
+};
 
 const DELTA_PILL = {
   HARD: 'linear-gradient(135deg, #6b1b6b, #32133e)',
@@ -1737,7 +1850,7 @@ class F1TyreStatisticsCard extends LitElement {
       --ts-chip: var(--f1-card-chip);
       --ts-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -1762,7 +1875,7 @@ class F1TyreStatisticsCard extends LitElement {
 
     .ts-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.6vw, 22px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -1816,7 +1929,7 @@ class F1TyreStatisticsCard extends LitElement {
     }
 
     .ts-compound-name {
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(12px, 3.2cqw, 22px);
       font-weight: 700;
       letter-spacing: clamp(0.05em, 0.08em, 0.1em);
@@ -2437,7 +2550,7 @@ class F1PitStopOverviewCard extends LitElement {
       --ts-chip: var(--f1-card-chip);
       --ts-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -2466,7 +2579,7 @@ class F1PitStopOverviewCard extends LitElement {
 
     .ps-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -2574,7 +2687,7 @@ class F1PitStopOverviewCard extends LitElement {
     .ps-tla.full-name {
       letter-spacing: 0.01em;
       text-transform: none;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-weight: 600;
     }
 
@@ -3892,7 +4005,7 @@ class F1DriverLapTimesCard extends LitElement {
       --ts-chip: var(--f1-card-chip);
       --ts-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -3931,7 +4044,7 @@ class F1DriverLapTimesCard extends LitElement {
 
     .dl-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -4120,7 +4233,7 @@ class F1DriverLapTimesCard extends LitElement {
     .dl-tla.full-name {
       letter-spacing: 0.01em;
       text-transform: none;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-weight: 600;
     }
 
@@ -5211,7 +5324,7 @@ class F1ChampionshipPredictionDriversCard extends LitElement {
       --ts-chip: var(--f1-card-chip);
       --ts-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -5236,7 +5349,7 @@ class F1ChampionshipPredictionDriversCard extends LitElement {
 
     .cpd-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -5421,7 +5534,7 @@ class F1ChampionshipPredictionDriversCard extends LitElement {
     .cpd-driver.full {
       letter-spacing: 0.01em;
       text-transform: none;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-weight: 600;
     }
 
@@ -6369,7 +6482,7 @@ class F1ChampionshipPredictionTeamsCard extends LitElement {
       --ts-chip: var(--f1-card-chip);
       --ts-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -6394,7 +6507,7 @@ class F1ChampionshipPredictionTeamsCard extends LitElement {
 
     .cpt-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -7461,7 +7574,7 @@ class F1SeasonProgressionCard extends LitElement {
         --sp-panel-soft: var(--f1-card-panel-soft, color-mix(in srgb, var(--primary-text-color, #111827) 3%, transparent));
         --sp-shadow: var(--f1-card-shadow, var(--ha-card-box-shadow, 0 12px 30px rgba(15, 23, 42, 0.14)));
         --sp-chart-height: 320px;
-        font-family: "Formula1 Display", "Noto Sans", system-ui, sans-serif;
+        font-family: var(--f1-card-body-font-family, "Formula1 Display", "Noto Sans", system-ui, sans-serif);
       }
 
       ha-card {
@@ -7571,7 +7684,7 @@ class F1SeasonProgressionCard extends LitElement {
 
       .sp-axis-label {
         fill: var(--sp-muted);
-        font-family: "Formula1 Display", "Noto Sans", system-ui, sans-serif;
+        font-family: var(--f1-card-body-font-family, "Formula1 Display", "Noto Sans", system-ui, sans-serif);
         font-size: 10px;
         font-weight: 700;
         letter-spacing: 0;
@@ -9114,7 +9227,7 @@ class F1LapPositionProgressionCard extends LitElement {
         --lp-panel-soft: var(--f1-card-panel-soft, color-mix(in srgb, var(--primary-text-color, #111827) 3%, transparent));
         --lp-shadow: var(--f1-card-shadow, var(--ha-card-box-shadow, 0 12px 30px rgba(15, 23, 42, 0.14)));
         --lp-chart-height: 320px;
-        font-family: "Formula1 Display", "Noto Sans", system-ui, sans-serif;
+        font-family: var(--f1-card-body-font-family, "Formula1 Display", "Noto Sans", system-ui, sans-serif);
       }
 
       ha-card {
@@ -9272,7 +9385,7 @@ class F1LapPositionProgressionCard extends LitElement {
 
       .lp-axis-label {
         fill: var(--lp-muted);
-        font-family: "Formula1 Display", "Noto Sans", system-ui, sans-serif;
+        font-family: var(--f1-card-body-font-family, "Formula1 Display", "Noto Sans", system-ui, sans-serif);
         font-size: 10px;
         font-weight: 700;
         letter-spacing: 0;
@@ -9280,7 +9393,7 @@ class F1LapPositionProgressionCard extends LitElement {
 
       .lp-side-heading {
         fill: var(--lp-muted);
-        font-family: "Formula1 Display", "Noto Sans", system-ui, sans-serif;
+        font-family: var(--f1-card-body-font-family, "Formula1 Display", "Noto Sans", system-ui, sans-serif);
         font-size: 10px;
         font-weight: 800;
         letter-spacing: 0;
@@ -9288,7 +9401,7 @@ class F1LapPositionProgressionCard extends LitElement {
 
       .lp-side-label {
         fill: var(--lp-text);
-        font-family: "Formula1 Display", "Noto Sans", system-ui, sans-serif;
+        font-family: var(--f1-card-body-font-family, "Formula1 Display", "Noto Sans", system-ui, sans-serif);
         font-size: 10px;
         font-weight: 800;
         letter-spacing: 0;
@@ -9296,7 +9409,7 @@ class F1LapPositionProgressionCard extends LitElement {
 
       .lp-side-position {
         fill: var(--lp-muted);
-        font-family: "Formula1 Display", "Noto Sans", system-ui, sans-serif;
+        font-family: var(--f1-card-body-font-family, "Formula1 Display", "Noto Sans", system-ui, sans-serif);
         font-size: 9px;
         font-weight: 800;
         letter-spacing: 0;
@@ -11737,7 +11850,7 @@ class F1LastRaceResultsCard extends LitElement {
       --ts-chip: var(--f1-card-chip);
       --ts-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -11762,7 +11875,7 @@ class F1LastRaceResultsCard extends LitElement {
 
     .cpd-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -11952,7 +12065,7 @@ class F1LastRaceResultsCard extends LitElement {
     .cpd-driver.full {
       letter-spacing: 0.01em;
       text-transform: none;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-weight: 600;
     }
 
@@ -12069,7 +12182,7 @@ class F1LastRaceResultsCard extends LitElement {
       background: var(--f1-card-chip);
       color: var(--ts-text);
       padding: 6px 34px 6px 10px;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: 12px;
       font-weight: 700;
       letter-spacing: 0.02em;
@@ -12843,7 +12956,7 @@ class F1InvestigationsCard extends LitElement {
       --ts-chip: var(--f1-card-chip);
       --ts-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -12868,7 +12981,7 @@ class F1InvestigationsCard extends LitElement {
 
     .inv-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -12941,7 +13054,7 @@ class F1InvestigationsCard extends LitElement {
     .inv-tla.full-name {
       letter-spacing: 0.01em;
       text-transform: none;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-weight: 600;
     }
 
@@ -13724,7 +13837,7 @@ class F1TrackLimitsCard extends LitElement {
       --ts-chip: var(--f1-card-chip);
       --ts-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -13749,7 +13862,7 @@ class F1TrackLimitsCard extends LitElement {
 
     .tl-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -13824,7 +13937,7 @@ class F1TrackLimitsCard extends LitElement {
     .tl-tla.full-name {
       letter-spacing: 0.01em;
       text-transform: none;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-weight: 600;
     }
 
@@ -14543,7 +14656,7 @@ class F1LiveSessionCard extends LitElement {
     }
 
     .ls-card {
-      font-family: 'Formula1 Display', 'Titillium Web', Arial, sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       display: flex;
       flex-direction: column;
       gap: clamp(8px, 1.5vw, 12px);
@@ -14588,7 +14701,7 @@ class F1LiveSessionCard extends LitElement {
     }
 
     .ls-gp-name {
-      font-family: 'Formula1 Wide', 'Formula1 Display', Arial, sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', Arial, sans-serif);
       font-weight: 600;
       font-size: clamp(13px, 2.2vw, 16px);
       letter-spacing: 0.02em;
@@ -14677,7 +14790,7 @@ class F1LiveSessionCard extends LitElement {
       align-items: center;
       padding: clamp(4px, 0.7vw, 6px) clamp(10px, 1.5vw, 14px);
       border-radius: 20px;
-      font-family: 'Formula1 Display', Arial, sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', Arial, sans-serif);
       font-weight: 700;
       font-size: clamp(9px, 1.3vw, 11px);
       text-transform: uppercase;
@@ -14768,7 +14881,7 @@ class F1LiveSessionCard extends LitElement {
     }
 
     .ls-weather-value {
-      font-family: 'Formula1 Display', Arial, sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', Arial, sans-serif);
       font-weight: 700;
       font-size: clamp(11px, 1.5vw, 13px);
       white-space: normal;
@@ -14810,7 +14923,7 @@ class F1LiveSessionCard extends LitElement {
     }
 
 	    .ls-time-value {
-	      font-family: 'Formula1 Display', Arial, sans-serif;
+	      font-family: var(--f1-card-body-font-family, 'Formula1 Display', Arial, sans-serif);
 	      font-weight: 700;
 	      font-size: clamp(11px, 1.5vw, 13px);
 	      color: var(--ls-text);
@@ -16309,7 +16422,7 @@ class F1ReplayControlCard extends LitElement {
     }
 
     .rc-card {
-      font-family: 'Formula1 Display', 'Titillium Web', Arial, sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       display: flex;
       flex-direction: column;
       gap: 10px;
@@ -16345,7 +16458,7 @@ class F1ReplayControlCard extends LitElement {
     }
 
     .rc-title {
-      font-family: 'Formula1 Wide', 'Formula1 Display', Arial, sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', Arial, sans-serif);
       font-weight: 600;
       font-size: 14px;
       letter-spacing: 0.018em;
@@ -17658,7 +17771,7 @@ class F1NextRaceCard extends LitElement {
     .nr-card {
       position: relative;
       overflow: hidden;
-      font-family: 'Formula1 Display', 'Titillium Web', Arial, sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       display: flex;
       flex-direction: column;
       gap: clamp(6px, 1vw, 10px);
@@ -17717,10 +17830,10 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-title {
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-heading-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(14px, 2vw, 18px);
       line-height: 1.06;
-      letter-spacing: 0.02em;
+      letter-spacing: var(--f1-card-heading-letter-spacing, 0.02em);
       text-wrap: balance;
       margin: 0;
     }
@@ -17733,7 +17846,7 @@ class F1NextRaceCard extends LitElement {
       font-size: clamp(9px, 1.15vw, 11px);
       color: var(--nr-muted);
       text-transform: uppercase;
-      letter-spacing: 0.05em;
+      letter-spacing: var(--f1-card-label-letter-spacing, 0.05em);
     }
 
     .nr-countdown-compact {
@@ -17761,14 +17874,14 @@ class F1NextRaceCard extends LitElement {
 
     .nr-countdown-inline,
     .nr-metric-value {
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       line-height: 1.05;
       white-space: nowrap;
     }
 
     .nr-countdown-inline {
       font-size: clamp(13px, 1.7vw, 17px);
-      letter-spacing: 0.03em;
+      letter-spacing: var(--f1-card-display-letter-spacing, 0.03em);
     }
 
     .nr-countdown-meta,
@@ -17789,9 +17902,10 @@ class F1NextRaceCard extends LitElement {
     .nr-section-label,
     .nr-weather-label,
     .nr-history-label {
+      font-family: var(--f1-card-label-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       font-size: 8px;
       font-weight: 700;
-      letter-spacing: 0.12em;
+      letter-spacing: var(--f1-card-label-letter-spacing, 0.12em);
       text-transform: uppercase;
       color: var(--nr-soft);
     }
@@ -17841,9 +17955,9 @@ class F1NextRaceCard extends LitElement {
 
     .nr-section-title,
     .nr-mini-title {
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-heading-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(10px, 1vw, 11px);
-      letter-spacing: 0.05em;
+      letter-spacing: var(--f1-card-heading-letter-spacing, 0.05em);
       margin: 0;
       text-transform: uppercase;
       color: var(--nr-text);
@@ -17895,9 +18009,10 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-summary-countdown-value {
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(15px, 2vw, 19px);
       line-height: 1.05;
+      letter-spacing: var(--f1-card-display-letter-spacing, 0.03em);
       color: var(--nr-text);
       white-space: nowrap;
     }
@@ -17981,11 +18096,12 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-schedule-head {
+      font-family: var(--f1-card-label-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       padding: 0 0 4px;
       border-bottom: 1px solid var(--f1-card-divider);
       font-size: 8px;
       font-weight: 700;
-      letter-spacing: 0.12em;
+      letter-spacing: var(--f1-card-label-letter-spacing, 0.12em);
       text-transform: uppercase;
       color: var(--nr-soft);
     }
@@ -18025,6 +18141,7 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-schedule-cell {
+      font-family: var(--f1-card-table-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       min-width: 0;
       font-size: 10px;
       color: var(--nr-text);
@@ -18090,9 +18207,10 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-schedule-inline-time label {
+      font-family: var(--f1-card-label-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       font-size: 8px;
       color: var(--nr-soft);
-      letter-spacing: 0.08em;
+      letter-spacing: var(--f1-card-label-letter-spacing, 0.08em);
       text-transform: uppercase;
     }
 
@@ -18264,9 +18382,10 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-weather-row-label {
+      font-family: var(--f1-card-label-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       font-size: 8px;
       font-weight: 700;
-      letter-spacing: 0.1em;
+      letter-spacing: var(--f1-card-label-letter-spacing, 0.1em);
       text-transform: uppercase;
       color: var(--nr-soft);
     }
@@ -18365,7 +18484,7 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-map-fallback-title {
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(11px, 1.4vw, 14px);
       line-height: 1;
       max-width: 14ch;
@@ -18379,6 +18498,7 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-chip {
+      font-family: var(--f1-card-label-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       display: inline-flex;
       align-items: center;
       gap: 4px;
@@ -18386,7 +18506,7 @@ class F1NextRaceCard extends LitElement {
       border-radius: 999px;
       font-size: 8px;
       font-weight: 700;
-      letter-spacing: 0.1em;
+      letter-spacing: var(--f1-card-label-letter-spacing, 0.1em);
       text-transform: uppercase;
       color: var(--nr-text);
       background: var(--f1-card-chip);
@@ -18475,10 +18595,11 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-time-line span {
+      font-family: var(--f1-card-label-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       font-size: 8px;
       color: var(--nr-muted);
       text-transform: uppercase;
-      letter-spacing: 0.08em;
+      letter-spacing: var(--f1-card-label-letter-spacing, 0.08em);
     }
 
     .nr-time-line strong {
@@ -18570,6 +18691,7 @@ class F1NextRaceCard extends LitElement {
     }
 
     .nr-history-toggle {
+      font-family: var(--f1-card-label-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -18582,7 +18704,7 @@ class F1NextRaceCard extends LitElement {
       font: inherit;
       font-size: 9px;
       font-weight: 700;
-      letter-spacing: 0.06em;
+      letter-spacing: var(--f1-card-label-letter-spacing, 0.06em);
       text-transform: uppercase;
       cursor: pointer;
     }
@@ -20538,7 +20660,7 @@ class F1SeasonCalendarCard extends LitElement {
       --sc-shadow: var(--f1-card-shadow);
       --sc-panel: var(--f1-card-panel);
       display: block;
-      font-family: 'Formula1 Display', 'Titillium Web', Arial, sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
     }
 
     ha-card {
@@ -20602,7 +20724,7 @@ class F1SeasonCalendarCard extends LitElement {
 
     .sc-title {
       margin: 0;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(14px, 2vw, 18px);
       line-height: 1.06;
       letter-spacing: 0.02em;
@@ -20774,7 +20896,7 @@ class F1SeasonCalendarCard extends LitElement {
     }
 
     .sc-date {
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: 10px;
       line-height: 1.1;
       color: var(--sc-text);
@@ -21382,7 +21504,7 @@ class F1RaceControlCard extends LitElement {
     }
 
     .rc-card {
-      font-family: 'Formula1 Display', 'Titillium Web', Arial, sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       display: flex;
       align-items: center;
       flex-wrap: wrap;
@@ -21497,7 +21619,7 @@ class F1RaceControlCard extends LitElement {
     }
 
     .rc-list-shell {
-      font-family: 'Formula1 Display', 'Titillium Web', Arial, sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       border-radius: var(--ha-card-border-radius, 12px);
       background:
         radial-gradient(circle at 10% 20%, var(--f1-card-panel), transparent 40%),
@@ -22932,7 +23054,7 @@ class F1FiaDocumentsCard extends LitElement {
       --fd-shadow: var(--f1-card-compact-shadow);
       --fd-red: #ff3b30;
       display: block;
-      font-family: 'Formula1 Display', 'Titillium Web', Arial, sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
     }
 
     ha-card {
@@ -24050,7 +24172,7 @@ class F1QualifyingTimingCard extends LitElement {
       --qt-chip: var(--f1-card-chip);
       --qt-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -24088,7 +24210,7 @@ class F1QualifyingTimingCard extends LitElement {
 
     .qt-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -24109,7 +24231,7 @@ class F1QualifyingTimingCard extends LitElement {
       background: rgba(139, 92, 246, 0.22);
       border: 1px solid rgba(139, 92, 246, 0.45);
       color: #d8b4fe;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(13px, 2vw, 16px);
       font-weight: 700;
       letter-spacing: 0.06em;
@@ -24195,7 +24317,7 @@ class F1QualifyingTimingCard extends LitElement {
     .qt-tla.full-name {
       letter-spacing: 0.01em;
       text-transform: none;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-weight: 600;
     }
 
@@ -25665,7 +25787,7 @@ class F1PracticeTimingCard extends LitElement {
       --pt-chip: var(--f1-card-chip);
       --pt-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -25702,7 +25824,7 @@ class F1PracticeTimingCard extends LitElement {
 
     .pt-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -25798,7 +25920,7 @@ class F1PracticeTimingCard extends LitElement {
     .pt-driver.full-name {
       letter-spacing: 0.01em;
       text-transform: none;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-weight: 600;
     }
 
@@ -26977,7 +27099,7 @@ class F1RaceLapCard extends LitElement {
       --rl-chip: var(--f1-card-chip);
       --rl-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -27015,7 +27137,7 @@ class F1RaceLapCard extends LitElement {
 
     .rl-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -27142,7 +27264,7 @@ class F1RaceLapCard extends LitElement {
     .rl-driver.full-name {
       letter-spacing: 0.01em;
       text-transform: none;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
       font-weight: 600;
     }
 
@@ -28432,7 +28554,7 @@ class F1StartingGridCard extends LitElement {
       --sg-chip: var(--f1-card-chip);
       --sg-shadow: var(--f1-card-shadow);
       display: block;
-      font-family: 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Noto Sans', sans-serif);
     }
 
     ha-card {
@@ -28479,7 +28601,7 @@ class F1StartingGridCard extends LitElement {
 
     .sg-header {
       text-align: center;
-      font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
       font-size: clamp(16px, 2.4vw, 20px);
       font-weight: 700;
       letter-spacing: clamp(0.03em, 0.06em, 0.08em);
@@ -29821,7 +29943,7 @@ class F1TrackMapCard extends LitElement {
     css`
       :host {
         display: block;
-        font-family: 'Formula1 Display', 'Titillium Web', Arial, sans-serif;
+        font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
       }
 
       ha-card {
@@ -29912,7 +30034,7 @@ class F1TrackMapCard extends LitElement {
       }
 
       .tm-title {
-        font-family: 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif;
+        font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
         font-size: clamp(16px, 2.4vw, 20px);
         font-weight: 700;
         line-height: 1.1;
@@ -30864,7 +30986,10 @@ class F1TrackMapCard extends LitElement {
       if (label) {
         const alignRight = canvasWidth > 0 && xy.x > canvasWidth - 54;
         const labelX = xy.x + (alignRight ? -9 : 9);
-        ctx.font = '700 11px "Formula1 Display", sans-serif';
+        const labelFontFamily = getComputedStyle(this)
+          .getPropertyValue('--f1-card-label-font-family')
+          .trim() || '"Formula1 Display", sans-serif';
+        ctx.font = `700 11px ${labelFontFamily}`;
         ctx.textAlign = alignRight ? 'right' : 'left';
         ctx.textBaseline = 'middle';
         ctx.fillStyle = '#f6f8fb';
@@ -31623,6 +31748,32 @@ installSectionsAutoHeight(F1TrackMapCard, {
   max_columns: 12,
   min_rows: 3,
 });
+
+const F1_FONT_STYLE_CARD_CLASSES = [
+  F1TyreStatisticsCard,
+  F1PitStopOverviewCard,
+  F1DriverLapTimesCard,
+  F1ChampionshipPredictionDriversCard,
+  F1ChampionshipPredictionTeamsCard,
+  F1SeasonProgressionCard,
+  F1LastRaceResultsCard,
+  F1LapPositionProgressionCard,
+  F1InvestigationsCard,
+  F1TrackLimitsCard,
+  F1LiveSessionCard,
+  F1ReplayControlCard,
+  F1NextRaceCard,
+  F1SeasonCalendarCard,
+  F1RaceControlCard,
+  F1FiaDocumentsCard,
+  F1QualifyingTimingCard,
+  F1PracticeTimingCard,
+  F1RaceLapCard,
+  F1StartingGridCard,
+  ...(typeof F1TrackMapCard === 'undefined' ? [] : [F1TrackMapCard]),
+];
+
+F1_FONT_STYLE_CARD_CLASSES.forEach(installFontStyleSupport);
 
 const F1_NO_SPOILER_CARD_CLASSES = [
   F1TyreStatisticsCard,

--- a/docs/cards/overview.md
+++ b/docs/cards/overview.md
@@ -113,6 +113,15 @@ lovelace:
 
 Each card has a visual editor with **Data Sources** for entity selection and **Display Options** for columns, theme, labels, logos, and layout.
 
+Example:
+
+```yaml
+type: custom:f1-next-race-card
+entity: sensor.f1_next_race
+theme_mode: auto
+font_style: balanced
+```
+
 :::info[Entity IDs]
 The defaults use the standard F1 Sensor entity IDs, such as `sensor.f1_driver_positions`. Older installations may have existing registry IDs from earlier releases. Select the correct entities in the visual editor if your IDs differ.
 :::
@@ -126,6 +135,7 @@ Many cards expose the same display options.
 | Option | Values | Description |
 | --- | --- | --- |
 | `theme_mode` | `dark`, `light`, `auto` | Visual theme. `dark` keeps the original F1 card look, `light` uses a light palette, and `auto` follows the Home Assistant theme. |
+| `font_style` | `wide`, `balanced`, `system` | Typography style. `wide` keeps the original F1 Sensor look, `balanced` keeps an F1-inspired style without the wide font in dense/mobile text, and `system` uses the Home Assistant/system font. |
 | `show_header` | `true`, `false` | Show the card title/header area. |
 | `show_table_header` | `true`, `false` | Show column labels above table-style cards. |
 | `show_full_name` | `true`, `false` | Show full driver names instead of TLA codes where supported. |


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

Adds a shared `font_style` option for the bundled F1 Sensor live data cards, as the current wide font headers were hard to read on my phone.

The new option lets users choose between three typography styles:

- `wide` — preserves the current/original F1 Sensor typography and remains the default.
- `balanced` — keeps an F1-inspired appearance while reducing use of wide display fonts in dense or compact card areas.
- `system` — uses the Home Assistant/system font throughout the card.

This is intended to improve readability on smaller/mobile dashboards without changing the default appearance for existing users.

This also centralizes card typography behind shared CSS variables to use consistent typography model internally.

Example:

```yaml
type: custom:f1-next-race-card
entity: sensor.f1_next_race
font_style: balanced
````

Existing dashboards continue to use the original `wide` style by default, so no user migration is required.


## Related issue

No issue was opened before this PR.

This change is based on mobile dashboard readability problems where the current wide Formula 1 display typography can become difficult to read in compact card layouts.

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [x] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [x] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [x] 🔧 Refactoring or internal cleanup

## How has this been tested?

Tested the new `font_style` option with the bundled live data cards in a local Home Assistant dashboard.

Verified:

- Existing cards without `font_style` still use the original `wide` typography.
- `font_style: wide` preserves the current/original card appearance.
- `font_style: balanced` reduces the use of wide display fonts in compact/dense areas.
- `font_style: system` uses the Home Assistant/system font stack.
- Invalid or missing `font_style` values fall back to `wide`.
- The configured value is applied to the card host as `data-font-style`.
- Dashboard reloads do not produce console errors.
- Mobile/narrow layouts are easier to read with `balanced` and `system`.

Tested cards:

- `custom:f1-next-race-card`
- `custom:f1-season-calendar-card`
- `custom:f1-live-session-card`
- `custom:f1-race-control-card`
- `custom:f1-qualifying-timing-card`
- `custom:f1-practice-timing-card`
- `custom:f1-race-lap-card`
- `custom:f1-starting-grid-card`
- `custom:f1-driver-lap-times-card`

- [x] Tested locally with a real Home Assistant instance
- [x] Existing automations and dashboards still work as expected after the change


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [x] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
