### PR TITLE
fix: **Let the F1 Sensor integration start when timezone lookup downl…

### DIFF
--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -218,6 +218,40 @@ F1_CIRCUIT_IMAGE_SLUGS: dict[str, dict[str, str]] = {
     }
 }
 
+F1_CIRCUIT_TIME_ZONES: dict[str, str] = {
+    "albert_park": "Australia/Melbourne",
+    "americas": "America/Chicago",
+    "bahrain": "Asia/Bahrain",
+    "baku": "Asia/Baku",
+    "catalunya": "Europe/Madrid",
+    "hungaroring": "Europe/Budapest",
+    "imola": "Europe/Rome",
+    "interlagos": "America/Sao_Paulo",
+    "istanbul": "Europe/Istanbul",
+    "jeddah": "Asia/Riyadh",
+    "losail": "Asia/Qatar",
+    "madring": "Europe/Madrid",
+    "marina_bay": "Asia/Singapore",
+    "miami": "America/New_York",
+    "monaco": "Europe/Monaco",
+    "monza": "Europe/Rome",
+    "mugello": "Europe/Rome",
+    "nurburgring": "Europe/Berlin",
+    "portimao": "Europe/Lisbon",
+    "red_bull_ring": "Europe/Vienna",
+    "ricard": "Europe/Paris",
+    "rodriguez": "America/Mexico_City",
+    "shanghai": "Asia/Shanghai",
+    "silverstone": "Europe/London",
+    "sochi": "Europe/Moscow",
+    "spa": "Europe/Brussels",
+    "suzuka": "Asia/Tokyo",
+    "vegas": "America/Los_Angeles",
+    "villeneuve": "America/Toronto",
+    "yas_marina": "Asia/Dubai",
+    "zandvoort": "Europe/Amsterdam",
+}
+
 # Legacy circuit map support (official F1 track maps with DRS zones)
 CIRCUIT_IMAGE_LEGACY_CDN_BASE_URL = "https://media.formula1.com/image/upload/f_auto,q_auto/content/dam/fom-website/2018-redesign-assets"
 CIRCUIT_MAP_LEGACY_CDN_PATH = "Circuit%20maps%2016x9"

