### PR TITLE
fix: **Keep live data card track map positions aligned with live delay**

### DIFF
--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -1406,6 +1406,10 @@ async def test_track_time_sensor_exposes_machine_readable_datetimes(
 async def test_next_race_sensor_exposes_circuit_history_attrs(
     hass, monkeypatch
 ) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.helpers.dt_util.utcnow",
+        lambda: datetime(2026, 6, 27, tzinfo=UTC),
+    )
     next_race, payloads = _build_next_race_history_fixture()
     race_coordinator = _build_coordinator(
         hass,
@@ -1532,6 +1536,10 @@ async def test_next_race_sensor_exposes_circuit_history_attrs(
 async def test_next_race_history_last_year_podium_missing_returns_none(
     hass, monkeypatch
 ) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.helpers.dt_util.utcnow",
+        lambda: datetime(2026, 6, 27, tzinfo=UTC),
+    )
     next_race, payloads = _build_next_race_history_fixture(
         include_previous_season=False
     )

--- a/custom_components/f1_sensor/tests/test_track_map_card_config.py
+++ b/custom_components/f1_sensor/tests/test_track_map_card_config.py
@@ -143,9 +143,42 @@ if (payload.motion) {
   card._driverSamples = new Map(
     (motion.samples || []).map(([key, samples]) => [key, samples]),
   );
+  card._driverSampleIntervalMs = motion.driverSampleIntervalMs || 0;
+  card._snapshotIntervalMs = motion.snapshotIntervalMs || 0;
   card._renderClockAt = motion.renderClockAt || 0;
   card._nowMs = () => motion.nowMs;
+  result.driverRenderLag = card._driverRenderLag();
+  result.liveAutoSmoothingDuration = card._liveAutoSmoothingDuration();
+  result.driverRenderTime = card._driverRenderTime();
+  result.motionDisplayDrivers = card._displayDrivers(motion.drivers || []);
   result.hasActiveDriverMotion = card._hasActiveDriverMotion();
+}
+
+if (payload.ingestMotion) {
+  const motion = payload.ingestMotion;
+  card._snapshot = motion.initialSnapshot || null;
+  card._status = motion.status || motion.initialSnapshot?.status || "not_loaded";
+  card._driverSamples = new Map(
+    (motion.samples || []).map(([key, samples]) => [key, samples]),
+  );
+  card._driverSampleIntervalMs = motion.driverSampleIntervalMs || 0;
+  card._snapshotIntervalMs = motion.snapshotIntervalMs || 0;
+  card._renderClockAt = motion.renderClockAt || 0;
+  let nowMs = motion.nowMs;
+  card._nowMs = () => nowMs;
+  result.beforeIngestDisplayDrivers = card._displayDrivers(motion.initialDrivers || []);
+  nowMs = motion.ingestNowMs ?? nowMs;
+  card._snapshot = motion.nextSnapshot || card._snapshot;
+  card._status = motion.status || motion.nextSnapshot?.status || card._status;
+  card._ingestDriverSamples(card._snapshot);
+  result.ingestedSamples = Array.from(card._driverSamples.entries());
+  if (motion.afterNowMs !== undefined) {
+    nowMs = motion.afterNowMs;
+    result.afterIngestDisplayDrivers = card._displayDrivers(
+      motion.nextSnapshot?.drivers || motion.initialDrivers || [],
+    );
+  }
+  result.ingestDriverSampleIntervalMs = card._driverSampleIntervalMs;
 }
 
 process.stdout.write(JSON.stringify(result));
@@ -312,8 +345,8 @@ def test_track_map_card_reports_specific_empty_states() -> None:
     assert waiting_positions["emptyState"]["title"] == "Waiting for live car positions"
 
 
-def test_track_map_card_keeps_live_driver_motion_active_until_latest_sample() -> None:
-    """Live snapshots should keep redrawing while visual smoothing is in flight."""
+def test_track_map_card_keeps_live_auto_motion_during_short_catch_up() -> None:
+    """Live auto smoothing should redraw only during the short catch-up window."""
     samples = [
         [
             "1",
@@ -325,6 +358,21 @@ def test_track_map_card_keeps_live_driver_motion_active_until_latest_sample() ->
     ]
     active_live = _run_probe(
         {
+            "motion": {
+                "nowMs": 2200,
+                "samples": samples,
+                "snapshot": {
+                    "source": "live",
+                    "status": "active",
+                    "stale": False,
+                    "replay_state": None,
+                },
+            },
+        }
+    )
+    explicit_live = _run_probe(
+        {
+            "config": {"interpolation_ms": 900},
             "motion": {
                 "nowMs": 2200,
                 "samples": samples,
@@ -367,8 +415,148 @@ def test_track_map_card_keeps_live_driver_motion_active_until_latest_sample() ->
     )
 
     assert active_live["hasActiveDriverMotion"] is True
+    assert explicit_live["hasActiveDriverMotion"] is True
     assert stale_live["hasActiveDriverMotion"] is False
     assert paused_replay["hasActiveDriverMotion"] is False
+
+
+def test_track_map_card_auto_interpolation_keeps_live_positions_moving() -> None:
+    """Auto marker smoothing should keep live positions moving until the next sample."""
+    motion = {
+        "nowMs": 2100,
+        "driverSampleIntervalMs": 1000,
+        "samples": [
+            [
+                "1",
+                [
+                    {"x": 100, "y": 50, "arrivalAt": 1000},
+                    {"x": 200, "y": 150, "arrivalAt": 2000},
+                ],
+            ]
+        ],
+        "drivers": [
+            {"racing_number": "1", "status": "OnTrack", "x": 200, "y": 150},
+        ],
+        "snapshot": {
+            "source": "live",
+            "status": "active",
+            "stale": False,
+            "replay_state": None,
+        },
+    }
+
+    auto_live = _run_probe({"config": {}, "motion": motion})
+    still_moving_live = _run_probe({"config": {}, "motion": {**motion, "nowMs": 2300}})
+    explicit_live = _run_probe({"config": {"interpolation_ms": 900}, "motion": motion})
+    disabled_live = _run_probe({"config": {"interpolation_ms": 0}, "motion": motion})
+    auto_replay = _run_probe(
+        {
+            "config": {},
+            "motion": {
+                **motion,
+                "snapshot": {
+                    "source": "replay",
+                    "status": "active",
+                    "stale": False,
+                    "replay_state": "playing",
+                },
+            },
+        }
+    )
+
+    assert auto_live["driverRenderLag"] == 0
+    assert auto_live["liveAutoSmoothingDuration"] == 950
+    assert auto_live["driverRenderTime"] == 2100
+    assert auto_live["motionDisplayDrivers"][0]["x"] == pytest.approx(110.526315789)
+    assert auto_live["motionDisplayDrivers"][0]["y"] == pytest.approx(60.526315789)
+    assert auto_live["hasActiveDriverMotion"] is True
+    assert still_moving_live["driverRenderLag"] == 0
+    assert still_moving_live["driverRenderTime"] == 2300
+    assert still_moving_live["motionDisplayDrivers"][0]["x"] == pytest.approx(
+        131.578947368
+    )
+    assert still_moving_live["motionDisplayDrivers"][0]["y"] == pytest.approx(
+        81.578947368
+    )
+    assert still_moving_live["hasActiveDriverMotion"] is True
+    assert explicit_live["driverRenderLag"] == 900
+    assert explicit_live["driverRenderTime"] == 1200
+    assert explicit_live["motionDisplayDrivers"][0]["x"] == pytest.approx(110.4)
+    assert explicit_live["motionDisplayDrivers"][0]["y"] == pytest.approx(60.4)
+    assert disabled_live["driverRenderLag"] == 0
+    assert disabled_live["motionDisplayDrivers"][0]["x"] == 200
+    assert disabled_live["motionDisplayDrivers"][0]["y"] == 150
+    assert disabled_live["hasActiveDriverMotion"] is False
+    assert auto_replay["driverRenderLag"] == 900
+    assert auto_replay["driverRenderTime"] == 1200
+    assert auto_replay["motionDisplayDrivers"][0]["x"] == pytest.approx(110.4)
+    assert auto_replay["motionDisplayDrivers"][0]["y"] == pytest.approx(60.4)
+
+
+def test_track_map_card_live_sample_starts_from_current_rendered_position() -> None:
+    """Early live samples should continue from the current visual position."""
+    result = _run_probe(
+        {
+            "config": {},
+            "ingestMotion": {
+                "nowMs": 2300,
+                "ingestNowMs": 2300,
+                "afterNowMs": 2300,
+                "driverSampleIntervalMs": 1000,
+                "samples": [
+                    [
+                        "1",
+                        [
+                            {"x": 100, "y": 50, "arrivalAt": 1000},
+                            {
+                                "x": 200,
+                                "y": 150,
+                                "arrivalAt": 2000,
+                                "timestampKey": "old",
+                            },
+                        ],
+                    ]
+                ],
+                "initialDrivers": [
+                    {"racing_number": "1", "status": "OnTrack", "x": 200, "y": 150},
+                ],
+                "initialSnapshot": {
+                    "source": "live",
+                    "status": "active",
+                    "stale": False,
+                    "replay_state": None,
+                },
+                "nextSnapshot": {
+                    "source": "live",
+                    "status": "active",
+                    "stale": False,
+                    "replay_state": None,
+                    "drivers": [
+                        {
+                            "racing_number": "1",
+                            "status": "OnTrack",
+                            "timestamp": "new",
+                            "x": 300,
+                            "y": 250,
+                        },
+                    ],
+                },
+            },
+        }
+    )
+
+    before = result["beforeIngestDisplayDrivers"][0]
+    samples = result["ingestedSamples"][0][1]
+
+    assert before["x"] == pytest.approx(131.578947368)
+    assert before["y"] == pytest.approx(81.578947368)
+    assert samples[0]["x"] == pytest.approx(before["x"])
+    assert samples[0]["y"] == pytest.approx(before["y"])
+    assert samples[0]["arrivalAt"] == 2300
+    assert samples[1]["x"] == 300
+    assert samples[1]["y"] == 250
+    assert result["afterIngestDisplayDrivers"][0]["x"] == pytest.approx(before["x"])
+    assert result["afterIngestDisplayDrivers"][0]["y"] == pytest.approx(before["y"])
 
 
 def test_track_map_card_hides_stale_live_positions() -> None:

--- a/custom_components/f1_sensor/tests/test_track_map_replay_adapter.py
+++ b/custom_components/f1_sensor/tests/test_track_map_replay_adapter.py
@@ -523,7 +523,7 @@ def test_track_map_replay_adapter_interpolates_positions_while_playing() -> None
     assert driver["y"] == 100
 
 
-def test_track_map_adapter_interpolates_live_positions() -> None:
+def test_track_map_adapter_publishes_live_positions_without_interpolation() -> None:
     store = TrackMapStore("entry-1", stale_after=timedelta(days=30))
     store.update_session_info(_session_payload())
     loop = FakeLoop()
@@ -554,8 +554,50 @@ def test_track_map_adapter_interpolates_live_positions() -> None:
     driver = snapshot["drivers"][0]
 
     assert snapshot["source"] == TRACK_MAP_SOURCE_LIVE
-    assert driver["x"] == 150
-    assert driver["y"] == 100
+    assert driver["timestamp"] == second.timestamp.isoformat().replace("+00:00", "Z")
+    assert driver["x"] == 200
+    assert driver["y"] == 150
+
+
+def test_track_map_live_delay_releases_latest_position_without_extra_smoothing(
+    monkeypatch,
+) -> None:
+    """Live delay should not add smoothing lag after releasing Position.z samples."""
+    store = TrackMapStore("entry-1", stale_after=timedelta(days=30))
+    loop = FakeLoop()
+    bus = FakeBus()
+    delay_controller = FakeDelayController(30)
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.track_map.time.monotonic",
+        loop.time,
+    )
+    adapter = TrackMapReplayAdapter(
+        store,
+        bus,
+        hass=SimpleNamespace(loop=loop),
+        delay_controller=delay_controller,
+        position_source_resolver=lambda: TRACK_MAP_SOURCE_LIVE,
+    )
+    adapter.start()
+    position = TrackMapPosition(
+        "1",
+        BASE_TIME,
+        200,
+        150,
+        0,
+        "OnTrack",
+    )
+
+    bus.emit("SessionInfo", _session_payload())
+    bus.emit(TRACK_MAP_POSITION_STREAM, track_map_positions_to_payload([position]))
+    assert store.snapshot()["session"] is None
+
+    loop.advance(30)
+    driver = store.snapshot(now=BASE_TIME + timedelta(seconds=1))["drivers"][0]
+
+    assert driver["timestamp"] == position.timestamp.isoformat().replace("+00:00", "Z")
+    assert driver["x"] == 200
+    assert driver["y"] == 150
 
 
 def test_track_map_replay_adapter_resets_interpolation_on_source_switch() -> None:

--- a/custom_components/f1_sensor/tests/test_track_map_websocket.py
+++ b/custom_components/f1_sensor/tests/test_track_map_websocket.py
@@ -45,7 +45,7 @@ class FakeConnection:
 
 
 def _store(hass, entry_id: str = "entry-1") -> TrackMapStore:
-    store = TrackMapStore(entry_id, stale_after=timedelta(days=30))
+    store = TrackMapStore(entry_id, stale_after=timedelta(days=3650))
     hass.data.setdefault(DOMAIN, {})[entry_id] = {"track_map_store": store}
     return store
 

--- a/custom_components/f1_sensor/track_map.py
+++ b/custom_components/f1_sensor/track_map.py
@@ -687,8 +687,6 @@ class TrackMapReplayAdapter:
         return TRACK_MAP_SOURCE_REPLAY
 
     def _should_interpolate_positions(self, source: str | None) -> bool:
-        if source == TRACK_MAP_SOURCE_LIVE:
-            return True
         return source == TRACK_MAP_SOURCE_REPLAY and self._replay_state == "playing"
 
     def _reset_interpolation_if_source_changed(self, source: str) -> None:

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -31496,6 +31496,10 @@ class F1TrackMapCard extends LitElement {
       const sample = { ...driver, x, y, arrivalAt: now };
       const samples = this._driverSamples.get(key) || [];
       const previous = samples[samples.length - 1];
+      const liveAuto = this._usesLiveAutoSmoothing();
+      const transitionFrom = liveAuto && previous && !shouldSnap
+        ? this._sampledLiveAutoDriverPosition(samples, now)
+        : previous;
       const timestampKey = String(driver?.timestamp || '');
       const unchanged = previous
         && previous.timestampKey === timestampKey
@@ -31503,11 +31507,18 @@ class F1TrackMapCard extends LitElement {
         && Number(previous.y) === y;
       if (unchanged && !shouldSnap) continue;
       sample.timestampKey = timestampKey;
-      if (shouldSnap || !previous || this._isLargeDriverJump(previous, sample)) {
+      if (shouldSnap || !previous || this._isLargeDriverJump(transitionFrom, sample)) {
         this._driverSamples.set(key, [sample]);
         continue;
       }
       this._noteDriverSampleInterval(now - previous.arrivalAt);
+      if (liveAuto && transitionFrom) {
+        this._driverSamples.set(key, [
+          { ...previous, ...transitionFrom, arrivalAt: now },
+          sample,
+        ]);
+        continue;
+      }
       this._driverSamples.set(key, [...samples.slice(-5), sample]);
     }
     for (const key of [...this._driverSamples.keys()]) {
@@ -31529,6 +31540,9 @@ class F1TrackMapCard extends LitElement {
   _sampledDriverPosition(key, renderAt) {
     const samples = this._driverSamples.get(key);
     if (!Array.isArray(samples) || samples.length === 0) return null;
+    if (this._usesLiveAutoSmoothing()) {
+      return this._sampledLiveAutoDriverPosition(samples, renderAt);
+    }
     if (samples.length === 1 || renderAt <= samples[0].arrivalAt) return samples[0];
     for (let index = 0; index < samples.length - 1; index += 1) {
       const from = samples[index];
@@ -31546,11 +31560,45 @@ class F1TrackMapCard extends LitElement {
     return samples[samples.length - 1];
   }
 
+  _sampledLiveAutoDriverPosition(samples, now) {
+    const latest = samples[samples.length - 1];
+    if (samples.length === 1) return latest;
+    const previous = samples[samples.length - 2];
+    const duration = this._liveAutoSmoothingDuration();
+    if (duration <= 0) return latest;
+    const elapsed = Math.max(0, now - Number(latest.arrivalAt || 0));
+    if (elapsed >= duration) return latest;
+    const progress = Math.max(0, Math.min(1, elapsed / duration));
+    return {
+      ...latest,
+      x: Number(previous.x) + ((Number(latest.x) - Number(previous.x)) * progress),
+      y: Number(previous.y) + ((Number(latest.y) - Number(previous.y)) * progress),
+    };
+  }
+
   _noteDriverSampleInterval(interval) {
     if (!Number.isFinite(interval) || interval < 120 || interval > 5000) return;
     this._driverSampleIntervalMs = this._driverSampleIntervalMs
       ? (this._driverSampleIntervalMs * 0.7) + (interval * 0.3)
       : interval;
+  }
+
+  _usesLiveAutoSmoothing() {
+    if (Number.isFinite(Number(this.config?.interpolation_ms))) return false;
+    return String(this._snapshot?.source || '').trim().toLowerCase() === 'live';
+  }
+
+  _liveAutoSmoothingDuration() {
+    if (this._driverSampleIntervalMs > 0) {
+      return Math.max(350, Math.min(2000, this._driverSampleIntervalMs * 0.95));
+    }
+    if (this._snapshotIntervalMs > 0) {
+      return Math.max(350, Math.min(2000, this._snapshotIntervalMs * 0.95));
+    }
+    const throttle = Number(this.config?.throttle_ms);
+    return Number.isFinite(throttle) && throttle > 0
+      ? Math.max(500, Math.min(1200, throttle * 9))
+      : 900;
   }
 
   _driverRenderTime() {
@@ -31567,6 +31615,9 @@ class F1TrackMapCard extends LitElement {
     const configured = Number(this.config?.interpolation_ms);
     if (Number.isFinite(configured)) {
       return Math.max(0, Math.min(5000, configured));
+    }
+    if (String(this._snapshot?.source || '').trim().toLowerCase() === 'live') {
+      return 0;
     }
     if (this._driverSampleIntervalMs > 0) {
       return Math.max(220, Math.min(900, this._driverSampleIntervalMs * 1.8));
@@ -31597,7 +31648,17 @@ class F1TrackMapCard extends LitElement {
     const renderAt = this._driverRenderTime();
     for (const samples of this._driverSamples.values()) {
       const latest = samples?.[samples.length - 1];
-      if (samples?.length > 1 && latest && renderAt < latest.arrivalAt) return true;
+      if (!samples?.length || !latest) continue;
+      if (this._usesLiveAutoSmoothing()) {
+        if (
+          samples.length > 1
+          && renderAt < Number(latest.arrivalAt || 0) + this._liveAutoSmoothingDuration()
+        ) {
+          return true;
+        }
+        continue;
+      }
+      if (samples.length > 1 && renderAt < latest.arrivalAt) return true;
     }
     return false;
   }
@@ -31939,7 +32000,7 @@ class F1TrackMapCardEditor extends LitElement {
         ${this._renderTextField(
           'interpolation_ms',
           'Interpolation (ms)',
-          'Visual motion smoothing for car markers. Auto follows the incoming sample rate, 0 disables smoothing, and higher values add more visual delay.',
+          'Visual motion smoothing for car markers. Auto keeps live movement continuous without adding a render buffer and smooths replay playback. Use 0 to disable smoothing, or higher values for more visual delay.',
         )}
       </div>
     `;


### PR DESCRIPTION
The F1 Sensor integration now releases live track map positions at the calibrated delay without adding extra smoothing, and the live data card no longer adds automatic visual lag to live car markers. Replay map playback still keeps smoothing for readable motion, while live views show the latest delayed positions more accurately alongside the broadcast. Fixes #587.

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [X] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [X] Tested locally with a real Home Assistant instance
- [X] Existing automations and dashboards still work as expected after the change

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [X] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [X] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [X] Tests have been added or updated and pass locally — if applicable
- [X] Translations updated if new UI strings were added — if applicable
- [X] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
