### PR TITLE
Beta

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -1830,6 +1830,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if live_state is not None:
                 for coordinator_key in (
                     "championship_prediction_coordinator",
+                    "team_radio_coordinator",
                     "pitstop_coordinator",
                 ):
                     coordinator = entry_data.get(coordinator_key)
@@ -2074,6 +2075,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # unavailable state until their backing stream capability becomes available.
     need_drivers = any(k in enabled for k in ("driver_list",))
     need_top_three = any(k in enabled for k in ("top_three",))
+    need_team_radio = any(k in enabled for k in ("team_radio",))
     need_pitstops = any(k in enabled for k in ("pitstops",))
     need_championship_prediction = any(
         k in enabled for k in ("championship_prediction",)
@@ -2124,6 +2126,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             live_state=live_state,
         )
         await top_three_coordinator.async_config_entry_first_refresh()
+
+    team_radio_coordinator = None
+    if enable_rc and need_team_radio:
+        team_radio_coordinator = TeamRadioCoordinator(
+            hass,
+            session_coordinator,
+            live_delay,
+            bus=live_bus,
+            config_entry=entry,
+            delay_controller=delay_controller,
+            live_state=live_state,
+        )
+        await team_radio_coordinator.async_config_entry_first_refresh()
 
     pitstop_coordinator = None
     if enable_rc and need_pitstops:
@@ -2199,6 +2214,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "weather_data_coordinator": weather_data_coordinator if enable_rc else None,
         "lap_count_coordinator": lap_count_coordinator if enable_rc else None,
         "top_three_coordinator": top_three_coordinator,
+        "team_radio_coordinator": team_radio_coordinator,
         "pitstop_coordinator": pitstop_coordinator,
         "championship_prediction_coordinator": championship_prediction_coordinator,
         "drivers_coordinator": drivers_coordinator,
@@ -2239,6 +2255,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             lap_count_coordinator if enable_rc else None,
             incident_coordinator if enable_rc else None,
             top_three_coordinator,
+            team_radio_coordinator,
             pitstop_coordinator,
             championship_prediction_coordinator,
             drivers_coordinator,
@@ -3304,6 +3321,167 @@ class LapCountCoordinator(DataUpdateCoordinator):
             self.data_list = []
             # Notify entities to clear their state
             self.async_set_updated_data(self._last_message)
