### PR TITLE
chore: Stabilize maintenance workflow checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ registries:
     type: npm-registry
     url: https://npm.pkg.github.com
     token: ${{ secrets.DEPENDABOT_GH_PACKAGES_TOKEN }}
+    scope: "@nicxe"
 
 updates:
   - package-ecosystem: "npm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/custom_components/f1_sensor/tests/test_replay_control_card.py
+++ b/custom_components/f1_sensor/tests/test_replay_control_card.py
@@ -265,8 +265,8 @@ def test_replay_control_card_module_loads_with_bundled_lit(tmp_path: Path) -> No
     if node is None:
         pytest.skip("node is required for replay control card tests")
 
-    shutil.copy2(CARD_PATH, tmp_path / CARD_PATH.name)
-    shutil.copy2(LIT_MODULE_PATH, tmp_path / LIT_MODULE_PATH.name)
+    shutil.copyfile(CARD_PATH, tmp_path / CARD_PATH.name)
+    shutil.copyfile(LIT_MODULE_PATH, tmp_path / LIT_MODULE_PATH.name)
     (tmp_path / "package.json").write_text('{"type":"module"}', encoding="utf-8")
 
     completed = subprocess.run(


### PR DESCRIPTION
## Summary
- add the @nicxe scope to the GitHub Packages registry used by Dependabot
- update the Pages deploy action to v5
- avoid metadata-preserving copies in the local replay card module test so macOS file flags do not break validation

## Validation
- npm ci
- npm run build
- ruby YAML parse for .github/dependabot.yml and .github/workflows/deploy.yml
- /Volumes/config/scripts/run_ruff.sh
- /Volumes/config/scripts/run_ruff_ci.sh
- /Volumes/config/scripts/run_tests.sh