### PR TITLE
v5.2-docs

### DIFF
--- a/blueprints/f1_incident_notifications.yaml
+++ b/blueprints/f1_incident_notifications.yaml
@@ -6,9 +6,8 @@ blueprint:
     Send neutral notifications for F1 Sensor incident alerts.
 
     The automation listens for f1_sensor_incident events and can filter by confidence,
-    session type, and event phase. Notifications use a stable tag based on incident_id
-    so supported notify targets update an existing incident notification instead of
-    creating duplicates for the same incident.
+    session type, and event phase. Notifications use short text by default for TV
+    overlays, with optional details for targets that can show more context.
   domain: automation
   source_url: https://github.com/Nicxe/f1_sensor
   author: Nicxe
@@ -147,13 +146,50 @@ blueprint:
       name: Notification Content
       icon: mdi:message-badge
       collapsed: true
-      description: Customize the generated title.
+      description: Customize the generated title and message text.
       input:
         title_prefix:
           name: Title Prefix
-          default: F1 Incident Alert
+          default: F1 Incident
           selector:
             text: {}
+        message_style:
+          name: Message Style
+          description: Compact is designed for short-lived TV overlays.
+          default: compact
+          selector:
+            select:
+              mode: dropdown
+              options:
+                - label: Compact
+                  value: compact
+                - label: Standard
+                  value: standard
+                - label: Detailed
+                  value: detailed
+        include_confidence_in_message:
+          name: Include Confidence In Message
+          description: Adds Low, Medium, or High to the message text.
+          default: true
+          selector:
+            boolean: {}
+        message_detail_fields:
+          name: Message Detail Fields
+          description: Extra fields for standard messages. Detailed messages include all available fields.
+          default: []
+          selector:
+            select:
+              mode: dropdown
+              multiple: true
+              options:
+                - label: Session
+                  value: session
+                - label: Race control
+                  value: race_control
+                - label: Track status
+                  value: track_status
+                - label: Location
+                  value: location
 
 mode: queued
 max: 10
@@ -175,6 +211,9 @@ variables:
   dnd_start: !input dnd_start_time
   dnd_end: !input dnd_end_time
   title_prefix_input: !input title_prefix
+  message_style_input: !input message_style
+  include_confidence_in_message_input: !input include_confidence_in_message
+  message_detail_fields_input: !input message_detail_fields
 
   incident_id: "{{ trigger.event.data.incident_id | default('', true) | string }}"
   incident_phase: "{{ trigger.event.data.phase | default('', true) | string | lower }}"
@@ -186,40 +225,30 @@ variables:
   track_status: "{{ trigger.event.data.track_status | default({}, true) }}"
   location: "{{ trigger.event.data.location | default({}, true) }}"
   driver_label: >-
-    {% set tla = driver.tla | default('', true) | string | trim %}
-    {% set number = driver.racing_number | default('', true) | string | trim %}
-    {% set name = driver.name | default('', true) | string | trim %}
-    {% if tla %}
-      {{ tla }}
-    {% elif number %}
-      Car {{ number }}
-    {% elif name %}
-      {{ name }}
-    {% else %}
-      a car
-    {% endif %}
+    {%- set tla = driver.tla | default('', true) | string | trim -%}
+    {%- set number = driver.racing_number | default('', true) | string | trim -%}
+    {%- set name = driver.name | default('', true) | string | trim -%}
+    {{ tla if tla else ('Car ' ~ number if number else (name if name else 'a car')) }}
   incident_session_type: >-
     {{ session.session_type | default('unknown', true) | string | lower }}
   incident_session_name: >-
     {{ session.session_name | default('', true) | string | trim }}
   reason_label: >-