+
+
+class TeamRadioCoordinator(_SessionFingerprintMixin, DataUpdateCoordinator):
+    """Coordinator for TeamRadio updates using SignalR."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        session_coord: LiveSessionCoordinator,
+        delay_seconds: int = 0,
+        bus: LiveBus | None = None,
+        config_entry: ConfigEntry | None = None,
+        delay_controller: LiveDelayController | None = None,
+        live_state: LiveAvailabilityTracker | None = None,
+        history_limit: int = 20,
+    ) -> None:
+        super().__init__(
+            hass,
+            coordinator_logger("team_radio", suppress_manual=True),
+            name="F1 Team Radio Coordinator",
+            update_interval=None,
+            config_entry=config_entry,
+        )
+        self._session_coord = session_coord
+        self.available = False
+        self._bus = bus
+        self._config_entry = config_entry
+        self._unsubs: list[Callable[[], None]] = []
+        self._delay_listener: Callable[[], None] | None = None
+        _init_delayed_ingest_state(self)
+        self._delay = max(0, int(delay_seconds or 0))
+        self._replay_mode = False
+        self._history_limit = max(1, int(history_limit or 20))
+        self._state: dict[str, Any] = {"latest": None, "history": []}
+        if delay_controller is not None:
+            self._delay_listener = delay_controller.add_listener(self.set_delay)
+        self._live_state_unsub: Callable[[], None] | None = None
+        if live_state is not None:
+            self._live_state_unsub = live_state.add_listener(self._handle_live_state)
+        self._session_unsub: Callable[[], None] | None = None
+        self._session_fingerprint: str | None = None
+
+    async def async_close(self, *_):
+        _close_unsubs(self._unsubs)
+        self._delay_listener = _call_unsub(self._delay_listener)
+        self._live_state_unsub = _call_unsub(self._live_state_unsub)
+        self._session_unsub = _call_unsub(self._session_unsub)
+        _close_delayed_ingest_state(self)
+
+    async def _async_update_data(self):
+        return self._state
+
+    def _handle_live_state(self, is_live: bool, reason: str | None) -> None:
+        if reason == "init":
+            return
+        self._replay_mode = _is_replay_delay_reason(reason)
+        if self._replay_mode:
+            _clear_delayed_ingest_state(self)
+        if _is_no_spoiler_live_state(reason):
+            _clear_delayed_ingest_state(self)
+            return
+        replay_available = bool(is_live and self._replay_mode)
+        auth_live_available = bool(
+            is_live
+            and not self._replay_mode
+            and self._bus is not None
+            and getattr(self._bus, "auth_enabled", False)
+        )
+        self.available = replay_available or auth_live_available
+        if not self.available:
+            _clear_delayed_ingest_state(self)
+            self._reset_store()
+
+    def set_delay(self, seconds: int) -> None:
+        _apply_delay_with_queue(self, seconds)
+
+    def _reset_store(self) -> None:
+        self._state = {"latest": None, "history": []}
+        with suppress(Exception):
+            self.async_set_updated_data(self._state)
+
+    @staticmethod
+    def _normalize_captures(payload: dict) -> list[dict]:
+        """Extract a flat list of TeamRadio capture dictionaries."""
+        if not isinstance(payload, dict):
+            return []
+        captures = payload.get("Captures")
+        static_root = payload.get("_static_root")
+        result: list[dict] = []
+
+        def _append_capture(item: Any) -> None:
+            if not isinstance(item, dict):
+                return
+            capture = dict(item)
+            if static_root and "_static_root" not in capture:
+                capture["_static_root"] = static_root
+            result.append(capture)
+
+        if isinstance(captures, list):
+            for item in captures:
+                _append_capture(item)
+        elif isinstance(captures, dict):
+            numeric_keys = [key for key in captures if str(key).isdigit()]
+            if numeric_keys:
+                for key in sorted(numeric_keys, key=lambda value: int(str(value))):
+                    _append_capture(captures.get(key))
+            elif any(key in captures for key in ("Utc", "RacingNumber", "Path")):
+                _append_capture(captures)
+        elif any(key in payload for key in ("Utc", "RacingNumber", "Path")):
+            _append_capture(payload)
+
+        return result
+
+    def _on_bus_message(self, msg: dict) -> None:
+        if not isinstance(msg, dict) or _is_no_spoiler_blocked(self):
+            return
+        captures = self._normalize_captures(msg)
+        if not captures:
+            return
+        history: list[dict] = [
+            dict(item)
+            for item in (self._state.get("history") or [])
+            if isinstance(item, dict)
+        ]
+        history.extend(captures)
+        if len(history) > self._history_limit:
+            history = history[-self._history_limit :]
+        self._state = {
+            "latest": captures[-1],
+            "history": history,
+        }
+        self.async_set_updated_data(self._state)
+        _LOGGER.debug(
+            "TeamRadio delivered latest=%s history_len=%s",
+            {
+                "Utc": captures[-1].get("Utc"),
+                "RacingNumber": captures[-1].get("RacingNumber"),
+                "Path": captures[-1].get("Path"),
+            },
+            len(history),
+        )
+
+    async def async_config_entry_first_refresh(self):
+        await super().async_config_entry_first_refresh()
+        try:
+            self._session_fingerprint = _compute_session_fingerprint(
+                getattr(self._session_coord, "data", None)
+            )
+            self._session_unsub = self._session_coord.async_add_listener(
+                self._on_session_index_update
+            )
+        except Exception:
+            self._session_unsub = None
+        bus = self._bus or self.hass.data.get(DOMAIN, {}).get("live_bus")
+        with suppress(Exception):
+            self._unsubs.append(
+                bus.subscribe(
+                    "TeamRadio",
+                    _wrap_delayed_handler(self, self._on_bus_message),
+                )
+            )
 
 
 class PitStopCoordinator(_SessionFingerprintMixin, DataUpdateCoordinator):
@@ -6209,6 +6387,11 @@ def _reset_replay_sensitive_coordinator_state(coordinator: Any) -> None:
         return
 
     if isinstance(coordinator, PitStopCoordinator):
+        _clear_delayed_ingest_state(coordinator)
+        coordinator._reset_store()
+        return
+
+    if isinstance(coordinator, TeamRadioCoordinator):
         _clear_delayed_ingest_state(coordinator)
         coordinator._reset_store()
         return

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -105,6 +105,7 @@ SUPPORTED_SENSOR_KEYS = frozenset(
         "on_track_incident",
         "possible_on_track_incident",
         "top_three",
+        "team_radio",
         "pitstops",
         "championship_prediction",
         "live_timing_diagnostics",

--- a/custom_components/f1_sensor/device_trigger.py
+++ b/custom_components/f1_sensor/device_trigger.py
@@ -54,6 +54,8 @@ _TRIGGER_MAP: dict[str, tuple[str, str, str | None]] = {
     "new_race_control_message": ("race_control", "sensor", None),
     "new_fia_document": ("fia_documents", "sensor", None),
     "investigation_changed": ("investigations", "sensor", None),
+    # Drivers device
+    "new_team_radio": ("team_radio", "sensor", None),
     # System device
     "live_timing_online": ("live_timing_online", "binary_sensor", "on"),
     "live_timing_offline": ("live_timing_online", "binary_sensor", "off"),

--- a/custom_components/f1_sensor/replay.py
+++ b/custom_components/f1_sensor/replay.py
@@ -30,6 +30,7 @@ KNOWN_STREAMS = {
     "TimingData",
     "DriverList",
     "TimingAppData",
+    "TeamRadio",
     "PitStopSeries",
     "ChampionshipPrediction",
     TRACK_MAP_POSITION_STREAM,
@@ -115,6 +116,7 @@ class ReplaySignalRClient:
         frames: list[ReplayFrame] = []
         prev_ts: float | None = None
         stream_hint = self._stream_hint
+        static_root: str | None = None
         try:
             with self._path.open("r", encoding="utf-8") as handle:
                 for raw_line in handle:
@@ -126,6 +128,7 @@ class ReplaySignalRClient:
                         # Extract stream name from the *.jsonStream URL.
                         url_stream = self._extract_stream_from_url(line)
                         stream_hint = url_stream or stream_hint
+                        static_root = self._extract_static_root_from_url(line)
                         continue
                     if stream_hint == TRACK_MAP_POSITION_STREAM and "{" not in line:
                         ts_part, payload_line = self._split_position_z_line(line)
@@ -161,6 +164,14 @@ class ReplaySignalRClient:
                     current_ts = self._parse_timestamp(ts_part)
                     delay = self._compute_delay(current_ts, prev_ts)
                     prev_ts = current_ts
+                    if (
+                        static_root
+                        and stream_name == "TeamRadio"
+                        and isinstance(payload, dict)
+                        and "_static_root" not in payload
+                    ):
+                        payload = dict(payload)
+                        payload["_static_root"] = static_root
                     frames.append(
                         ReplayFrame(delay=delay, stream=stream_name, payload=payload)
                     )
@@ -237,6 +248,17 @@ class ReplaySignalRClient:
         if tail.endswith(".jsonStream"):
             tail = tail[: -len(".jsonStream")]
         return tail if tail in KNOWN_STREAMS else None
+
+    @staticmethod
+    def _extract_static_root_from_url(line: str) -> str | None:
+        try:
+            _, url = line.split(":", 1)
+        except ValueError:
+            return None
+        full_url = url.strip().rstrip("/")
+        if not full_url or "/" not in full_url:
+            return None
+        return full_url.rsplit("/", 1)[0]
 
     @staticmethod
     def _extract_stream(obj: dict) -> tuple[str | None, dict | None]:

--- a/custom_components/f1_sensor/replay_mode.py
+++ b/custom_components/f1_sensor/replay_mode.py
@@ -57,6 +57,7 @@ REPLAY_STREAMS = [
     "DriverList",
     "TimingAppData",
     "TopThree",
+    "TeamRadio",
     "PitStopSeries",
     "ChampionshipPrediction",
     "DriverRaceInfo",
@@ -73,7 +74,7 @@ INDEX_STATUS_NO_DATA = "no_data"
 INDEX_STATUS_ERROR = "error"
 # Cache version - bump this when replay index contents change in a way that
 # requires re-downloading cached sessions.
-CACHE_VERSION = 12
+CACHE_VERSION = 13
 FORMATION_SEARCH_WINDOW = timedelta(seconds=90)
 FORMATION_HTTP_TIMEOUT = 20
 SEEK_INDEX_INTERVAL_MS = 5_000
@@ -874,6 +875,7 @@ class ReplaySessionManager:
             return frames
 
         # Parse jsonStream format: each line is timestamp + JSON
+        static_root = url.rstrip("/").rsplit("/", 1)[0]
         for line in text.splitlines():
             line = line.strip()
             if not line:
@@ -891,6 +893,9 @@ class ReplaySessionManager:
             try:
                 timestamp_ms = self._parse_timestamp_to_ms(timestamp_str)
                 payload = json.loads(json_str)
+                if stream_name == "TeamRadio" and isinstance(payload, dict):
+                    payload = dict(payload)
+                    payload["_static_root"] = static_root
 
                 frames.append(
                     ReplayFrame(

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -65,6 +65,8 @@ from .helpers import (
 )
 from .replay_entities import F1ReplayStatusSensor
 
+TEAM_RADIO_STATIC_BASE = "https://livetiming.formula1.com/static"
+
 WMO_CODE_TO_MDI = {
     0: "mdi:weather-sunny",
     1: "mdi:weather-partly-cloudy",
@@ -286,6 +288,7 @@ async def async_setup_entry(
             data.get("race_control_coordinator"),
         ),
         "top_three": (None, data.get("top_three_coordinator")),
+        "team_radio": (F1TeamRadioSensor, data.get("team_radio_coordinator")),
         "pitstops": (F1PitStopsSensor, data.get("pitstop_coordinator")),
         "championship_prediction": (
             None,
@@ -476,6 +479,7 @@ class F1LiveTimingModeSensor(F1AuxEntity, SensorEntity):
         "TopThree",
         "TimingAppData",
         "ChampionshipPrediction",
+        "TeamRadio",
         "DriverRaceInfo",
         "CarData.z",
         "Position.z",
@@ -4997,6 +5001,187 @@ class F1InvestigationsSensor(F1BaseEntity, RestoreEntity, SensorEntity):
             "penalties": [],
             "last_update": None,
         }
+
+
+class F1TeamRadioSensor(
+    _ReplayOrAuthGatedStreamMixin, F1BaseEntity, RestoreEntity, SensorEntity
+):
+    """Sensor exposing the latest Team Radio clip."""
+
+    _device_category = "drivers"
+    _history_limit = 20
+
+    _attr_translation_key = "team_radio"
+    _auth_gated_stream = "TeamRadio"
+
+    def __init__(self, coordinator, unique_id, entry_id, device_name):
+        super().__init__(coordinator, unique_id, entry_id, device_name)
+        self._attr_icon = "mdi:headset"
+        self._attr_native_value = None
+        self._attr_extra_state_attributes = {}
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._last_utc: str | None = None
+        self._history: list[dict] = []
+        self._sequence = 0
+
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        removal = self.coordinator.async_add_listener(self._handle_coordinator_update)
+        self.async_on_remove(removal)
+
+        payload = self._extract_current()
+        updated = payload is not None
+        if payload:
+            self._apply_payload(payload, force=True)
+        elif self._is_stream_active():
+            last = await self.async_get_last_state()
+            if last and last.state not in (None, "unknown", "unavailable"):
+                self._attr_native_value = last.state
+                self._attr_extra_state_attributes = dict(
+                    getattr(last, "attributes", {}) or {}
+                )
+                hist = self._attr_extra_state_attributes.get("history")
+                if isinstance(hist, list):
+                    self._history = [
+                        dict(item)
+                        for item in hist[: self._history_limit]
+                        if isinstance(item, dict)
+                    ]
+                self._last_utc = self._attr_extra_state_attributes.get("utc")
+        else:
+            self._clear_state()
+        self._handle_stream_state(updated)
+        self.async_write_ha_state()
+
+    def _extract_current(self) -> dict | None:
+        data = self.coordinator.data
+        if isinstance(data, dict):
+            latest = data.get("latest")
+            if isinstance(latest, dict):
+                return latest
+        return None
+
+    @staticmethod
+    def _cleanup_string(value) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _normalize_utc(self, utc_str: str | None) -> str | None:
+        text = self._cleanup_string(utc_str)
+        if not text:
+            return None
+        try:
+            parsed = datetime.datetime.fromisoformat(text.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=datetime.UTC)
+            return parsed.astimezone(datetime.UTC).isoformat(timespec="seconds")
+        except Exception:
+            return text
+
+    def _build_clip_url(self, payload: dict, path: str | None) -> str | None:
+        if not path:
+            return None
+
+        static_root = self._cleanup_string(
+            payload.get("_static_root") or payload.get("static_root")
+        )
+        if static_root:
+            return f"{static_root.rstrip('/')}/{path.lstrip('/')}"
+
+        try:
+            reg = self.hass.data.get(DOMAIN, {}).get(self._entry_id)
+            live_supervisor = (
+                reg.get("live_supervisor") if isinstance(reg, dict) else None
+            )
+            window = getattr(live_supervisor, "current_window", None)
+            base_path = getattr(window, "path", None)
+            if not isinstance(base_path, str) or not base_path:
+                return None
+
+            cleaned_base = base_path.strip("/")
+            year = None
+            if isinstance(reg, dict):
+                session_coord = reg.get("session_coordinator")
+                year = getattr(session_coord, "year", None)
+            if cleaned_base and not re.match(r"^\d{4}/", f"{cleaned_base}/"):
+                if year and str(year).isdigit():
+                    cleaned_base = f"{int(year)}/{cleaned_base}"
+            root = f"{TEAM_RADIO_STATIC_BASE}/{cleaned_base}"
+            return f"{root}/{path.lstrip('/')}"
+        except Exception:
+            return None
+
+    def _apply_payload(self, payload: dict, *, force: bool = False) -> None:
+        if not isinstance(payload, dict):
+            return
+        utc_raw = (
+            payload.get("Utc")
+            or payload.get("utc")
+            or payload.get("processedAt")
+            or payload.get("timestamp")
+        )
+        utc_norm = self._normalize_utc(utc_raw)
+        if utc_norm and self._last_utc == utc_norm and not force:
+            return
+
+        racing_number = self._cleanup_string(payload.get("RacingNumber"))
+        path = self._cleanup_string(payload.get("Path"))
+        clip_url = self._build_clip_url(payload, path)
+        received_at = dt_util.utcnow().isoformat(timespec="seconds")
+
+        self._sequence += 1
+
+        attrs = {
+            "utc": utc_norm,
+            "received_at": received_at,
+            "racing_number": racing_number,
+            "path": path,
+            "clip_url": clip_url,
+            "sequence": self._sequence,
+            "raw_message": payload,
+        }
+
+        self._history.insert(
+            0,
+            {
+                "utc": utc_norm,
+                "racing_number": racing_number,
+                "path": path,
+                "clip_url": clip_url,
+            },
+        )
+        self._history = self._history[: self._history_limit]
+        attrs["history"] = [dict(item) for item in self._history]
+
+        self._attr_native_value = utc_norm
+        self._attr_extra_state_attributes = attrs
+        self._last_utc = utc_norm
+
+    def _handle_coordinator_update(self) -> None:
+        payload = self._extract_current()
+        updated = payload is not None
+        if not self._handle_stream_state(updated):
+            return
+        if not self._is_stream_active():
+            self._safe_write_ha_state()
+            return
+        if payload is None:
+            return
+        self._apply_payload(payload)
+        self._safe_write_ha_state()
+
+    @property
+    def state(self):
+        return self._attr_native_value
+
+    def _clear_state(self) -> None:
+        self._attr_native_value = None
+        self._attr_extra_state_attributes = {}
+        self._history = []
+        self._sequence = 0
+        self._last_utc = None
 
 
 class F1PitStopsSensor(

--- a/custom_components/f1_sensor/signalr.py
+++ b/custom_components/f1_sensor/signalr.py
@@ -50,6 +50,7 @@ AUTH_GATED_LIVE_STREAMS = (
     "Position.z",
     "DriverRaceInfo",
     "ChampionshipPrediction",
+    "TeamRadio",
     "PitStopSeries",
 )
 

--- a/custom_components/f1_sensor/tests/test_diagnostics.py
+++ b/custom_components/f1_sensor/tests/test_diagnostics.py
@@ -92,6 +92,7 @@ async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
                     "CarData.z",
                     "ChampionshipPrediction",
                     "PitStopSeries",
+                    "TeamRadio",
                 }
             ),
             "replay_only_streams": frozenset(),
@@ -101,6 +102,7 @@ async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
                     "TrackStatus",
                     "ChampionshipPrediction",
                     "PitStopSeries",
+                    "TeamRadio",
                 }
             ),
             "auth_enabled": True,
@@ -122,11 +124,13 @@ async def test_diagnostics_redacts_auth_header_and_exposes_safe_runtime_state(
             "CarData.z",
             "ChampionshipPrediction",
             "PitStopSeries",
+            "TeamRadio",
         ],
         "active_live_streams": [
             "ChampionshipPrediction",
             "PitStopSeries",
             "SessionStatus",
+            "TeamRadio",
             "TrackStatus",
         ],
     }
@@ -193,6 +197,7 @@ async def test_diagnostics_hides_auth_state_when_f1tv_auth_disabled(
                     "CarData.z",
                     "ChampionshipPrediction",
                     "PitStopSeries",
+                    "TeamRadio",
                 }
             ),
             "replay_only_streams": frozenset(),

--- a/custom_components/f1_sensor/tests/test_live_delay_queue.py
+++ b/custom_components/f1_sensor/tests/test_live_delay_queue.py
@@ -9,6 +9,7 @@ from custom_components.f1_sensor.__init__ import (
     MAX_DELAY_QUEUE_ITEMS,
     LiveDriversCoordinator,
     PitStopCoordinator,
+    TeamRadioCoordinator,
     TopThreeCoordinator,
     _apply_delay_with_queue,
     _close_delayed_ingest_state,
@@ -250,5 +251,61 @@ async def test_pitstop_continues_updating_with_live_delay(hass) -> None:
         await hass.async_block_till_done()
         assert coordinator.data["total_stops"] == 2
         assert len(coordinator.data["cars"]["44"]["stops"]) == 2
+    finally:
+        await coordinator.async_close()
+
+
+@pytest.mark.asyncio
+async def test_team_radio_continues_updating_with_live_delay(hass) -> None:
+    coordinator = TeamRadioCoordinator(
+        hass,
+        session_coord=SimpleNamespace(),
+        delay_seconds=1,
+        bus=None,
+        config_entry=None,
+        delay_controller=None,
+        live_state=None,
+        history_limit=10,
+    )
+    wrapped = _wrap_delayed_handler(coordinator, coordinator._on_bus_message)
+
+    try:
+        wrapped(
+            {
+                "Captures": [
+                    {
+                        "Utc": "2026-03-06T04:52:47.5228207Z",
+                        "RacingNumber": "14",
+                        "Path": "TeamRadio/ALO_14_20260306_155235.mp3",
+                    }
+                ]
+            }
+        )
+        await asyncio.sleep(0.2)
+        wrapped(
+            {
+                "Captures": {
+                    "1": {
+                        "Utc": "2026-03-07T01:42:48.7125725Z",
+                        "RacingNumber": "63",
+                        "Path": "TeamRadio/RUS_63_20260307_124200.mp3",
+                    }
+                }
+            }
+        )
+
+        await asyncio.sleep(0.9)
+        await hass.async_block_till_done()
+        assert (
+            coordinator.data["latest"]["Path"] == "TeamRadio/ALO_14_20260306_155235.mp3"
+        )
+        assert len(coordinator.data["history"]) == 1
+
+        await asyncio.sleep(0.35)
+        await hass.async_block_till_done()
+        assert (
+            coordinator.data["latest"]["Path"] == "TeamRadio/RUS_63_20260307_124200.mp3"
+        )
+        assert len(coordinator.data["history"]) == 2
     finally:
         await coordinator.async_close()

--- a/custom_components/f1_sensor/tests/test_live_mode_restore.py
+++ b/custom_components/f1_sensor/tests/test_live_mode_restore.py
@@ -28,6 +28,7 @@ from custom_components.f1_sensor.sensor import (
     F1ChampionshipPredictionTeamsSensor,
     F1PitStopsSensor,
     F1StraightModeSensor,
+    F1TeamRadioSensor,
     F1TrackStatusSensor,
     F1TrackWeatherSensor,
 )
@@ -619,6 +620,13 @@ async def test_formation_start_is_available_during_auth_live_sessions(hass) -> N
     ("factory", "restored_state", "attributes"),
     [
         (
+            lambda coordinator, entry_id: F1TeamRadioSensor(
+                coordinator, f"{entry_id}_team_radio", entry_id, "F1"
+            ),
+            "2026-03-08T04:00:00+00:00",
+            {"history": []},
+        ),
+        (
             lambda coordinator, entry_id: F1PitStopsSensor(
                 coordinator, f"{entry_id}_pitstops", entry_id, "F1"
             ),
@@ -653,6 +661,14 @@ async def test_replay_capable_sensors_stay_unavailable_during_public_live(
 @pytest.mark.parametrize(
     ("factory", "restored_state", "attributes", "stream"),
     [
+        (
+            lambda coordinator, entry_id: F1TeamRadioSensor(
+                coordinator, f"{entry_id}_team_radio", entry_id, "F1"
+            ),
+            "2026-03-08T04:00:00+00:00",
+            {"history": []},
+            "TeamRadio",
+        ),
         (
             lambda coordinator, entry_id: F1PitStopsSensor(
                 coordinator, f"{entry_id}_pitstops", entry_id, "F1"

--- a/custom_components/f1_sensor/tests/test_replay_mode_timeouts.py
+++ b/custom_components/f1_sensor/tests/test_replay_mode_timeouts.py
@@ -43,6 +43,22 @@ class _TextResponse:
         return self._text
 
 
+class _RawTextResponse:
+    def __init__(self, text: str) -> None:
+        self.status = 200
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        del exc_type, exc, tb
+        return False
+
+    async def text(self) -> str:
+        return self._text
+
+
 class _IndexHttp:
     def __init__(self, payload: dict) -> None:
         self.payload = payload
@@ -51,6 +67,16 @@ class _IndexHttp:
     def get(self, url: str):
         self.get_calls.append(url)
         return _TextResponse(self.payload)
+
+
+class _StreamHttp:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.get_calls: list[str] = []
+
+    def get(self, url: str):
+        self.get_calls.append(url)
+        return _RawTextResponse(self.text)
 
 
 def _session() -> ReplaySession:
@@ -166,6 +192,33 @@ async def test_download_stream_timeout_returns_empty_list(hass) -> None:
 
     assert frames == []
     assert len(timeout_http.get_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_download_stream_annotates_team_radio_static_root(hass) -> None:
+    http = _StreamHttp(
+        "\n".join(
+            (
+                '00:00:01.000{"Captures":[{"Utc":"2026-07-05T14:01:01Z",'
+                '"RacingNumber":"3","Path":"TeamRadio/VER_3.mp3"}]}',
+                '00:00:02.000{"Captures":{"1":{"Utc":"2026-07-05T14:40:34Z",'
+                '"RacingNumber":"44","Path":"TeamRadio/HAM_44.mp3"}}}',
+            )
+        )
+    )
+    manager = ReplaySessionManager(hass, "entry-test", http)  # type: ignore[arg-type]
+
+    frames = await manager._download_stream(
+        "https://livetiming.formula1.com/static/2026/session/TeamRadio.jsonStream",
+        "TeamRadio",
+    )
+
+    assert len(frames) == 2
+    assert frames[0].stream == "TeamRadio"
+    assert frames[0].payload["_static_root"] == (
+        "https://livetiming.formula1.com/static/2026/session"
+    )
+    assert frames[1].payload["Captures"]["1"]["Path"] == "TeamRadio/HAM_44.mp3"
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_replay_only_coordinators.py
+++ b/custom_components/f1_sensor/tests/test_replay_only_coordinators.py
@@ -5,6 +5,7 @@ import pytest
 from custom_components.f1_sensor import (
     ChampionshipPredictionCoordinator,
     PitStopCoordinator,
+    TeamRadioCoordinator,
 )
 from custom_components.f1_sensor.live_window import LiveAvailabilityTracker
 
@@ -19,6 +20,7 @@ class _StubBus:
 @pytest.mark.parametrize(
     ("coordinator_cls", "extra_kwargs"),
     [
+        (TeamRadioCoordinator, {}),
         (PitStopCoordinator, {}),
     ],
 )

--- a/custom_components/f1_sensor/tests/test_replay_seek.py
+++ b/custom_components/f1_sensor/tests/test_replay_seek.py
@@ -36,6 +36,7 @@ from custom_components.f1_sensor.incident_detection import (
 )
 from custom_components.f1_sensor.live_window import LiveAvailabilityTracker
 from custom_components.f1_sensor.replay_mode import (
+    CACHE_VERSION,
     ReplayController,
     ReplayFrame,
     ReplayIndex,
@@ -649,7 +650,7 @@ async def test_replay_cached_index_upgrades_seek_checkpoints(
     upgraded = json.loads(index_file.read_text(encoding="utf-8"))
 
     assert index.seek_checkpoints
-    assert upgraded["cache_version"] == 12
+    assert upgraded["cache_version"] == CACHE_VERSION
     assert upgraded["seek_checkpoints"][0]["state"]["TrackStatus"] == {"Status": "1"}
 
 

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -55,6 +55,7 @@ from custom_components.f1_sensor.sensor import (
     F1PitStopsSensor,
     F1SeasonResultsSensor,
     F1SprintResultsSensor,
+    F1TeamRadioSensor,
     F1TopThreePositionSensor,
     F1TrackTimeSensor,
     F1TvTokenExpiresAtSensor,
@@ -2046,6 +2047,45 @@ async def test_pitstops_sensor_excludes_cars_from_recorder(hass) -> None:
     sensor._apply_payload(updated_payload)
 
     assert sensor.last_reset == datetime.fromisoformat("2026-03-01T15:00:00+00:00")
+
+
+@pytest.mark.asyncio
+async def test_team_radio_sensor_exposes_latest_clip_url(hass) -> None:
+    coordinator = _build_coordinator(
+        hass,
+        {
+            "latest": {
+                "Utc": "2026-07-05T14:01:01.3296419Z",
+                "RacingNumber": "44",
+                "Path": "TeamRadio/HAM_44_20260705_154016.mp3",
+                "_static_root": (
+                    "https://livetiming.formula1.com/static/2026/"
+                    "2026-07-05_British_Grand_Prix/2026-07-05_Race"
+                ),
+            },
+            "history": [],
+        },
+    )
+    entry_id = "test_entry_team_radio"
+    _set_entry_context(hass, entry_id, stream_active=True)
+
+    sensor = F1TeamRadioSensor(
+        coordinator,
+        f"{entry_id}_team_radio",
+        entry_id,
+        "F1",
+    )
+    state = await _add_sensor_and_get_state(hass, sensor)
+
+    assert state.state == "2026-07-05T14:01:01+00:00"
+    assert state.attributes["racing_number"] == "44"
+    assert state.attributes["path"] == "TeamRadio/HAM_44_20260705_154016.mp3"
+    assert state.attributes["clip_url"] == (
+        "https://livetiming.formula1.com/static/2026/"
+        "2026-07-05_British_Grand_Prix/2026-07-05_Race/"
+        "TeamRadio/HAM_44_20260705_154016.mp3"
+    )
+    assert state.attributes["history"][0]["clip_url"] == state.attributes["clip_url"]
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_setup.py
+++ b/custom_components/f1_sensor/tests/test_setup.py
@@ -1075,6 +1075,9 @@ async def test_async_setup_entry_live_mode_registers_replay_only_components(
             patch("custom_components.f1_sensor.TopThreeCoordinator", DummyCoordinator)
         )
         stack.enter_context(
+            patch("custom_components.f1_sensor.TeamRadioCoordinator", DummyCoordinator)
+        )
+        stack.enter_context(
             patch(
                 "custom_components.f1_sensor.LiveDriversCoordinator", DummyCoordinator
             )
@@ -1097,6 +1100,7 @@ async def test_async_setup_entry_live_mode_registers_replay_only_components(
             "LiveModeCoordinator",
             "LiveDriversCoordinator",
             "TopThreeCoordinator",
+            "TeamRadioCoordinator",
             "PitStopCoordinator",
             "ChampionshipPredictionCoordinator",
         ):
@@ -1126,6 +1130,7 @@ async def test_async_setup_entry_live_mode_registers_replay_only_components(
     assert entry_data["operation_mode"] == OPERATION_MODE_LIVE
     assert entry_data["formation_start_tracker"] is sentinel_tracker
     assert entry_data["incident_coordinator"] is not None
+    assert entry_data["team_radio_coordinator"] is not None
     assert entry_data["pitstop_coordinator"] is not None
     assert entry_data["championship_prediction_coordinator"] is not None
 

--- a/custom_components/f1_sensor/tests/test_signalr_core.py
+++ b/custom_components/f1_sensor/tests/test_signalr_core.py
@@ -384,6 +384,7 @@ def test_no_auth_live_stream_contract_excludes_gated_and_replay_only_streams():
         "Position.z",
         "DriverRaceInfo",
         "ChampionshipPrediction",
+        "TeamRadio",
         "PitStopSeries",
     )
     assert REPLAY_ONLY_STREAMS == ()

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -21,6 +21,7 @@
       "new_race_control_message": "New race control message",
       "new_fia_document": "New FIA document published",
       "investigation_changed": "Investigation status changed",
+      "new_team_radio": "New team radio message",
       "live_timing_online": "Live timing came online",
       "live_timing_offline": "Live timing went offline"
     }
@@ -255,6 +256,9 @@
       },
       "tyre_statistics": {
         "name": "Tyre statistics"
+      },
+      "team_radio": {
+        "name": "Team radio"
       },
       "race_lap_count": {
         "name": "Race lap count"

--- a/custom_components/f1_sensor/translations/fi.json
+++ b/custom_components/f1_sensor/translations/fi.json
@@ -21,6 +21,7 @@
       "new_race_control_message": "Uusi viesti kilpailun johdolta",
       "new_fia_document": "Uusi FIA:n dokumentti julkaistu",
       "investigation_changed": "Tutkinnan tila muuttui",
+      "new_team_radio": "Uusi tiimiradioviesti",
       "live_timing_online": "Live-ajoitus yhdistetty",
       "live_timing_offline": "Live-ajoitus katkaistu"
     }
@@ -207,6 +208,9 @@
       },
       "tyre_statistics": {
         "name": "Rengastilastot"
+      },
+      "team_radio": {
+        "name": "Tiimiradio"
       },
       "race_lap_count": {
         "name": "Kierrosmäärä"

--- a/custom_components/f1_sensor/translations/it.json
+++ b/custom_components/f1_sensor/translations/it.json
@@ -21,6 +21,7 @@
       "new_race_control_message": "Nuovo messaggio dalla direzione gara",
       "new_fia_document": "Nuovo documento FIA pubblicato",
       "investigation_changed": "Stato investigazione cambiato",
+      "new_team_radio": "Nuovo team radio",
       "live_timing_online": "Telemetria online",
       "live_timing_offline": "Telemetria offline"
     }
@@ -244,6 +245,9 @@
       },
       "tyre_statistics": {
         "name": "Statistiche gomme"
+      },
+      "team_radio": {
+        "name": "Team radio"
       },
       "race_lap_count": {
         "name": "Numero giri"

--- a/custom_components/f1_sensor/translations/sv.json
+++ b/custom_components/f1_sensor/translations/sv.json
@@ -21,6 +21,7 @@
       "new_race_control_message": "Nytt Race Control-meddelande",
       "new_fia_document": "Nytt FIA-dokument publicerat",
       "investigation_changed": "Utredningsstatus ändrad",
+      "new_team_radio": "Nytt teamradio-meddelande",
       "live_timing_online": "Live timing online",
       "live_timing_offline": "Live timing offline"
     }
@@ -251,6 +252,9 @@
       },
       "tyre_statistics": {
         "name": "Däckstatistik"
+      },
+      "team_radio": {
+        "name": "Teamradio"
       },
       "race_lap_count": {
         "name": "Varvsräkning"

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -53,7 +53,7 @@ Use ready-made blueprints for [Track Status lights](/blueprints/track-status-lig
 | Mode | What it means |
 | --- | --- |
 | Public live timing | Standard live mode without F1TV Auth. Core live entities and confirmed incident alerts work here |
-| F1TV Auth live timing | Optional mode for extra live features such as live Track Map, Pit Stops, Championship Prediction, and earlier incident candidates |
+| F1TV Auth live timing | Optional mode for extra live features such as live Track Map, Pit Stops, Team Radio, Championship Prediction, and earlier incident candidates |
 | Replay Mode | Historical playback from Formula 1's session archive. Some live-auth features can appear later when the archived session contains the needed data |
 | Developer mode | Advanced testing with a local replay dump. Use it to reproduce integration behavior, not to follow a TV replay |
 

--- a/docs/entities/live_data.md
+++ b/docs/entities/live_data.md
@@ -22,7 +22,7 @@ Live data uses three separate availability modes:
 | Mode | What it means |
 | --- | --- |
 | Public live timing | Standard live mode without F1TV Auth. This powers session status, track status, Safety Car, Race Control, weather, driver timing, tyres, top three, and confirmed incident detection |
-| F1TV Auth live timing | Optional live mode. It can add extra live data for features such as Track Map, Pit Stops, Championship Prediction, formation start refinement, and earlier incident candidates |
+| F1TV Auth live timing | Optional live mode. It can add extra live data for features such as Track Map, Pit Stops, Team Radio, Championship Prediction, formation start refinement, and earlier incident candidates |
 | Replay Mode | Historical playback from Formula 1's session archive. Some data that requires F1TV Auth live can work later when the replay archive contains it |
 
 [Track Map](/features/track-map) is not a normal Home Assistant entity. It is a dashboard card feature that uses live or replay car position data when available.
@@ -147,6 +147,7 @@ Use this section to understand the possible values for enum-type states and attr
 | [sensor.f1_track_weather](#track-weather)             | Current on-track weather (air temp, track temp, rainfall, wind speed, etc.)|
 | [sensor.f1_driver_list](#driver-list)                 | Show list and details on all drivers, including team color, headshot URL etc| 
 | [sensor.f1_pitstops](#pit-stops)                      | Pit stop events and aggregated pit stop series per car `(Replay Mode or F1TV Auth live timing)` |
+| [sensor.f1_team_radio](#team-radio)                   | Latest team radio clip and rolling history `(Replay Mode or F1TV Auth live timing)` |
 | [sensor.f1_current_tyres](#current-tyres)             | Current tyre compound per driver |
 | [sensor.f1_tyre_statistics](#tyre-statistics)         | Aggregated tyre statistics per compound |
 | [sensor.f1_driver_positions](#driver-positions)       | Driver positions and lap times |
@@ -167,7 +168,7 @@ Use this section to understand the possible values for enum-type states and attr
 All of these entities update **only in relation to an active session**, typically starting less than an hour before and continuing for a few minutes after the session ends. Outside these windows, the entities will be set to **Unavailable** (not updating and not providing new data).
 :::
 :::info[Replay and F1TV Auth live timing entities]
-Some entities stay registered in Home Assistant even when the needed source data is not available. Pit Stops and Championship Prediction can update in [Replay Mode](/features/replay-mode) and can update during live sessions when [F1TV Auth](/features/f1tv-auth) is paired with a valid token.
+Some entities stay registered in Home Assistant even when the needed source data is not available. Pit Stops, Team Radio, and Championship Prediction can update in [Replay Mode](/features/replay-mode) and can update during live sessions when [F1TV Auth](/features/f1tv-auth) is paired with a valid token.
 
 Formation Start can also improve during live sessions when the needed extra live timing data is available.
 :::
@@ -731,6 +732,47 @@ Each entry in `stops` contains:
 :::info[INFO]
 Available during race and sprint sessions in Replay Mode, and during live F1TV Auth timing when the required extra live data is available.
 :::
+
+---
+
+## Team Radio
+:::info[Replay Mode or F1TV Auth live timing]
+This entity stays registered in Home Assistant. It updates in [Replay Mode](/features/replay-mode) and can update during live sessions when [F1TV Auth](/features/f1tv-auth) is paired with a valid token and live team radio data is available.
+:::
+
+Latest curated team radio clip with a rolling history. This is not the full raw driver radio feed; it follows the Team Radio clips Formula 1 publishes for the session.
+
+**State**
+- ISO-8601 timestamp of the most recent radio clip, or `unknown` when none are available.
+
+**Example**
+```text
+2026-07-05T14:01:01+00:00
+```
+
+**Attributes**
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| utc | string | ISO-8601 timestamp of the radio clip |
+| received_at | string | ISO-8601 timestamp when Home Assistant received the message |
+| racing_number | string | Car number for the driver |
+| path | string | Relative path to the audio file |
+| clip_url | string | Full URL to the audio clip when available |
+| sequence | number | Message counter for deduplication |
+| raw_message | object | Raw team radio capture from the timing feed |
+| history | list | Rolling list of recent radio clips, up to 20 items |
+
+Each entry in `history` contains:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| utc | string | ISO-8601 timestamp of the radio clip |
+| racing_number | string | Car number for the driver |
+| path | string | Relative path to the audio file |
+| clip_url | string | Full URL to the audio clip when available |
+
+---
 
 ## Current Tyres
 

--- a/docs/features/f1tv-auth.md
+++ b/docs/features/f1tv-auth.md
@@ -31,7 +31,7 @@ Public live timing covers the normal live features most dashboards and automatio
 
 ## What F1TV Auth can add during live sessions
 
-F1TV Auth can support live features such as Track Map, Pit Stops, Championship Prediction, formation start refinement, and earlier incident candidate signals. These features still depend on what Formula 1 publishes for each session, so a valid token does not guarantee that every extra feature is available every time.
+F1TV Auth can support live features such as Track Map, Pit Stops, Team Radio, Championship Prediction, formation start refinement, and earlier incident candidate signals. These features still depend on what Formula 1 publishes for each session, so a valid token does not guarantee that every extra feature is available every time.
 
 ## Subscription requirement
 
@@ -55,6 +55,7 @@ Public live timing continues to work if F1TV access is missing, expired, invalid
 | Track Map | Not available live | Requires F1TV Auth and live car position data | Works when replay contains car position data |
 | Incident location context | Not available from live position | Can improve when Track Map has fresh location data | Works when replay contains car position data |
 | Pit Stops | Not available live | Can work when Formula 1 publishes live pit stop data | Works when replay contains pit stop data |
+| Team Radio | Not available live | Can work when Formula 1 publishes live team radio clips | Works when replay contains team radio clips |
 | Championship Prediction | Not available live | Can work when Formula 1 publishes live prediction data | Works when replay contains prediction data |
 | Formation Start | Public fallback only where available | Can improve when extra live timing data is available | Works in Replay Mode |
 

--- a/docs/features/replay-mode.md
+++ b/docs/features/replay-mode.md
@@ -66,7 +66,7 @@ Testing the integration with a dump supplied or captured for development? Use [D
 
 Replay Mode is separate from live F1TV Auth. Public live timing works without a token, optional [F1TV Auth](/features/f1tv-auth) can unlock extra live features during a real live session, and Replay Mode can use archived data after the session has completed.
 
-This means Replay Mode can sometimes show data that public live timing did not show during the live session. For example, Pit Stops, Championship Prediction, Track Map, and incident location context can work in replay when the archive contains the needed data.
+This means Replay Mode can sometimes show data that public live timing did not show during the live session. For example, Pit Stops, Team Radio, Championship Prediction, Track Map, and incident location context can work in replay when the archive contains the needed data.
 
 ## What Replay Mode can replay
 
@@ -74,6 +74,7 @@ This means Replay Mode can sometimes show data that public live timing did not s
 | --- | --- |
 | Public live timing | Session status, track status, Race Control, weather, driver timing, tyres, and top three can replay when available in the archive |
 | Pit Stops | Works when the replay archive contains pit stop data |
+| Team Radio | Works when the replay archive contains team radio clips |
 | Championship Prediction | Works when the replay archive contains prediction data |
 | Formation Start | Works for race and sprint sessions when the replay data supports it |
 | Track Map | Best effort when the replay archive contains car position data |

--- a/docs/getting-started/add-integration.md
+++ b/docs/getting-started/add-integration.md
@@ -31,7 +31,7 @@ The setup form lets you choose how much F1 data Home Assistant should create and
 | **Enabled sensors** | Select the static, live, and helper entities you want Home Assistant to create |
 | **Enable live F1 API** | Turn this on for live session status, track status, Safety Car, Race Control, weather, timing, tyres, and incident alerts |
 | **First day of race week** | Choose when `binary_sensor.f1_race_week` should turn on for your dashboards and automations |
-| **Connect F1TV access with Token Helper** | Optional. Use this only when you want extra live-auth features such as live Track Map, Pit Stops, Championship Prediction, or earlier incident candidates |
+| **Connect F1TV access with Token Helper** | Optional. Use this only when you want extra live-auth features such as live Track Map, Pit Stops, Team Radio, Championship Prediction, or earlier incident candidates |
 
 :::info[F1TV Auth is optional]
 Public live timing works without F1TV Auth. Leave F1TV pairing off if you only need schedules, standings, public live timing, Race Control, weather, driver timing, tyres, and confirmed incident alerts.
@@ -57,7 +57,7 @@ The integration organizes all entities across **six dedicated sub-devices**, whi
 | **Race** | Next race info, track time, race week indicator, season calendar |
 | **Championship** | Driver and constructor standings, points progression, championship predictions* |
 | **Session** | Session status, track status, safety car, weather, timing sensors, starting grid, formation start*, overtake mode, straight mode |
-| **Drivers** | Driver list, tyres, tyre statistics, driver positions, pit stops* |
+| **Drivers** | Driver list, tyres, tyre statistics, driver positions, pit stops*, team radio* |
 | **Officials** | Race control messages, FIA documents, track limits, investigations |
 | **System** | Live delay, calibration controls, replay controls, live timing connectivity, F1TV token status and controls |
 
@@ -80,7 +80,7 @@ For detailed instructions on syncing with your TV, including guided calibration,
 
 Public live timing works without F1TV Auth. This covers the normal live features most users need, including session status, track status, Safety Car, Race Control, weather, driver timing, tyres, and confirmed incident alerts.
 
-Optional [F1TV Auth](/features/f1tv-auth) can be paired with the [F1TV Token Helper](/help/f1tv-token-helper) when you want extra live timing features during a real live session. It can enable or improve features such as [Track Map](/features/track-map), Pit Stops, Championship Prediction, formation start data, and earlier incident candidates.
+Optional [F1TV Auth](/features/f1tv-auth) can be paired with the [F1TV Token Helper](/help/f1tv-token-helper) when you want extra live timing features during a real live session. It can enable or improve features such as [Track Map](/features/track-map), Pit Stops, Team Radio, Championship Prediction, formation start data, and earlier incident candidates.
 
 Replay Mode is a separate mode. It can show some data that requires F1TV Auth during live sessions because replay uses Formula 1's public session archive after the session has completed.
 

--- a/docs/help/f1tv-auth-setup.md
+++ b/docs/help/f1tv-auth-setup.md
@@ -4,7 +4,7 @@ title: F1TV Auth Setup
 ---
 
 F1TV Auth connects optional Formula 1 live timing access to F1 Sensor through the F1TV Token Helper.
-Use this page when you want live Track Map, Pit Stops, Championship Prediction, formation start refinements, or earlier incident candidates during an active Formula 1 session.
+Use this page when you want live Track Map, Pit Stops, Team Radio, Championship Prediction, formation start refinements, or earlier incident candidates during an active Formula 1 session.
 
 ## How it works
 
@@ -43,6 +43,7 @@ F1TV Auth can add live features such as:
 ```text
 Live Track Map
 Pit Stops during live sessions
+Team Radio during live sessions
 Championship Prediction during live sessions
 Formation start improvements
 Earlier incident candidates
@@ -52,7 +53,7 @@ In **Live Mode**, these features should not be expected to update with public li
 They can update during live sessions after you add a valid F1TV token and Formula 1 publishes the required data.
 
 Some F1TV Auth features also have replay support.
-For example, Championship Prediction and Pit Stops can use the recorded session archive in **Replay Mode**, but they require F1TV Auth during a real live session.
+For example, Championship Prediction, Pit Stops, and Team Radio can use the recorded session archive in **Replay Mode**, but they require F1TV Auth during a real live session.
 
 If the token is missing, expired, or rejected, extra live data becomes unavailable or stops receiving F1TV-only updates while public live timing continues.
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -73,7 +73,7 @@ F1 controls subscription names, availability, and prices. As a rough guide, F1 T
 
 F1TV Auth can unlock extra live data when Formula 1 provides it during an active session.
 
-This can enable live [Track Map](/features/track-map), Pit Stops, Championship Prediction, formation start improvements, and earlier incident candidates. Replay Mode is separate and can show some of this data later when the replay archive contains it.
+This can enable live [Track Map](/features/track-map), Pit Stops, Team Radio, Championship Prediction, formation start improvements, and earlier incident candidates. Replay Mode is separate and can show some of this data later when the replay archive contains it.
 </details>
 
 <details>
@@ -99,12 +99,13 @@ The same cleanup clears the Home Assistant Repairs warning for stale standalone 
 
 
 <details>
-<summary>Why are some entities like Pit Stops and Championship Prediction unavailable without F1TV Auth?</summary>
+<summary>Why are some entities like Pit Stops, Team Radio, and Championship Prediction unavailable without F1TV Auth?</summary>
 
 These entities depend on data that is not part of public live timing. They can update in [Replay Mode](/features/replay-mode), and they can update during real live sessions when [F1TV Auth](/features/f1tv-auth) is paired with a valid token. Without that token, they remain unavailable while public live timing continues.
 
 The affected entities are:
 - `sensor.f1_pitstops`
+- `sensor.f1_team_radio`
 - `sensor.f1_championship_prediction_drivers`
 - `sensor.f1_championship_prediction_teams`
 - `binary_sensor.f1_formation_start`
@@ -125,7 +126,7 @@ Check `sensor.f1_f1tv_token_status`, the Track Map card status, and `sensor.f1_l
 
 Replay Mode uses Formula 1's session archive after the session has completed. Some data that requires F1TV Auth during a live session can be available later in the replay archive.
 
-That is why Track Map, Pit Stops, Championship Prediction, or incident location context can appear in Replay Mode even when they were not available from public live timing during the live session.
+That is why Track Map, Pit Stops, Team Radio, Championship Prediction, or incident location context can appear in Replay Mode even when they were not available from public live timing during the live session.
 </details>
 
 


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [X] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [X] Tested locally with a real Home Assistant instance
- [X] Existing automations and dashboards still work as expected after the change

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [X] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [X] Tests have been added or updated and pass locally — if applicable
- [X] Translations updated if new UI strings were added — if applicable
- [X] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
