### PR TITLE
Beta

### DIFF
--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -218,6 +218,40 @@ F1_CIRCUIT_IMAGE_SLUGS: dict[str, dict[str, str]] = {
     }
 }
 
+F1_CIRCUIT_TIME_ZONES: dict[str, str] = {
+    "albert_park": "Australia/Melbourne",
+    "americas": "America/Chicago",
+    "bahrain": "Asia/Bahrain",
+    "baku": "Asia/Baku",
+    "catalunya": "Europe/Madrid",
+    "hungaroring": "Europe/Budapest",
+    "imola": "Europe/Rome",
+    "interlagos": "America/Sao_Paulo",
+    "istanbul": "Europe/Istanbul",
+    "jeddah": "Asia/Riyadh",
+    "losail": "Asia/Qatar",
+    "madring": "Europe/Madrid",
+    "marina_bay": "Asia/Singapore",
+    "miami": "America/New_York",
+    "monaco": "Europe/Monaco",
+    "monza": "Europe/Rome",
+    "mugello": "Europe/Rome",
+    "nurburgring": "Europe/Berlin",
+    "portimao": "Europe/Lisbon",
+    "red_bull_ring": "Europe/Vienna",
+    "ricard": "Europe/Paris",
+    "rodriguez": "America/Mexico_City",
+    "shanghai": "Asia/Shanghai",
+    "silverstone": "Europe/London",
+    "sochi": "Europe/Moscow",
+    "spa": "Europe/Brussels",
+    "suzuka": "Asia/Tokyo",
+    "vegas": "America/Los_Angeles",
+    "villeneuve": "America/Toronto",
+    "yas_marina": "Asia/Dubai",
+    "zandvoort": "Europe/Amsterdam",
+}
+
 # Legacy circuit map support (official F1 track maps with DRS zones)
 CIRCUIT_IMAGE_LEGACY_CDN_BASE_URL = "https://media.formula1.com/image/upload/f_auto,q_auto/content/dam/fom-website/2018-redesign-assets"
 CIRCUIT_MAP_LEGACY_CDN_PATH = "Circuit%20maps%2016x9"