-    {% if incident_phase == 'cleared' %}
-      cleared
-    {% elif incident_reason == 'race_control_stopped_with_car_low_speed' %}
-      stopped
-    {% elif incident_reason.startswith('car_low_speed') %}
-      may have stopped
-    {% elif incident_reason == 'timing_stopped' %}
-      stopped
-    {% elif incident_reason == 'race_control' %}
-      race control report
-    {% elif incident_reason == 'track_status' %}
-      track status alert
-    {% elif incident_reason %}
-      {{ incident_reason | replace('_', ' ') }}
-    {% else %}
-      reported
-    {% endif %}
+    {%- if incident_phase == 'cleared' -%}
+    incident cleared
+    {%- elif incident_reason in ['race_control_stopped_with_car_low_speed', 'timing_stopped'] -%}
+    stopped on track
+    {%- elif incident_reason.startswith('car_low_speed') -%}
+    possibly stopped on track
+    {%- elif incident_reason == 'race_control' -%}
+    race control alert
+    {%- elif incident_reason == 'track_status' -%}
+    track status alert
+    {%- elif incident_reason -%}
+    {{ incident_reason | replace('_', ' ') }}
+    {%- else -%}
+    reported
+    {%- endif -%}
   incident_confidence_score: >-
     {% if incident_confidence == 'high' %}
       2
@@ -237,6 +266,17 @@ variables:
       1
     {% else %}
       0
