### PR TITLE
chore: Tune Dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,50 @@ registries:
     type: npm-registry
     url: https://npm.pkg.github.com
     token: ${{ secrets.DEPENDABOT_GH_PACKAGES_TOKEN }}
-    scope: "@nicxe"
 
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
     registries:
       - github-packages
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    groups:
+      docs-site:
+        patterns:
+          - "@docusaurus/*"
+          - "@easyops-cn/docusaurus-search-local"
+          - "@mdx-js/*"
+          - "clsx"
+          - "prism-react-renderer"
+          - "react"
+          - "react-dom"
+      release-tooling:
+        dependency-type: "development"
+        patterns:
+          - "@nicxe/semantic-release-config"
+          - "@semantic-release/*"
+          - "conventional-changelog-conventionalcommits"
+          - "semantic-release"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Tune Dependabot automation so routine version updates create less noise while security updates and high-value dependency maintenance remain automated.

## Changes

- Disable routine npm version update PRs where npm is only used for release tooling.
- Group useful npm, Python, and GitHub Actions updates to reduce PR volume.
- Keep weekly or monthly schedules where dependency updates still support active build, release, or documentation workflows.

## Validation

- Parsed all updated Dependabot YAML files successfully.
- Ran `git diff --check` for the changed Dependabot files.