--- a/custom_components/f1_sensor/helpers.py
+++ b/custom_components/f1_sensor/helpers.py
@@ -28,6 +28,7 @@ from .const import (
     CIRCUIT_OUTLINE_LEGACY_CDN_PATH,
     DOMAIN,
     F1_CIRCUIT_IMAGE_SLUGS,
+    F1_CIRCUIT_TIME_ZONES,
     F1_COUNTRY_CODES,
     F1_LEGACY_CIRCUIT_MAP_NAMES,
     F1_LEGACY_CIRCUIT_OUTLINE_NAMES,
@@ -169,7 +170,7 @@ _TZFPY_WARNED = False
 
 
 def get_timezone(lat: Any, lon: Any) -> str | None:
-    """Return an IANA timezone name for the provided coordinates via tzfpy."""
+    """Return an IANA timezone name for coordinates via optional tzfpy."""
     if lat is None or lon is None:
         return None
 
@@ -182,8 +183,8 @@ def get_timezone(lat: Any, lon: Any) -> str | None:
     if _tzfpy_get_tz is None:
         global _TZFPY_WARNED
         if not _TZFPY_WARNED:
-            _LOGGER.error(
-                "tzfpy dependency missing; timezone lookups disabled for coordinates"
+            _LOGGER.debug(
+                "Optional tzfpy dependency missing; coordinate timezone lookups disabled"
             )
             _TZFPY_WARNED = True
         return None
@@ -197,6 +198,13 @@ def get_timezone(lat: Any, lon: Any) -> str | None:
             )
         return None
     return tz
+
+
+def get_circuit_timezone(circuit_id: str | None) -> str | None:
+    """Return the known IANA timezone name for an F1 circuit."""
+    if not circuit_id:
+        return None
+    return F1_CIRCUIT_TIME_ZONES.get(circuit_id)
 
 
 def get_country_code(country_name: str | None) -> str | None:

--- a/custom_components/f1_sensor/manifest.json
+++ b/custom_components/f1_sensor/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/Nicxe/f1_sensor",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/Nicxe/f1_sensor/issues",
-    "requirements": ["tzfpy>=1.1.0", "python-dateutil>=2.8"],
+    "requirements": ["python-dateutil>=2.8"],
     "version": "1.0.0"
 }

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -56,6 +56,7 @@ from .entity import (
 from .helpers import (
     get_circuit_map_url,
     get_circuit_outline_url,
+    get_circuit_timezone,
     get_country_code,
     get_country_flag_url,
     get_next_race,
@@ -151,6 +152,13 @@ def _combine_date_time(
 
 def _timezone_from_location(lat, lon):
     return get_timezone(lat, lon)
+
+
+def _timezone_from_circuit(circuit):
+    loc = circuit.get("Location", {})
+    return get_circuit_timezone(circuit.get("circuitId")) or _timezone_from_location(
+        loc.get("lat"), loc.get("long")
+    )
 
 
 def _to_local(iso_ts, timezone):
@@ -846,7 +854,7 @@ class F1NextRaceSensor(_NextRaceMixin, F1BaseEntity, SensorEntity):
 
         circuit = race.get("Circuit", {})
         loc = circuit.get("Location", {})
-        timezone = _timezone_from_location(loc.get("lat"), loc.get("long"))
+        timezone = _timezone_from_circuit(circuit)
 
         first_practice = race.get("FirstPractice", {})
         second_practice = race.get("SecondPractice", {})
@@ -946,8 +954,7 @@ class F1TrackTimeSensor(_NextRaceMixin, F1BaseEntity, SensorEntity):
     def _get_circuit_timezone(self, race):
         if not race:
             return None
-        loc = race.get("Circuit", {}).get("Location", {})
-        return _timezone_from_location(loc.get("lat"), loc.get("long"))
+        return _timezone_from_circuit(race.get("Circuit", {}))
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
@@ -1409,7 +1416,7 @@ class F1LastRaceSensor(F1BaseEntity, SensorEntity):
         results = [_clean_result(r) for r in race.get("Results", [])]
         circuit = race.get("Circuit", {})
         loc = circuit.get("Location", {})
-        timezone = _timezone_from_location(loc.get("lat"), loc.get("long"))
+        timezone = _timezone_from_circuit(circuit)
         race_start = _combine_date_time(
             race.get("date"), race.get("time"), force_utc=True
         )

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -178,6 +178,13 @@ process.stdout.write(JSON.stringify(result));
 """
 
 
+def test_manifest_keeps_timezone_lookup_optional() -> None:
+    manifest_path = ROOT / "custom_components" / "f1_sensor" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+
+    assert "tzfpy>=1.1.0" not in manifest["requirements"]
+
+
 class _LiveState:
     def __init__(self, is_live: bool = False) -> None:
         self.is_live = is_live
@@ -1303,6 +1310,37 @@ async def test_next_race_sensor_uses_2026_detailed_circuit_map(
 
 
 @pytest.mark.asyncio
+async def test_next_race_sensor_uses_known_circuit_timezone_without_tzfpy(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.helpers.dt_util.utcnow",
+        lambda: datetime(2026, 3, 10, tzinfo=UTC),
+    )
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.sensor._timezone_from_location",
+        lambda _lat, _lon: None,
+    )
+    coordinator = _build_coordinator(
+        hass,
+        {"MRData": {"RaceTable": {"Races": [_build_race(date="2026-03-15")]}}},
+    )
+    entry_id = "test_entry_next_race_timezone"
+    _set_entry_context(hass, entry_id)
+
+    sensor = F1NextRaceSensor(
+        coordinator,
+        f"{entry_id}_next_race",
+        entry_id,
+        "F1",
+    )
+    state = await _add_sensor_and_get_state(hass, sensor)
+
+    assert state.attributes["circuit_timezone"] == "Australia/Melbourne"
+    assert state.attributes["race_start_local"] == "2026-03-15T15:00:00+11:00"
+
+
+@pytest.mark.asyncio
 async def test_next_race_sensor_caches_state_attributes(hass, monkeypatch) -> None:
     monkeypatch.setattr(
         "custom_components.f1_sensor.helpers.dt_util.utcnow",
@@ -1321,7 +1359,18 @@ async def test_next_race_sensor_caches_state_attributes(hass, monkeypatch) -> No
     )
     coordinator = _build_coordinator(
         hass,
-        {"MRData": {"RaceTable": {"Races": [_build_race(date="2026-03-15")]}}},
+        {
+            "MRData": {
+                "RaceTable": {
+                    "Races": [
+                        _build_race(
+                            circuit_id="unknown_test",
+                            date="2026-03-15",
+                        )
+                    ]
+                }
+            }
+        },
     )
     entry_id = "test_entry_next_race_cache"
     _set_entry_context(hass, entry_id)
@@ -1347,7 +1396,15 @@ async def test_next_race_sensor_caches_state_attributes(hass, monkeypatch) -> No
     coordinator.async_set_updated_data(
         {
             "MRData": {
-                "RaceTable": {"Races": [_build_race(round_="2", date="2026-03-22")]}
+                "RaceTable": {
+                    "Races": [
+                        _build_race(
+                            circuit_id="unknown_test",
+                            round_="2",
+                            date="2026-03-22",
+                        )
+                    ]
+                }
             }
         }
     )

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -1406,6 +1406,10 @@ async def test_track_time_sensor_exposes_machine_readable_datetimes(
 async def test_next_race_sensor_exposes_circuit_history_attrs(
     hass, monkeypatch
 ) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.helpers.dt_util.utcnow",
+        lambda: datetime(2026, 6, 27, tzinfo=UTC),
+    )
     next_race, payloads = _build_next_race_history_fixture()
     race_coordinator = _build_coordinator(
         hass,
@@ -1532,6 +1536,10 @@ async def test_next_race_sensor_exposes_circuit_history_attrs(
 async def test_next_race_history_last_year_podium_missing_returns_none(
     hass, monkeypatch
 ) -> None:
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.helpers.dt_util.utcnow",
+        lambda: datetime(2026, 6, 27, tzinfo=UTC),
+    )
     next_race, payloads = _build_next_race_history_fixture(
         include_previous_season=False
     )

--- a/custom_components/f1_sensor/tests/test_track_map_card_config.py
+++ b/custom_components/f1_sensor/tests/test_track_map_card_config.py
@@ -143,9 +143,42 @@ if (payload.motion) {
   card._driverSamples = new Map(
     (motion.samples || []).map(([key, samples]) => [key, samples]),
   );
+  card._driverSampleIntervalMs = motion.driverSampleIntervalMs || 0;
+  card._snapshotIntervalMs = motion.snapshotIntervalMs || 0;
   card._renderClockAt = motion.renderClockAt || 0;
   card._nowMs = () => motion.nowMs;
+  result.driverRenderLag = card._driverRenderLag();
+  result.liveAutoSmoothingDuration = card._liveAutoSmoothingDuration();
+  result.driverRenderTime = card._driverRenderTime();
+  result.motionDisplayDrivers = card._displayDrivers(motion.drivers || []);
   result.hasActiveDriverMotion = card._hasActiveDriverMotion();
+}
+
+if (payload.ingestMotion) {
+  const motion = payload.ingestMotion;
+  card._snapshot = motion.initialSnapshot || null;
+  card._status = motion.status || motion.initialSnapshot?.status || "not_loaded";
+  card._driverSamples = new Map(
+    (motion.samples || []).map(([key, samples]) => [key, samples]),
+  );
+  card._driverSampleIntervalMs = motion.driverSampleIntervalMs || 0;
+  card._snapshotIntervalMs = motion.snapshotIntervalMs || 0;
+  card._renderClockAt = motion.renderClockAt || 0;
+  let nowMs = motion.nowMs;
+  card._nowMs = () => nowMs;
+  result.beforeIngestDisplayDrivers = card._displayDrivers(motion.initialDrivers || []);
+  nowMs = motion.ingestNowMs ?? nowMs;
+  card._snapshot = motion.nextSnapshot || card._snapshot;
+  card._status = motion.status || motion.nextSnapshot?.status || card._status;
+  card._ingestDriverSamples(card._snapshot);
+  result.ingestedSamples = Array.from(card._driverSamples.entries());
+  if (motion.afterNowMs !== undefined) {
+    nowMs = motion.afterNowMs;
+    result.afterIngestDisplayDrivers = card._displayDrivers(
+      motion.nextSnapshot?.drivers || motion.initialDrivers || [],
+    );
+  }
+  result.ingestDriverSampleIntervalMs = card._driverSampleIntervalMs;
 }
 
 process.stdout.write(JSON.stringify(result));
@@ -312,8 +345,8 @@ def test_track_map_card_reports_specific_empty_states() -> None:
     assert waiting_positions["emptyState"]["title"] == "Waiting for live car positions"
 
 
-def test_track_map_card_keeps_live_driver_motion_active_until_latest_sample() -> None:
-    """Live snapshots should keep redrawing while visual smoothing is in flight."""
+def test_track_map_card_keeps_live_auto_motion_during_short_catch_up() -> None:
+    """Live auto smoothing should redraw only during the short catch-up window."""
     samples = [
         [
             "1",
@@ -325,6 +358,21 @@ def test_track_map_card_keeps_live_driver_motion_active_until_latest_sample() ->
     ]
     active_live = _run_probe(
         {
+            "motion": {
+                "nowMs": 2200,
+                "samples": samples,
+                "snapshot": {
+                    "source": "live",
+                    "status": "active",
+                    "stale": False,
+                    "replay_state": None,
+                },
+            },
+        }
+    )
+    explicit_live = _run_probe(
+        {
+            "config": {"interpolation_ms": 900},
             "motion": {
                 "nowMs": 2200,
                 "samples": samples,
@@ -367,8 +415,148 @@ def test_track_map_card_keeps_live_driver_motion_active_until_latest_sample() ->
     )
 
     assert active_live["hasActiveDriverMotion"] is True
+    assert explicit_live["hasActiveDriverMotion"] is True
     assert stale_live["hasActiveDriverMotion"] is False
     assert paused_replay["hasActiveDriverMotion"] is False
+
+
+def test_track_map_card_auto_interpolation_keeps_live_positions_moving() -> None:
+    """Auto marker smoothing should keep live positions moving until the next sample."""
+    motion = {
+        "nowMs": 2100,
+        "driverSampleIntervalMs": 1000,
+        "samples": [
+            [
+                "1",
+                [
+                    {"x": 100, "y": 50, "arrivalAt": 1000},
+                    {"x": 200, "y": 150, "arrivalAt": 2000},
+                ],
+            ]
+        ],
+        "drivers": [
+            {"racing_number": "1", "status": "OnTrack", "x": 200, "y": 150},
+        ],
+        "snapshot": {
+            "source": "live",
+            "status": "active",
+            "stale": False,
+            "replay_state": None,
+        },
+    }
+
+    auto_live = _run_probe({"config": {}, "motion": motion})
+    still_moving_live = _run_probe({"config": {}, "motion": {**motion, "nowMs": 2300}})
+    explicit_live = _run_probe({"config": {"interpolation_ms": 900}, "motion": motion})
+    disabled_live = _run_probe({"config": {"interpolation_ms": 0}, "motion": motion})
+    auto_replay = _run_probe(
+        {
+            "config": {},
+            "motion": {
+                **motion,
+                "snapshot": {
+                    "source": "replay",
+                    "status": "active",
+                    "stale": False,
+                    "replay_state": "playing",
+                },
+            },
+        }
+    )
+
+    assert auto_live["driverRenderLag"] == 0
+    assert auto_live["liveAutoSmoothingDuration"] == 950
+    assert auto_live["driverRenderTime"] == 2100
+    assert auto_live["motionDisplayDrivers"][0]["x"] == pytest.approx(110.526315789)
+    assert auto_live["motionDisplayDrivers"][0]["y"] == pytest.approx(60.526315789)
+    assert auto_live["hasActiveDriverMotion"] is True
+    assert still_moving_live["driverRenderLag"] == 0
+    assert still_moving_live["driverRenderTime"] == 2300
+    assert still_moving_live["motionDisplayDrivers"][0]["x"] == pytest.approx(
+        131.578947368
+    )
+    assert still_moving_live["motionDisplayDrivers"][0]["y"] == pytest.approx(
+        81.578947368
+    )
+    assert still_moving_live["hasActiveDriverMotion"] is True
+    assert explicit_live["driverRenderLag"] == 900
+    assert explicit_live["driverRenderTime"] == 1200
+    assert explicit_live["motionDisplayDrivers"][0]["x"] == pytest.approx(110.4)
+    assert explicit_live["motionDisplayDrivers"][0]["y"] == pytest.approx(60.4)
+    assert disabled_live["driverRenderLag"] == 0
+    assert disabled_live["motionDisplayDrivers"][0]["x"] == 200
+    assert disabled_live["motionDisplayDrivers"][0]["y"] == 150
+    assert disabled_live["hasActiveDriverMotion"] is False
+    assert auto_replay["driverRenderLag"] == 900
+    assert auto_replay["driverRenderTime"] == 1200
+    assert auto_replay["motionDisplayDrivers"][0]["x"] == pytest.approx(110.4)
+    assert auto_replay["motionDisplayDrivers"][0]["y"] == pytest.approx(60.4)
+
+
+def test_track_map_card_live_sample_starts_from_current_rendered_position() -> None:
+    """Early live samples should continue from the current visual position."""
+    result = _run_probe(
+        {
+            "config": {},
+            "ingestMotion": {
+                "nowMs": 2300,
+                "ingestNowMs": 2300,
+                "afterNowMs": 2300,
+                "driverSampleIntervalMs": 1000,
+                "samples": [
+                    [
+                        "1",
+                        [
+                            {"x": 100, "y": 50, "arrivalAt": 1000},
+                            {
+                                "x": 200,
+                                "y": 150,
+                                "arrivalAt": 2000,
+                                "timestampKey": "old",
+                            },
+                        ],
+                    ]
+                ],
+                "initialDrivers": [
+                    {"racing_number": "1", "status": "OnTrack", "x": 200, "y": 150},
+                ],
+                "initialSnapshot": {
+                    "source": "live",
+                    "status": "active",
+                    "stale": False,
+                    "replay_state": None,
+                },
+                "nextSnapshot": {
+                    "source": "live",
+                    "status": "active",
+                    "stale": False,
+                    "replay_state": None,
+                    "drivers": [
+                        {
+                            "racing_number": "1",
+                            "status": "OnTrack",
+                            "timestamp": "new",
+                            "x": 300,
+                            "y": 250,
+                        },
+                    ],
+                },
+            },
+        }
+    )
+
+    before = result["beforeIngestDisplayDrivers"][0]
+    samples = result["ingestedSamples"][0][1]
+
+    assert before["x"] == pytest.approx(131.578947368)
+    assert before["y"] == pytest.approx(81.578947368)
+    assert samples[0]["x"] == pytest.approx(before["x"])
+    assert samples[0]["y"] == pytest.approx(before["y"])
+    assert samples[0]["arrivalAt"] == 2300
+    assert samples[1]["x"] == 300
+    assert samples[1]["y"] == 250
+    assert result["afterIngestDisplayDrivers"][0]["x"] == pytest.approx(before["x"])
+    assert result["afterIngestDisplayDrivers"][0]["y"] == pytest.approx(before["y"])
 
 
 def test_track_map_card_hides_stale_live_positions() -> None:

--- a/custom_components/f1_sensor/tests/test_track_map_replay_adapter.py
+++ b/custom_components/f1_sensor/tests/test_track_map_replay_adapter.py
@@ -523,7 +523,7 @@ def test_track_map_replay_adapter_interpolates_positions_while_playing() -> None
     assert driver["y"] == 100
 
 
-def test_track_map_adapter_interpolates_live_positions() -> None:
+def test_track_map_adapter_publishes_live_positions_without_interpolation() -> None:
     store = TrackMapStore("entry-1", stale_after=timedelta(days=30))
     store.update_session_info(_session_payload())
     loop = FakeLoop()
@@ -554,8 +554,50 @@ def test_track_map_adapter_interpolates_live_positions() -> None:
     driver = snapshot["drivers"][0]
 
     assert snapshot["source"] == TRACK_MAP_SOURCE_LIVE
-    assert driver["x"] == 150
-    assert driver["y"] == 100
+    assert driver["timestamp"] == second.timestamp.isoformat().replace("+00:00", "Z")
+    assert driver["x"] == 200
+    assert driver["y"] == 150
+
+
+def test_track_map_live_delay_releases_latest_position_without_extra_smoothing(
+    monkeypatch,
+) -> None:
+    """Live delay should not add smoothing lag after releasing Position.z samples."""
+    store = TrackMapStore("entry-1", stale_after=timedelta(days=30))
+    loop = FakeLoop()
+    bus = FakeBus()
+    delay_controller = FakeDelayController(30)
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.track_map.time.monotonic",
+        loop.time,
+    )
+    adapter = TrackMapReplayAdapter(
+        store,
+        bus,
+        hass=SimpleNamespace(loop=loop),
+        delay_controller=delay_controller,
+        position_source_resolver=lambda: TRACK_MAP_SOURCE_LIVE,
+    )
+    adapter.start()
+    position = TrackMapPosition(
+        "1",
+        BASE_TIME,
+        200,
+        150,
+        0,
+        "OnTrack",
+    )
+
+    bus.emit("SessionInfo", _session_payload())
+    bus.emit(TRACK_MAP_POSITION_STREAM, track_map_positions_to_payload([position]))
+    assert store.snapshot()["session"] is None
+
+    loop.advance(30)
+    driver = store.snapshot(now=BASE_TIME + timedelta(seconds=1))["drivers"][0]
+
+    assert driver["timestamp"] == position.timestamp.isoformat().replace("+00:00", "Z")
+    assert driver["x"] == 200
+    assert driver["y"] == 150
 
 
 def test_track_map_replay_adapter_resets_interpolation_on_source_switch() -> None:

--- a/custom_components/f1_sensor/tests/test_track_map_websocket.py
+++ b/custom_components/f1_sensor/tests/test_track_map_websocket.py
@@ -45,7 +45,7 @@ class FakeConnection:
 
 
 def _store(hass, entry_id: str = "entry-1") -> TrackMapStore:
-    store = TrackMapStore(entry_id, stale_after=timedelta(days=30))
+    store = TrackMapStore(entry_id, stale_after=timedelta(days=3650))
     hass.data.setdefault(DOMAIN, {})[entry_id] = {"track_map_store": store}
     return store
 

--- a/custom_components/f1_sensor/track_map.py
+++ b/custom_components/f1_sensor/track_map.py
@@ -687,8 +687,6 @@ class TrackMapReplayAdapter:
         return TRACK_MAP_SOURCE_REPLAY
 
     def _should_interpolate_positions(self, source: str | None) -> bool:
-        if source == TRACK_MAP_SOURCE_LIVE:
-            return True
         return source == TRACK_MAP_SOURCE_REPLAY and self._replay_state == "playing"
 
     def _reset_interpolation_if_source_changed(self, source: str) -> None:

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -31496,6 +31496,10 @@ class F1TrackMapCard extends LitElement {
       const sample = { ...driver, x, y, arrivalAt: now };
       const samples = this._driverSamples.get(key) || [];
       const previous = samples[samples.length - 1];
+      const liveAuto = this._usesLiveAutoSmoothing();
+      const transitionFrom = liveAuto && previous && !shouldSnap
+        ? this._sampledLiveAutoDriverPosition(samples, now)
+        : previous;
       const timestampKey = String(driver?.timestamp || '');
       const unchanged = previous
         && previous.timestampKey === timestampKey
@@ -31503,11 +31507,18 @@ class F1TrackMapCard extends LitElement {
         && Number(previous.y) === y;
       if (unchanged && !shouldSnap) continue;
       sample.timestampKey = timestampKey;
-      if (shouldSnap || !previous || this._isLargeDriverJump(previous, sample)) {
+      if (shouldSnap || !previous || this._isLargeDriverJump(transitionFrom, sample)) {
         this._driverSamples.set(key, [sample]);
         continue;
       }
       this._noteDriverSampleInterval(now - previous.arrivalAt);
+      if (liveAuto && transitionFrom) {
+        this._driverSamples.set(key, [
+          { ...previous, ...transitionFrom, arrivalAt: now },
+          sample,
+        ]);
+        continue;
+      }
       this._driverSamples.set(key, [...samples.slice(-5), sample]);
     }
     for (const key of [...this._driverSamples.keys()]) {
@@ -31529,6 +31540,9 @@ class F1TrackMapCard extends LitElement {
   _sampledDriverPosition(key, renderAt) {
     const samples = this._driverSamples.get(key);
     if (!Array.isArray(samples) || samples.length === 0) return null;
+    if (this._usesLiveAutoSmoothing()) {
+      return this._sampledLiveAutoDriverPosition(samples, renderAt);
+    }
     if (samples.length === 1 || renderAt <= samples[0].arrivalAt) return samples[0];
     for (let index = 0; index < samples.length - 1; index += 1) {
       const from = samples[index];
@@ -31546,11 +31560,45 @@ class F1TrackMapCard extends LitElement {
     return samples[samples.length - 1];
   }
 
+  _sampledLiveAutoDriverPosition(samples, now) {
+    const latest = samples[samples.length - 1];
+    if (samples.length === 1) return latest;
+    const previous = samples[samples.length - 2];
+    const duration = this._liveAutoSmoothingDuration();
+    if (duration <= 0) return latest;
+    const elapsed = Math.max(0, now - Number(latest.arrivalAt || 0));
+    if (elapsed >= duration) return latest;
+    const progress = Math.max(0, Math.min(1, elapsed / duration));
+    return {
+      ...latest,
+      x: Number(previous.x) + ((Number(latest.x) - Number(previous.x)) * progress),
+      y: Number(previous.y) + ((Number(latest.y) - Number(previous.y)) * progress),
+    };
+  }
+
   _noteDriverSampleInterval(interval) {
     if (!Number.isFinite(interval) || interval < 120 || interval > 5000) return;
     this._driverSampleIntervalMs = this._driverSampleIntervalMs
       ? (this._driverSampleIntervalMs * 0.7) + (interval * 0.3)
       : interval;
+  }
+
+  _usesLiveAutoSmoothing() {
+    if (Number.isFinite(Number(this.config?.interpolation_ms))) return false;
+    return String(this._snapshot?.source || '').trim().toLowerCase() === 'live';
+  }
+
+  _liveAutoSmoothingDuration() {
+    if (this._driverSampleIntervalMs > 0) {
+      return Math.max(350, Math.min(2000, this._driverSampleIntervalMs * 0.95));
+    }
+    if (this._snapshotIntervalMs > 0) {
+      return Math.max(350, Math.min(2000, this._snapshotIntervalMs * 0.95));
+    }
+    const throttle = Number(this.config?.throttle_ms);
+    return Number.isFinite(throttle) && throttle > 0
+      ? Math.max(500, Math.min(1200, throttle * 9))
+      : 900;
   }
 
   _driverRenderTime() {
@@ -31567,6 +31615,9 @@ class F1TrackMapCard extends LitElement {
     const configured = Number(this.config?.interpolation_ms);
     if (Number.isFinite(configured)) {
       return Math.max(0, Math.min(5000, configured));
+    }
+    if (String(this._snapshot?.source || '').trim().toLowerCase() === 'live') {
+      return 0;
     }
     if (this._driverSampleIntervalMs > 0) {
       return Math.max(220, Math.min(900, this._driverSampleIntervalMs * 1.8));
@@ -31597,7 +31648,17 @@ class F1TrackMapCard extends LitElement {
     const renderAt = this._driverRenderTime();
     for (const samples of this._driverSamples.values()) {
       const latest = samples?.[samples.length - 1];
-      if (samples?.length > 1 && latest && renderAt < latest.arrivalAt) return true;
+      if (!samples?.length || !latest) continue;
+      if (this._usesLiveAutoSmoothing()) {
+        if (
+          samples.length > 1
+          && renderAt < Number(latest.arrivalAt || 0) + this._liveAutoSmoothingDuration()
+        ) {
+          return true;
+        }
+        continue;
+      }
+      if (samples.length > 1 && renderAt < latest.arrivalAt) return true;
     }
     return false;
   }
@@ -31939,7 +32000,7 @@ class F1TrackMapCardEditor extends LitElement {
         ${this._renderTextField(
           'interpolation_ms',
           'Interpolation (ms)',
-          'Visual motion smoothing for car markers. Auto follows the incoming sample rate, 0 disables smoothing, and higher values add more visual delay.',
+          'Visual motion smoothing for car markers. Auto keeps live movement continuous without adding a render buffer and smooths replay playback. Use 0 to disable smoothing, or higher values for more visual delay.',
         )}
       </div>
     `;


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [X] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
