### PR TITLE
fix: Restore compatible release tooling dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "conventional-changelog-conventionalcommits"
+        update-types:
+          - "version-update:semver-major"
     groups:
       docs-site:
         patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/github": "^12.0.9",
         "@semantic-release/release-notes-generator": "^14.1.1",
-        "conventional-changelog-conventionalcommits": "^10.2.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "patch-package": "^8.0.0",
         "semantic-release": "^25.0.5"
       },
@@ -2004,16 +2004,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.0.tgz",
-      "integrity": "sha512-12qHxvlKjHmP0PQ+17EREgC7lWyLwbph1RKcZQZ7k7ZWGmrxfxC9gadHGfvzr0g0u8BhiBGg3tks93txodlyRQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {
@@ -9401,16 +9391,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.0.tgz",
-      "integrity": "sha512-UtlM9GqolY7OmlQh5L/UEVoKsTUpTgUVy1PU8JN5gl5Ydaejb7WRklGliG1SKPxxj7hzA173eG3Kt5fYWE2pmg==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/github": "^12.0.9",
     "@semantic-release/release-notes-generator": "^14.1.1",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "patch-package": "^8.0.0",
     "semantic-release": "^25.0.5"
   },


### PR DESCRIPTION
## Summary

Restore release-tooling dependencies to versions compatible with the shared semantic-release configuration.

## Changes

- Downgrade `conventional-changelog-conventionalcommits` back to the supported v9 range.
- Add a Dependabot ignore rule for major updates of that package so the peer conflict does not recur automatically.

## Validation

- Ran `npm ci` successfully in the updated worktree.
