### PR TITLE
chore: Fix

### DIFF
--- a/blueprints/f1_incident_notifications.yaml
+++ b/blueprints/f1_incident_notifications.yaml
@@ -343,7 +343,16 @@ variables:
       {{ prefix }}
     {% endif %}
   notification_summary: >-
-    {{ ((driver_label | trim) ~ ' ' ~ (reason_label | trim) ~ confidence_suffix) | trim }}
+    {% set confidence = confidence_label | trim %}
+    {{
+      (
+        (driver_label | trim)
+        ~ ' '
+        ~ (reason_label | trim)
+        ~ (' (' ~ confidence ~ ')' if include_confidence_in_message_input and confidence else '')
+      )
+      | trim
+    }}
   notification_message: >-
     {%- set style = message_style_input | default('compact', true) | string | lower -%}
     {%- if style == 'compact' -%}

--- a/custom_components/f1_sensor/tests/test_incident_notifications_blueprint.py
+++ b/custom_components/f1_sensor/tests/test_incident_notifications_blueprint.py
@@ -49,6 +49,8 @@ async def _setup_blueprint_automation(
     media_player_gate: str = "",
     enable_dnd: bool = False,
     activation_condition: list[dict[str, Any]] | None = None,
+    message_style: str = "compact",
+    message_detail_fields: list[str] | None = None,
 ) -> bool:
     config = {
         "automation": [
@@ -72,6 +74,8 @@ async def _setup_blueprint_automation(
                         "dnd_end_time": "07:00:00",
                         "activation_condition": activation_condition or [],
                         "title_prefix": "F1 Incident Test",
+                        "message_style": message_style,
+                        "message_detail_fields": message_detail_fields or [],
                     },
                 },
             }
@@ -162,7 +166,7 @@ async def test_default_incident_notification_is_neutral_and_tagged(
     assert calls == [
         {
             "title": "F1 Incident Test (MEDIUM)",
-            "message": "Possible on-track incident: GAS stopped\nSession: Race",
+            "message": "GAS stopped on track (Medium)",
             "data": {
                 "tag": "f1_incident_2026_miami_race_10_2026_05_03t17_00_01z",
                 "group": "f1_incidents",
@@ -231,9 +235,7 @@ async def test_practice_high_can_pass_when_practice_is_selected(
     )
 
     assert len(calls) == 1
-    assert calls[0]["message"] == (
-        "Possible on-track incident: GAS stopped\nSession: Practice 1"
-    )
+    assert calls[0]["message"] == "GAS stopped on track (High)"
 
 
 @pytest.mark.asyncio
@@ -243,13 +245,17 @@ async def test_incident_notification_includes_optional_location_description(
     await _install_blueprint(hass)
     calls = _register_notification_service(hass)
 
-    assert await _setup_blueprint_automation(hass)
+    assert await _setup_blueprint_automation(
+        hass,
+        message_style="standard",
+        message_detail_fields=["session", "location"],
+    )
     calls.clear()
 
     await _fire_incident(hass, location_description="on track, sector 2")
 
     assert calls[0]["message"] == (
-        "Possible on-track incident: GAS stopped\n"
+        "GAS stopped on track (Medium)\n"
         "Session: Race\n"
         "Location: on track, sector 2"
     )
@@ -273,9 +279,7 @@ async def test_candidate_and_cleared_notifications_are_opt_in(
     await _fire_incident(hass, phase="cleared", confidence="medium")
 
     assert [call["data"]["phase"] for call in calls] == ["candidate", "cleared"]
-    assert calls[1]["message"] == (
-        "Possible on-track incident: GAS cleared\nSession: Race"
-    )
+    assert calls[1]["message"] == "GAS incident cleared (Medium)"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