--- a/custom_components/f1_sensor/helpers.py
+++ b/custom_components/f1_sensor/helpers.py
@@ -28,6 +28,7 @@ from .const import (
     CIRCUIT_OUTLINE_LEGACY_CDN_PATH,
     DOMAIN,
     F1_CIRCUIT_IMAGE_SLUGS,
+    F1_CIRCUIT_TIME_ZONES,
     F1_COUNTRY_CODES,
     F1_LEGACY_CIRCUIT_MAP_NAMES,
     F1_LEGACY_CIRCUIT_OUTLINE_NAMES,
@@ -169,7 +170,7 @@ _TZFPY_WARNED = False
 
 
 def get_timezone(lat: Any, lon: Any) -> str | None:
-    """Return an IANA timezone name for the provided coordinates via tzfpy."""
+    """Return an IANA timezone name for coordinates via optional tzfpy."""
     if lat is None or lon is None:
         return None
 
@@ -182,8 +183,8 @@ def get_timezone(lat: Any, lon: Any) -> str | None:
     if _tzfpy_get_tz is None:
         global _TZFPY_WARNED
         if not _TZFPY_WARNED:
-            _LOGGER.error(
-                "tzfpy dependency missing; timezone lookups disabled for coordinates"
+            _LOGGER.debug(
+                "Optional tzfpy dependency missing; coordinate timezone lookups disabled"
             )
             _TZFPY_WARNED = True
         return None
@@ -197,6 +198,13 @@ def get_timezone(lat: Any, lon: Any) -> str | None:
             )
         return None
     return tz
+
+
+def get_circuit_timezone(circuit_id: str | None) -> str | None:
+    """Return the known IANA timezone name for an F1 circuit."""
+    if not circuit_id:
+        return None
+    return F1_CIRCUIT_TIME_ZONES.get(circuit_id)
 
 
 def get_country_code(country_name: str | None) -> str | None:

--- a/custom_components/f1_sensor/manifest.json
+++ b/custom_components/f1_sensor/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/Nicxe/f1_sensor",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Nicxe/f1_sensor/issues",
-    "requirements": ["tzfpy>=1.1.0", "python-dateutil>=2.8"],
+    "requirements": ["python-dateutil>=2.8"],
     "version": "1.0.0"
 }

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -56,6 +56,7 @@ from .entity import (
 from .helpers import (
     get_circuit_map_url,
     get_circuit_outline_url,
+    get_circuit_timezone,
     get_country_code,
     get_country_flag_url,
     get_next_race,
@@ -151,6 +152,13 @@ def _combine_date_time(
 
 def _timezone_from_location(lat, lon):
     return get_timezone(lat, lon)
+
+
+def _timezone_from_circuit(circuit):
+    loc = circuit.get("Location", {})
+    return get_circuit_timezone(circuit.get("circuitId")) or _timezone_from_location(
+        loc.get("lat"), loc.get("long")
+    )
 
 
 def _to_local(iso_ts, timezone):
@@ -846,7 +854,7 @@ class F1NextRaceSensor(_NextRaceMixin, F1BaseEntity, SensorEntity):
 
         circuit = race.get("Circuit", {})
         loc = circuit.get("Location", {})
-        timezone = _timezone_from_location(loc.get("lat"), loc.get("long"))
+        timezone = _timezone_from_circuit(circuit)
 
         first_practice = race.get("FirstPractice", {})
         second_practice = race.get("SecondPractice", {})
@@ -946,8 +954,7 @@ class F1TrackTimeSensor(_NextRaceMixin, F1BaseEntity, SensorEntity):
     def _get_circuit_timezone(self, race):
         if not race:
             return None
-        loc = race.get("Circuit", {}).get("Location", {})
-        return _timezone_from_location(loc.get("lat"), loc.get("long"))
+        return _timezone_from_circuit(race.get("Circuit", {}))
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
@@ -1409,7 +1416,7 @@ class F1LastRaceSensor(F1BaseEntity, SensorEntity):
         results = [_clean_result(r) for r in race.get("Results", [])]
         circuit = race.get("Circuit", {})
         loc = circuit.get("Location", {})
-        timezone = _timezone_from_location(loc.get("lat"), loc.get("long"))
+        timezone = _timezone_from_circuit(circuit)
         race_start = _combine_date_time(
             race.get("date"), race.get("time"), force_utc=True
         )

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -178,6 +178,13 @@ process.stdout.write(JSON.stringify(result));
 """
 
 
+def test_manifest_keeps_timezone_lookup_optional() -> None:
+    manifest_path = ROOT / "custom_components" / "f1_sensor" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+
+    assert "tzfpy>=1.1.0" not in manifest["requirements"]
+
+
 class _LiveState:
     def __init__(self, is_live: bool = False) -> None:
         self.is_live = is_live
@@ -1303,6 +1310,37 @@ async def test_next_race_sensor_uses_2026_detailed_circuit_map(
 
 
 @pytest.mark.asyncio
+async def test_next_race_sensor_uses_known_circuit_timezone_without_tzfpy(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.helpers.dt_util.utcnow",
+        lambda: datetime(2026, 3, 10, tzinfo=UTC),
+    )
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.sensor._timezone_from_location",
+        lambda _lat, _lon: None,
+    )
+    coordinator = _build_coordinator(
+        hass,
+        {"MRData": {"RaceTable": {"Races": [_build_race(date="2026-03-15")]}}},
+    )
+    entry_id = "test_entry_next_race_timezone"
+    _set_entry_context(hass, entry_id)
+
+    sensor = F1NextRaceSensor(
+        coordinator,
+        f"{entry_id}_next_race",
+        entry_id,
+        "F1",
+    )
+    state = await _add_sensor_and_get_state(hass, sensor)
+
+    assert state.attributes["circuit_timezone"] == "Australia/Melbourne"
+    assert state.attributes["race_start_local"] == "2026-03-15T15:00:00+11:00"
+
+
+@pytest.mark.asyncio
 async def test_next_race_sensor_caches_state_attributes(hass, monkeypatch) -> None:
     monkeypatch.setattr(
         "custom_components.f1_sensor.helpers.dt_util.utcnow",
@@ -1321,7 +1359,18 @@ async def test_next_race_sensor_caches_state_attributes(hass, monkeypatch) -> No
     )
     coordinator = _build_coordinator(
         hass,
-        {"MRData": {"RaceTable": {"Races": [_build_race(date="2026-03-15")]}}},
+        {
+            "MRData": {
+                "RaceTable": {
+                    "Races": [
+                        _build_race(
+                            circuit_id="unknown_test",
+                            date="2026-03-15",
+                        )
+                    ]
+                }
+            }
+        },
     )
     entry_id = "test_entry_next_race_cache"
     _set_entry_context(hass, entry_id)
@@ -1347,7 +1396,15 @@ async def test_next_race_sensor_caches_state_attributes(hass, monkeypatch) -> No
     coordinator.async_set_updated_data(
         {
             "MRData": {
-                "RaceTable": {"Races": [_build_race(round_="2", date="2026-03-22")]}
+                "RaceTable": {
+                    "Races": [
+                        _build_race(
+                            circuit_id="unknown_test",
+                            round_="2",
+                            date="2026-03-22",
+                        )
+                    ]
+                }
             }
         }
     )


### PR DESCRIPTION
…oads fail**

The F1 Sensor integration no longer depends on an optional timezone lookup download during Home Assistant startup, so it can load when Home Assistant's package source is temporarily unavailable. Known F1 race locations still provide local circuit times from built-in timezone data, preserving next-race and track-time behavior for normal calendars. Existing setups do not need configuration changes.

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [X] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