+    {% endif %}
+  confidence_label: >-
+    {{ 'High' if incident_confidence == 'high' else 'Medium' if incident_confidence == 'medium' else 'Low' if incident_confidence == 'low' else 'Unknown' }}
+  confidence_suffix: >-
+    {{ (' (' ~ confidence_label ~ ')') if include_confidence_in_message_input and confidence_label else '' }}
+  message_detail_fields: >-
+    {% set fields = message_detail_fields_input | default([]) %}
+    {% if fields is string %}
+      {{ [fields] if fields else [] }}
+    {% else %}
+      {{ fields }}
     {% endif %}
   phase_ok: >-
     {{
@@ -295,34 +335,44 @@ variables:
   notification_tag: >-
     {{ 'f1_incident_' ~ (incident_id | slugify) if incident_id else 'f1_incident' }}
   notification_title: >-
-    {% set prefix = title_prefix_input | default('F1 Incident Alert', true) | string | trim %}
+    {% set prefix = title_prefix_input | default('F1 Incident', true) | string | trim %}
     {% set confidence = incident_confidence | upper %}
     {% if confidence %}
       {{ prefix ~ ' (' ~ confidence ~ ')' }}
     {% else %}
       {{ prefix }}
     {% endif %}
+  notification_summary: >-
+    {{ ((driver_label | trim) ~ ' ' ~ (reason_label | trim) ~ confidence_suffix) | trim }}
   notification_message: >-
-    {% set base = 'Possible on-track incident: ' ~ driver_label ~ ' ' ~ reason_label %}
-    {% set ns = namespace(lines=[base | trim]) %}
-    {% if incident_session_name %}
-      {% set ns.lines = ns.lines + ['Session: ' ~ incident_session_name] %}
-    {% elif incident_session_type %}
-      {% set ns.lines = ns.lines + ['Session: ' ~ (incident_session_type | title)] %}
-    {% endif %}
-    {% set rc_message = race_control.message | default('', true) | string | trim %}
-    {% if rc_message %}
-      {% set ns.lines = ns.lines + ['Race control: ' ~ rc_message] %}
-    {% endif %}
-    {% set track_message = track_status.message | default('', true) | string | trim %}
-    {% if track_message %}
-      {% set ns.lines = ns.lines + ['Track status: ' ~ track_message] %}
-    {% endif %}
-    {% set location_description = location.description | default('', true) | string | trim %}
-    {% if location_description %}
-      {% set ns.lines = ns.lines + ['Location: ' ~ location_description] %}
-    {% endif %}
-    {{ ns.lines | join('\n') }}
+    {%- set style = message_style_input | default('compact', true) | string | lower -%}
+    {%- if style == 'compact' -%}
+    {{ notification_summary }}
+    {%- else -%}
+      {% set details = message_detail_fields | default([], true) %}
+      {% set include_all_details = style == 'detailed' %}
+      {% set ns = namespace(lines=[notification_summary | trim]) %}
+      {% if include_all_details or 'session' in details %}
+        {% if incident_session_name %}
+          {% set ns.lines = ns.lines + ['Session: ' ~ incident_session_name] %}
+        {% elif incident_session_type %}
+          {% set ns.lines = ns.lines + ['Session: ' ~ (incident_session_type | title)] %}
+        {% endif %}
+      {% endif %}
+      {% set rc_message = race_control.message | default('', true) | string | trim %}
+      {% if rc_message and (include_all_details or 'race_control' in details) %}
+        {% set ns.lines = ns.lines + ['Race control: ' ~ rc_message] %}
+      {% endif %}
+      {% set track_message = track_status.message | default('', true) | string | trim %}
+      {% if track_message and (include_all_details or 'track_status' in details) %}
+        {% set ns.lines = ns.lines + ['Track status: ' ~ track_message] %}
+      {% endif %}
+      {% set location_description = location.description | default('', true) | string | trim %}
+      {% if location_description and (include_all_details or 'location' in details) %}
+        {% set ns.lines = ns.lines + ['Location: ' ~ location_description] %}
+      {% endif %}
+      {{- ns.lines | join('\n') -}}
+    {%- endif -%}
 
 condition:
   - condition: template

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -20,18 +20,18 @@ Start with the [installation guide](/getting-started/installation), then use [co
 
 Most users should install the stable release. See [Release Channels](/getting-started/release-channels) before using beta or `dev` builds.
 
-## Version 5.1
+## Version 5.2
 
-Version 5.1 expands live, replay, dashboard, and automation support:
+Version 5.2 improves the bundled dashboard cards, incident notifications, and live timing sync:
 
-- [Track Map](/features/track-map) adds live and replay circuit maps with driver markers
-- [Incident Detection](/features/incident-detection) adds neutral stopped-car and on-track incident alerts
-- [Incident Notifications](/blueprints/incident-notifications) adds a ready-made notification blueprint with conservative defaults
-- [F1TV Auth](/features/f1tv-auth) becomes a standard optional feature for supported extra live timing data
-- [Replay Mode](/features/replay-mode) adds a draggable seek bar and improved replay state restoration
-- [Live Data Cards](/cards/cards-overview) add lap position and championship progression charts, Track Map, and compact layouts
+- [Live Data Cards](/cards/cards-overview) add configurable font styles for wide, balanced, and system typography
+- Practice and Race timing cards can show optional S1, S2, and S3 sector columns with timing highlights
+- The Race Control card can hide track limits messages without deleting saved Race Control history
+- [Track Map](/features/track-map) now follows [Live Delay](/features/live-delay) during live sessions and handles unavailable position data more clearly
+- [Incident Notifications](/blueprints/incident-notifications) add optional presence, media player, do-not-disturb, and custom activation conditions
+- Weather sensors and cards now match Home Assistant temperature and wind unit preferences more consistently
 
-Version 5.1 also includes reliability fixes for replay controls, practice timing, pit stop and tyre data, next-race updates, expired F1TV access, and consecutive Track Status blueprint alerts.
+Version 5.2 also includes correctness fixes for sector timing alignment, lap position progression finish positions, and post-race position lines in the bundled cards.
 
 ## Features
 

--- a/docs/blueprints/incident-notifications.md
+++ b/docs/blueprints/incident-notifications.md
@@ -78,6 +78,21 @@ Public confirmed incident alerts work without F1TV Auth. F1TV Auth can improve c
 
 Supported notification services receive a stable tag based on `incident_id`. This lets later updates replace the existing notification instead of creating a duplicate.
 
+### Step 4 - Add activation conditions
+
+Activation conditions are optional. Leave them empty if incident notifications should always use the filters above.
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| **Presence Devices** | Empty | If configured, at least one selected device tracker must be `home` |
+| **Media Player Gate** | Empty | If configured, the selected media player must be `on`, `idle`, or `playing` |
+| **Enable Do Not Disturb Window** | Off | Blocks incident notifications during the configured time window |
+| **DND Start Time** | `23:00:00` | Start of the quiet window |
+| **DND End Time** | `07:00:00` | End of the quiet window |
+| **Activation Condition** | Empty | Extra Home Assistant conditions that must pass before a notification is sent |
+
+Use activation conditions when you only want incident alerts while someone is home, while a Formula 1 screen is active, or outside quiet hours.
+
 ## Notification wording
 
 Blueprint messages use neutral wording such as:

--- a/docs/cards/overview.md
+++ b/docs/cards/overview.md
@@ -26,11 +26,11 @@ Public live timing works without F1TV Auth. Cards that show live Track Map, Pit 
 | [F1 Live Session](#f1-live-session-card) | `custom:f1-live-session-card` | Session status, track condition, weather, and lap counter |
 | [F1 Next Race](#f1-next-race-card) | `custom:f1-next-race-card` | Next race countdown, schedule, circuit map, weather, and track time |
 | [F1 Season Calendar](#f1-season-calendar-card) | `custom:f1-season-calendar-card` | Season schedule with past and upcoming races |
-| [F1 Race Control](#f1-race-control-card) | `custom:f1-race-control-card` | Race Control messages and flags |
+| [F1 Race Control](#f1-race-control-card) | `custom:f1-race-control-card` | Race Control messages, flags, and optional message filters |
 | [F1 FIA Documents](#f1-fia-documents-card) | `custom:f1-fia-documents-card` | FIA documents and decision PDFs for the current weekend |
 | [F1 Qualifying Timing](#f1-qualifying-timing-card) | `custom:f1-qualifying-timing-card` | Qualifying order, sector timing, and Q1/Q2/Q3 data |
-| [F1 Practice Timing](#f1-practice-timing-card) | `custom:f1-practice-timing-card` | Practice order, tyre age, lap times, and timing indicators |
-| [F1 Race Lap](#f1-race-lap-card) | `custom:f1-race-lap-card` | Race or sprint order with gaps, tyres, pit stops, and lap times |
+| [F1 Practice Timing](#f1-practice-timing-card) | `custom:f1-practice-timing-card` | Practice order, tyre age, optional sectors, lap times, and timing indicators |
+| [F1 Race Lap](#f1-race-lap-card) | `custom:f1-race-lap-card` | Race or sprint order with gaps, optional sectors, tyres, pit stops, and lap times |
 | [F1 Starting Grid](#f1-starting-grid-card) | `custom:f1-starting-grid-card` | Provisional or confirmed Sprint and Race starting grid |
 | [F1 Last Race Results](#f1-last-race-results-card) | `custom:f1-last-race-results-card` | Race and sprint classifications with grid, delta, points, and status |
 | [F1 Lap Position Progression](#f1-lap-position-progression-card) | `custom:f1-lap-position-progression-card` | Post-race lap-by-lap position chart for completed main races |
@@ -227,7 +227,7 @@ Displays the current season schedule as a compact race list. Past races can be d
 
 `custom:f1-race-control-card`
 
-Shows Race Control messages with category, flag state, and optional FIA branding. It can display only the latest message or a scrollable message list.
+Shows Race Control messages with category, flag state, and optional FIA branding. It can display only the latest message or a scrollable message list, and can hide noisy blue flag or track limits notices from the visible card.
 
 ![Placeholder - F1 Race Control card screenshot](/img/placeholder_card_race_control.png)
 
@@ -239,6 +239,7 @@ Shows Race Control messages with category, flag state, and optional FIA branding
 | `display_mode` | `latest` | Use `latest` for a compact card or `list` for a feed view |
 | `show_fia_logo` | `true` | Show the FIA logo in the header |
 | `hide_blue_flags` | `false` | Hide blue flag messages |
+| `hide_track_limits` | `false` | Hide track limits messages from the banner or list without deleting saved history |
 | `min_display_time` | `0` | Minimum time in milliseconds before rotating to a newer message |
 | `list_max_height` | `600` | Maximum list height in pixels when using list mode |
 | `show_clear_button` | `true` | Show the clear button in list mode |
@@ -304,11 +305,13 @@ This card is designed for Qualifying and Sprint Qualifying. Outside those sessio
 | `show_full_name` | `false` | Show full driver names |
 | `show_delta` | `true` | Show timing delta when available |
 | `show_timing_indicators` | `false` | Highlight overall fastest, personal fastest, and timed sector states |
-| `sector_display_mode` | `current` | Sector display mode used by the visual editor |
+| `sector_display_mode` | `current` | Sector display mode. Use `current`, `personal_best`, or `hybrid` |
 | `team_logo_style` | `color` | Logo appearance |
 | `color_overall_fastest` | card default | Color for overall fastest timing cells |
 | `color_personal_fastest` | card default | Color for personal best timing cells |
 | `color_timed` | card default | Color for normally timed cells |
+
+Current sector mode keeps S1, S2, and S3 aligned with live sector progress. After a lap completes, the completed lap sectors remain visible and dimmed until the driver completes the next S1, so the card does not mix sector times from different laps.
 
 ---
 
@@ -316,7 +319,7 @@ This card is designed for Qualifying and Sprint Qualifying. Outside those sessio
 
 `custom:f1-practice-timing-card`
 
-Shows practice order with driver status, tyres, tyre age, last lap, fastest lap, and optional timing indicators.
+Shows practice order with driver status, tyres, tyre age, optional S1-S3 sectors, last lap, fastest lap, and optional timing indicators.
 
 ![Placeholder - F1 Practice Timing card screenshot](/img/placeholder_card_practice_timing.png)
 
@@ -336,6 +339,7 @@ Shows practice order with driver status, tyres, tyre age, last lap, fastest lap,
 | `show_status` | `true` | Show driver status |
 | `show_tyre` | `true` | Show tyre compound |
 | `show_tyre_age` | `true` | Show tyre stint age |
+| `show_sectors` | `false` | Show optional S1, S2, and S3 live sector columns |
 | `show_last_lap` | `true` | Show last lap |
 | `show_fastest_lap` | `true` | Show personal fastest lap |
 | `show_timing_indicators` | `false` | Highlight timing states |
@@ -347,7 +351,7 @@ Shows practice order with driver status, tyres, tyre age, last lap, fastest lap,
 
 `custom:f1-race-lap-card`
 
-Displays race or sprint order with driver gaps, tyre compound, tyre age, pit count, last lap, and personal fastest lap. Gap mode can show the gap to the leader or interval to the car ahead.
+Displays race or sprint order with driver gaps, tyre compound, tyre age, pit count, optional S1-S3 sectors, last lap, and personal fastest lap. Gap mode can show the gap to the leader or interval to the car ahead.
 
 :::info[Session availability]
 This card is designed for Race and Sprint sessions. Some columns depend on data that is only available during live or authenticated/replay timing.
@@ -375,11 +379,14 @@ This card is designed for Race and Sprint sessions. Some columns depend on data 
 | `show_tyre` | `true` | Show tyre compound |
 | `show_tyre_age` | `true` | Show tyre stint age |
 | `show_pit_count` | `true` | Show number of pit stops |
+| `show_sectors` | `false` | Show optional S1, S2, and S3 live sector columns |
 | `show_last_lap` | `true` | Show last lap time |
 | `show_fastest_lap` | `true` | Show personal fastest lap |
 | `show_timing_indicators` | `false` | Highlight timing states |
 | `team_logo_style` | `color` | Logo appearance |
 | `show_availability_notice` | `true` | Show notices for unavailable F1TV Auth enhanced data |
+
+Practice and Race sector columns use the same live sector handling as Qualifying. Completed lap sectors stay aligned and dimmed until the driver completes the next S1.
 
 ---
 
@@ -487,7 +494,7 @@ top_limit: 10
 | `top_limit` | `0` | Limit visible entries by final position. `0` shows all drivers |
 | `chart_height` | `420` | Chart height in pixels |
 
-The chart places P1 at the top and lap number on the x-axis. Driver labels on the left show the starting order, while the right side shows the current final order for completed races. Select a driver label on either side to hide or show that driver's progression line. Drivers that have classification metadata but no lap timing rows are still listed in the side labels, but they do not draw a progression line. Hover or focus a chart point to see driver, lap, position, race name, and grid-to-finish context when available. Jolpica data is loaded for one selected race at a time and reused from the integration cache where possible.
+The chart places P1 at the top and lap number on the x-axis. Driver labels on the left show the starting order, while the right side shows the official classified finishing order for completed races. Each progression line ends at the driver's classified result, so the chart stays consistent when penalties or other post-race adjustments change the order after the final lap. Select a driver label on either side to hide or show that driver's progression line. Drivers that have classification metadata but no lap timing rows are still listed in the side labels, but they do not draw a progression line. Hover or focus a chart point to see driver, lap, position, race name, and grid-to-finish context when available. Jolpica data is loaded for one selected race at a time and reused from the integration cache where possible.
 
 :::info[Sprint limitation]
 Sprint sessions can appear in the selector so the season context is complete, but Jolpica currently exposes sprint classification results rather than sprint lap-by-lap positions. Those sprint entries render an unsupported state instead of a chart.
@@ -799,6 +806,8 @@ Shows a circuit map with driver markers, optional lap progress, and track status
 :::info[Availability]
 The card needs the F1 Sensor integration, an active live or replay session, and usable Track Map data. During live sessions, car positions require F1TV Auth. During Replay Mode, car positions require archived position data for the loaded session.
 :::
+
+When [Live Delay](/features/live-delay) is configured, live Track Map updates follow the same delay as other live dashboard data. Replay playback remains immediate.
 
 **Required setup:** F1 Sensor integration with live data or Replay Mode enabled
 

--- a/docs/entities/live_data.md
+++ b/docs/entities/live_data.md
@@ -515,12 +515,16 @@ This sensor is active only during sprint and race sessions.
 Live trackside weather from F1 Live Timing. Updates only in direct connection with a session, and remains unchanged otherwise.
 
 **State**
-- Number: air temperature (°C), or `unknown`.
+- Number: air temperature in Home Assistant's selected temperature unit, or `unknown`.
 
 **Example**
 ```text
 18.6
 ```
+
+:::info
+Home Assistant may display the sensor state in another temperature unit, such as Fahrenheit, when your system uses that unit. The weather attributes remain in the documented source units, such as Celsius for temperatures and meters per second for wind speed.
+:::
 
 **Attributes**
 

--- a/docs/entities/static_data.md
+++ b/docs/entities/static_data.md
@@ -332,12 +332,16 @@ Each entry in `Constructors` contains:
 `sensor.f1_weather` - Compact weather for the circuit location: current and projected at race start.
 
 **State**
-- Number: current air temperature (°C), or `unknown`.
+- Number: current air temperature in Home Assistant's selected temperature unit, or `unknown`.
 
 **Example**
 ```text
 18.6
 ```
+
+:::info
+Home Assistant may display the sensor state in another temperature unit, such as Fahrenheit, when your system uses that unit. The weather attributes remain in the documented source units, such as Celsius for temperatures and meters per second for wind speed.
+:::
 
 **Attributes**
 

--- a/docs/features/live-delay.md
+++ b/docs/features/live-delay.md
@@ -3,17 +3,17 @@ id: live-delay
 title: Live Delay, Sync with TV
 ---
 
-The live update delay lets you delay delivery of live messages so they better align with what you see on TV or streaming services.
+The live update delay lets you delay delivery of live messages and live Track Map updates so they better align with what you see on TV or streaming services.
 
 This is especially useful for dashboards and automations, for example flashing lights on a red flag or reacting to safety car deployments, so they happen at the same moment you see them on screen.
 
-### Typical broadcast delays
+## Typical broadcast delays
 
 Actual delays vary by provider, but these ranges are common:
 
-• **Broadcast TV** (satellite, cable, terrestrial): ~5–10 seconds behind
-• **Streaming services**: ~20–45 seconds behind, sometimes more
-• **Sports cable / OTT providers**: ~45–60 seconds or more depending on provider
+- **Broadcast TV** (satellite, cable, terrestrial): about 5-10 seconds behind
+- **Streaming services**: about 20-45 seconds behind, sometimes more
+- **Sports cable / OTT providers**: about 45-60 seconds or more depending on provider
 
 By setting the delay accordingly, Home Assistant can react in sync with the live pictures you are watching.
 :::info[Standard entity IDs]
@@ -42,9 +42,13 @@ During the broadcast, they always show the moment the race clock flips to the st
 
 ## Incident alerts and notifications
 
-Live Delay also applies to likely on-track incident updates. This means `f1_sensor_incident` events, the On-track Incident and Possible On-track Incident binary sensors, and notification blueprints can be delayed to match what you see on TV.
+Live Delay also applies to live Track Map updates and likely on-track incident updates. This means the Track Map card, `f1_sensor_incident` events, the On-track Incident and Possible On-track Incident binary sensors, and notification blueprints can be delayed to match what you see on TV.
 
 Use this when you want a possible stopped-car notification to arrive with the broadcast pictures instead of ahead of them.
+
+:::info
+Replay Mode does not wait for Live Delay. Replay playback and replay Track Map data are shown immediately according to the replay controls.
+:::
 
 
 ---

--- a/docs/features/track-map.md
+++ b/docs/features/track-map.md
@@ -17,9 +17,13 @@ Track Map shows car markers on a circuit map during live or replay sessions. It 
 
 Live Track Map depends on [F1TV Auth](/features/f1tv-auth). Replay Track Map is separate from live auth and can work later from archived replay data when the session archive contains car positions.
 
+During live sessions, Track Map follows the configured [Live Delay](/features/live-delay). This keeps car markers aligned with the rest of the Live Data Cards and with delayed TV or streaming broadcasts. Replay Track Map is not delayed.
+
 ## What to expect
 
 The card shows a circuit outline, driver markers, optional lap progress, and track status context. If the session does not provide usable car positions, the card waits instead of showing misleading locations.
+
+If Formula 1 publishes an invalid position frame, for example a frame that places every on-track car at the same zero coordinates, the card marks position data as unavailable and keeps the last usable markers stale instead of moving every car to the wrong place. It automatically recovers when valid positions return.
 
 Supported circuits can show a map quickly. For newer or unsupported circuits, replay data may need enough usable position updates before the map can be drawn.
 
@@ -67,6 +71,7 @@ The card is bundled with F1 Sensor and is registered with the other [Live Data C
 | `Replay` | Replay Mode is playing Track Map data |
 | `Waiting` | A session is loaded but no car positions are available yet |
 | `Stale` | The latest live position data is too old to trust |
+| `No position data` | Replay position data is unavailable at this point in the loaded session |
 | `No geometry` | Car positions exist but the map outline is not ready |
 | `No session` | No live or replay session is loaded for Track Map |
 | `Not loaded` | The card has not received a Track Map snapshot yet |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "f1-sensor",
-  "version": "5.1",
+  "version": "5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "f1-sensor",
-      "version": "5.1",
+      "version": "5.2",
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/plugin-content-docs": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f1-sensor",
-  "version": "5.1",
+  "version": "5.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
