### PR TITLE
Dev

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -115,6 +115,7 @@ from .live_window import (
     LiveSessionSupervisor,
 )
 from .no_spoiler import NoSpoilerModeManager
+from .race_weather import F1RaceWeatherCoordinator
 from .replay import ReplaySignalRClient
 from .replay_mode import ReplayController, ReplayState
 from .replay_start import ReplayStartReferenceController
@@ -1603,6 +1604,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     if next_race_history_coordinator is not None:
         next_race_history_coordinator._no_spoiler_sensitive = False
+    race_weather_coordinator = (
+        F1RaceWeatherCoordinator(
+            hass,
+            race_coordinator,
+            session=http_session,
+            config_entry=entry,
+        )
+        if race_coordinator is not None and "weather" in enabled
+        else None
+    )
     driver_coordinator = (
         F1DataCoordinator(
             hass,
@@ -2027,6 +2038,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await race_coordinator.async_config_entry_first_refresh()
     if next_race_history_coordinator:
         await next_race_history_coordinator.async_refresh()
+    if race_weather_coordinator:
+        # Weather is an optional upstream. A failed first refresh must not prevent
+        # unrelated F1 entities from loading; CoordinatorEntity exposes it as
+        # unavailable and the hourly coordinator will retry automatically.
+        await race_weather_coordinator.async_refresh()
     if driver_coordinator:
         await driver_coordinator.async_config_entry_first_refresh()
     if constructor_coordinator:
@@ -2195,6 +2211,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "http_persist": persisted_map,
         "race_coordinator": race_coordinator,
         "next_race_history_coordinator": next_race_history_coordinator,
+        "race_weather_coordinator": race_weather_coordinator,
         "driver_coordinator": driver_coordinator,
         "constructor_coordinator": constructor_coordinator,
         "last_race_coordinator": last_race_coordinator,
@@ -2264,6 +2281,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "activity_filter_unsub": None,
         "no_spoiler_unsub": None,
     }
+
+    if race_weather_coordinator is not None:
+        race_weather_coordinator.async_start()
 
     if race_control_log_store is not None:
         _async_register_race_control_log_interfaces(hass)

--- a/custom_components/f1_sensor/binary_sensor.py
+++ b/custom_components/f1_sensor/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.event import async_track_time_interval
@@ -38,7 +39,7 @@ from .entity import (
     is_auth_gated_stream_active,
     is_no_spoiler_live_state,
     is_replay_only_stream_active,
-    set_suggested_object_id,
+    set_default_entity_id,
 )
 from .formation_start import FormationStartTracker
 from .helpers import get_next_race, normalize_track_status
@@ -110,7 +111,9 @@ async def async_setup_entry(
             entry.entry_id,
             base,
         )
-        set_suggested_object_id(sensor, default_object_id("live_timing_online"))
+        set_default_entity_id(
+            sensor, Platform.BINARY_SENSOR, default_object_id("live_timing_online")
+        )
         sensors.append(sensor)
     if "race_week" not in disabled:
         sensor = F1RaceWeekSensor(
@@ -120,7 +123,9 @@ async def async_setup_entry(
             base,
             race_week_start=race_week_start,
         )
-        set_suggested_object_id(sensor, default_object_id("race_week"))
+        set_default_entity_id(
+            sensor, Platform.BINARY_SENSOR, default_object_id("race_week")
+        )
         sensors.append(sensor)
     if "safety_car" not in disabled:
         coord = data.get("track_status_coordinator")
@@ -131,7 +136,9 @@ async def async_setup_entry(
                 entry.entry_id,
                 base,
             )
-            set_suggested_object_id(sensor, default_object_id("safety_car"))
+            set_default_entity_id(
+                sensor, Platform.BINARY_SENSOR, default_object_id("safety_car")
+            )
             sensors.append(sensor)
     if "on_track_incident" not in disabled:
         coord = data.get("incident_coordinator")
@@ -142,7 +149,11 @@ async def async_setup_entry(
                 entry.entry_id,
                 base,
             )
-            set_suggested_object_id(sensor, default_object_id("on_track_incident"))
+            set_default_entity_id(
+                sensor,
+                Platform.BINARY_SENSOR,
+                default_object_id("on_track_incident"),
+            )
             sensors.append(sensor)
     if "possible_on_track_incident" not in disabled:
         coord = data.get("incident_coordinator")
@@ -153,8 +164,10 @@ async def async_setup_entry(
                 entry.entry_id,
                 base,
             )
-            set_suggested_object_id(
-                sensor, default_object_id("possible_on_track_incident")
+            set_default_entity_id(
+                sensor,
+                Platform.BINARY_SENSOR,
+                default_object_id("possible_on_track_incident"),
             )
             sensors.append(sensor)
     if "formation_start" not in disabled:
@@ -166,7 +179,9 @@ async def async_setup_entry(
                 entry.entry_id,
                 base,
             )
-            set_suggested_object_id(sensor, default_object_id("formation_start"))
+            set_default_entity_id(
+                sensor, Platform.BINARY_SENSOR, default_object_id("formation_start")
+            )
             sensors.append(sensor)
     if "overtake_mode" not in disabled:
         coord = data.get("live_mode_coordinator")
@@ -177,7 +192,9 @@ async def async_setup_entry(
                 entry.entry_id,
                 base,
             )
-            set_suggested_object_id(sensor, default_object_id("overtake_mode"))
+            set_default_entity_id(
+                sensor, Platform.BINARY_SENSOR, default_object_id("overtake_mode")
+            )
             sensors.append(sensor)
     async_add_entities(sensors, True)
 

--- a/custom_components/f1_sensor/button.py
+++ b/custom_components/f1_sensor/button.py
@@ -8,6 +8,7 @@ import time
 from homeassistant.components import persistent_notification
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 
@@ -28,7 +29,7 @@ from .const import (
     CONF_LIVE_TIMING_AUTH_HEADER,
     DOMAIN,
 )
-from .entity import F1AuxEntity, default_object_id, set_suggested_object_id
+from .entity import F1AuxEntity, default_object_id, set_default_entity_id
 from .replay_entities import (
     F1ReplayBackButton,
     F1ReplayForwardButton,
@@ -59,7 +60,9 @@ async def async_setup_entry(
             entry.entry_id,
             name,
         )
-        set_suggested_object_id(entity, default_object_id("delay_calibration_match"))
+        set_default_entity_id(
+            entity, Platform.BUTTON, default_object_id("delay_calibration_match")
+        )
         entities.append(entity)
 
     # Public F1TV auth can be enabled without exposing developer-only Jolpica
@@ -71,7 +74,9 @@ async def async_setup_entry(
             device_name=name,
             unique_id=f"{entry.entry_id}_clear_f1tv_access",
         )
-        set_suggested_object_id(entity, default_object_id("clear_f1tv_access"))
+        set_default_entity_id(
+            entity, Platform.BUTTON, default_object_id("clear_f1tv_access")
+        )
         entities.append(entity)
 
     if is_auth_feature_enabled():
@@ -81,7 +86,9 @@ async def async_setup_entry(
             device_name=name,
             unique_id=f"{entry.entry_id}_refresh_f1tv_access",
         )
-        set_suggested_object_id(entity, default_object_id("refresh_f1tv_access"))
+        set_default_entity_id(
+            entity, Platform.BUTTON, default_object_id("refresh_f1tv_access")
+        )
         entities.append(entity)
 
     if const.ENABLE_DEVELOPMENT_MODE_UI and registry.get("http_session") is not None:
@@ -91,7 +98,9 @@ async def async_setup_entry(
             device_name=name,
             unique_id=f"{entry.entry_id}_jolpica_user_agent_test",
         )
-        set_suggested_object_id(entity, default_object_id("jolpica_ua_test"))
+        set_default_entity_id(
+            entity, Platform.BUTTON, default_object_id("jolpica_ua_test")
+        )
         entities.append(entity)
 
     # Replay mode buttons
@@ -113,7 +122,7 @@ async def async_setup_entry(
                 entry.entry_id,
                 name,
             )
-            set_suggested_object_id(entity, default_object_id(key))
+            set_default_entity_id(entity, Platform.BUTTON, default_object_id(key))
             entities.append(entity)
 
     if entities:

--- a/custom_components/f1_sensor/calendar.py
+++ b/custom_components/f1_sensor/calendar.py
@@ -7,11 +7,12 @@ import logging
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity import F1BaseEntity, default_object_id, set_suggested_object_id
+from .entity import F1BaseEntity, default_object_id, set_default_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,7 +86,9 @@ async def async_setup_entry(
         entry_id=entry.entry_id,
         device_name=base,
     )
-    set_suggested_object_id(entity, default_object_id("season_calendar"))
+    set_default_entity_id(
+        entity, Platform.CALENDAR, default_object_id("season_calendar")
+    )
     async_add_entities([entity])
 
 

--- a/custom_components/f1_sensor/const.py
+++ b/custom_components/f1_sensor/const.py
@@ -12,6 +12,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.SELECT,
     Platform.CALENDAR,
+    Platform.WEATHER,
 ]
 
 # Replay Mode

--- a/custom_components/f1_sensor/entity.py
+++ b/custom_components/f1_sensor/entity.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 import json
 from pathlib import Path
 
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import Entity
@@ -146,10 +147,20 @@ def default_object_id(key: str | None) -> str | None:
     return _default_object_id_from_translation_key(key)
 
 
-def set_suggested_object_id(entity: Entity, object_id: str | None) -> None:
-    """Set a stable suggested object ID when one is provided."""
+def set_default_entity_id(
+    entity: Entity, platform: Platform, object_id: str | None
+) -> None:
+    """Set the stable default entity ID for a newly registered entity.
+
+    Home Assistant 2026.2 and later treats ``suggested_object_id`` as a base
+    name and may prefix it with the device name. Setting a domain-correct
+    ``entity_id`` keeps the integration's established defaults for new registry
+    entries. Existing registry entries are still resolved by unique ID and keep
+    their current entity IDs.
+    """
     if object_id:
         entity._attr_suggested_object_id = object_id
+        entity.entity_id = f"{platform}.{object_id}"
 
 
 def _entity_name_from_key(

--- a/custom_components/f1_sensor/media_player.py
+++ b/custom_components/f1_sensor/media_player.py
@@ -12,12 +12,13 @@ from homeassistant.components.media_player.const import (
     MediaPlayerState,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
-from .entity import F1AuxEntity, default_object_id, set_suggested_object_id
+from .entity import F1AuxEntity, default_object_id, set_default_entity_id
 from .replay_mode import ReplayController, ReplayState
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,7 +45,9 @@ async def async_setup_entry(
         entry.entry_id,
         name,
     )
-    set_suggested_object_id(entity, default_object_id("replay_player"))
+    set_default_entity_id(
+        entity, Platform.MEDIA_PLAYER, default_object_id("replay_player")
+    )
     async_add_entities([entity])
 
 

--- a/custom_components/f1_sensor/number.py
+++ b/custom_components/f1_sensor/number.py
@@ -6,12 +6,13 @@ from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 
 from .calibration import LiveDelayCalibrationManager
 from .const import DOMAIN
-from .entity import F1AuxEntity, default_object_id, set_suggested_object_id
+from .entity import F1AuxEntity, default_object_id, set_default_entity_id
 from .live_delay import LiveDelayController
 
 
@@ -34,7 +35,7 @@ async def async_setup_entry(
         entry_id=entry.entry_id,
         device_name=entry.data.get("sensor_name", "F1"),
     )
-    set_suggested_object_id(entity, default_object_id("live_delay"))
+    set_default_entity_id(entity, Platform.NUMBER, default_object_id("live_delay"))
     async_add_entities([entity])
 
 

--- a/custom_components/f1_sensor/race_weather.py
+++ b/custom_components/f1_sensor/race_weather.py
@@ -1,0 +1,641 @@
+"""Shared weather data for the circuit hosting the next Formula 1 race."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+import logging
+from typing import Any, TypedDict
+
+from aiohttp import ClientError, ClientSession
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import RACE_SWITCH_GRACE
+from .helpers import get_next_race
+
+_LOGGER = logging.getLogger(__name__)
+
+OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
+FORECAST_DAYS = 16
+RACE_FORECAST_TOLERANCE = timedelta(minutes=60)
+
+WEATHER_FIELDS = (
+    "temperature_2m",
+    "relative_humidity_2m",
+    "precipitation",
+    "precipitation_probability",
+    "cloud_cover",
+    "wind_speed_10m",
+    "wind_direction_10m",
+    "wind_gusts_10m",
+    "visibility",
+    "weather_code",
+    "is_day",
+)
+
+DAILY_WEATHER_FIELDS = (
+    "weather_code",
+    "temperature_2m_max",
+    "temperature_2m_min",
+    "precipitation_sum",
+    "precipitation_probability_max",
+    "wind_speed_10m_max",
+    "wind_gusts_10m_max",
+    "wind_direction_10m_dominant",
+)
+
+WMO_CODE_TO_MDI = {
+    0: "mdi:weather-sunny",
+    1: "mdi:weather-partly-cloudy",
+    2: "mdi:weather-partly-cloudy",
+    3: "mdi:weather-cloudy",
+    45: "mdi:weather-fog",
+    48: "mdi:weather-fog",
+    51: "mdi:weather-rainy",
+    53: "mdi:weather-rainy",
+    55: "mdi:weather-rainy",
+    56: "mdi:weather-snowy-rainy",
+    57: "mdi:weather-snowy-rainy",
+    61: "mdi:weather-rainy",
+    63: "mdi:weather-rainy",
+    65: "mdi:weather-pouring",
+    66: "mdi:weather-snowy-rainy",
+    67: "mdi:weather-snowy-rainy",
+    71: "mdi:weather-snowy",
+    73: "mdi:weather-snowy",
+    75: "mdi:weather-snowy",
+    77: "mdi:weather-snowy",
+    80: "mdi:weather-rainy",
+    81: "mdi:weather-rainy",
+    82: "mdi:weather-pouring",
+    85: "mdi:weather-snowy",
+    86: "mdi:weather-snowy",
+    95: "mdi:weather-lightning",
+    96: "mdi:weather-lightning-rainy",
+    99: "mdi:weather-lightning-rainy",
+}
+
+
+class WeatherObservation(TypedDict, total=False):
+    """Normalized Open-Meteo observation in native units."""
+
+    datetime: str
+    temperature: float | None
+    temperature_low: float | None
+    humidity: float | None
+    cloud_coverage: int | None
+    precipitation: float | None
+    precipitation_probability: int | None
+    wind_speed: float | None
+    wind_bearing: float | None
+    wind_gust_speed: float | None
+    visibility: float | None
+    weather_code: int | None
+    condition: str | None
+    is_daytime: bool | None
+
+
+class RaceWeatherData(TypedDict):
+    """Weather snapshot associated with one scheduled race."""
+
+    race_key: str | None
+    race_start: str | None
+    circuit: dict[str, Any]
+    current: WeatherObservation
+    daily: list[WeatherObservation]
+    hourly: list[WeatherObservation]
+    twice_daily: list[WeatherObservation]
+    race: WeatherObservation
+
+
+def _as_float(value: Any) -> float | None:
+    """Return a finite numeric value when possible."""
+    if value is None or value == "":
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if result != result or result in (float("inf"), float("-inf")):
+        return None
+    return result
+
+
+def _as_int(value: Any) -> int | None:
+    """Return an integer value when possible."""
+    number = _as_float(value)
+    return round(number) if number is not None else None
+
+
+def _parse_utc_datetime(value: Any, utc_offset_seconds: int = 0) -> datetime | None:
+    """Parse an ISO timestamp and normalize it to UTC."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC) - timedelta(seconds=utc_offset_seconds)
+    return parsed.astimezone(UTC)
+
+
+def _race_start_utc(race: Mapping[str, Any] | None) -> datetime | None:
+    """Return the scheduled race start as an aware UTC datetime."""
+    if not race or not race.get("date"):
+        return None
+    time_value = race.get("time") or "00:00:00Z"
+    return _parse_utc_datetime(f"{race['date']}T{time_value}")
+
+
+def _next_race(schedule: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Select the next/current race from a Jolpica schedule payload."""
+    if not schedule:
+        return None
+    races = (
+        schedule.get("MRData", {}).get("RaceTable", {}).get("Races", [])
+        if isinstance(schedule, Mapping)
+        else []
+    )
+    _, race = get_next_race(
+        races,
+        grace=RACE_SWITCH_GRACE,
+        default_time="00:00:00Z",
+    )
+    return race
+
+
+def race_key(race: Mapping[str, Any] | None) -> str | None:
+    """Build a stable key for detecting a change of target race."""
+    if not race:
+        return None
+    circuit = race.get("Circuit") or {}
+    values = (race.get("season"), race.get("round"), circuit.get("circuitId"))
+    if not any(value is not None for value in values):
+        return None
+    return ":".join("" if value is None else str(value) for value in values)
+
+
+def wmo_condition(code: Any, is_daytime: bool | None = None) -> str | None:
+    """Map a WMO weather interpretation code to a Home Assistant condition."""
+    normalized = _as_int(code)
+    if normalized is None:
+        return None
+    if normalized == 0:
+        return "clear-night" if is_daytime is False else "sunny"
+    if normalized in (1, 2):
+        return "partlycloudy"
+    if normalized == 3:
+        return "cloudy"
+    if normalized in (45, 48):
+        return "fog"
+    if normalized in (51, 53, 55, 61, 63, 80, 81):
+        return "rainy"
+    if normalized in (65, 82):
+        return "pouring"
+    if normalized in (56, 57, 66, 67):
+        return "snowy-rainy"
+    if normalized in (71, 73, 75, 77, 85, 86):
+        return "snowy"
+    if normalized == 95:
+        return "lightning"
+    if normalized in (96, 99):
+        return "lightning-rainy"
+    return "exceptional"
+
+
+def weather_icon(code: Any, is_daytime: bool | None = None) -> str:
+    """Return an MDI icon for a normalized WMO condition."""
+    normalized = _as_int(code)
+    if normalized == 0 and is_daytime is False:
+        return "mdi:weather-night"
+    return WMO_CODE_TO_MDI.get(normalized, "mdi:weather-partly-cloudy")
+
+
+def wind_direction_abbreviation(degrees: Any) -> str | None:
+    """Return a 16-point compass abbreviation."""
+    value = _as_float(degrees)
+    if value is None:
+        return None
+    directions = (
+        "N",
+        "NNE",
+        "NE",
+        "ENE",
+        "E",
+        "ESE",
+        "SE",
+        "SSE",
+        "S",
+        "SSW",
+        "SW",
+        "WSW",
+        "W",
+        "WNW",
+        "NW",
+        "NNW",
+    )
+    return directions[round((value % 360) / 22.5) % len(directions)]
+
+
+def _normalize_observation(
+    raw: Mapping[str, Any], timestamp: Any = None, utc_offset_seconds: int = 0
+) -> WeatherObservation:
+    """Normalize one Open-Meteo current or hourly record."""
+    parsed_time = _parse_utc_datetime(timestamp or raw.get("time"), utc_offset_seconds)
+    is_day = _as_int(raw.get("is_day"))
+    is_daytime = bool(is_day) if is_day in (0, 1) else None
+    code = _as_int(raw.get("weather_code"))
+    observation: WeatherObservation = {
+        "temperature": _as_float(raw.get("temperature_2m")),
+        "humidity": _as_float(raw.get("relative_humidity_2m")),
+        "cloud_coverage": _as_int(raw.get("cloud_cover")),
+        "precipitation": _as_float(raw.get("precipitation")),
+        "precipitation_probability": _as_int(raw.get("precipitation_probability")),
+        "wind_speed": _as_float(raw.get("wind_speed_10m")),
+        "wind_bearing": _as_float(raw.get("wind_direction_10m")),
+        "wind_gust_speed": _as_float(raw.get("wind_gusts_10m")),
+        "visibility": _as_float(raw.get("visibility")),
+        "weather_code": code,
+        "condition": wmo_condition(code, is_daytime),
+        "is_daytime": is_daytime,
+    }
+    if parsed_time is not None:
+        observation["datetime"] = parsed_time.isoformat()
+    return observation
+
+
+def _hourly_observations(
+    hourly: Mapping[str, Any], utc_offset_seconds: int = 0
+) -> list[WeatherObservation]:
+    """Convert Open-Meteo column arrays into timestamped observations."""
+    times = hourly.get("time")
+    if not isinstance(times, list):
+        return []
+    observations: list[WeatherObservation] = []
+    for index, timestamp in enumerate(times):
+        raw: dict[str, Any] = {}
+        for field in WEATHER_FIELDS:
+            values = hourly.get(field)
+            raw[field] = (
+                values[index]
+                if isinstance(values, list) and index < len(values)
+                else None
+            )
+        observation = _normalize_observation(raw, timestamp, utc_offset_seconds)
+        if "datetime" in observation:
+            observations.append(observation)
+    return observations
+
+
+def _daily_observations(
+    daily: Mapping[str, Any], utc_offset_seconds: int = 0
+) -> list[WeatherObservation]:
+    """Convert Open-Meteo daily column arrays into native forecasts."""
+    times = daily.get("time")
+    if not isinstance(times, list):
+        return []
+    observations: list[WeatherObservation] = []
+    for index, timestamp in enumerate(times):
+        raw = {
+            field: values[index] if index < len(values) else None
+            for field in DAILY_WEATHER_FIELDS
+            if isinstance((values := daily.get(field)), list)
+        }
+        parsed_time = _parse_utc_datetime(timestamp, utc_offset_seconds)
+        temperature = _as_float(raw.get("temperature_2m_max"))
+        if parsed_time is None or temperature is None:
+            continue
+        code = _as_int(raw.get("weather_code"))
+        observations.append(
+            {
+                "datetime": parsed_time.isoformat(),
+                "temperature": temperature,
+                "temperature_low": _as_float(raw.get("temperature_2m_min")),
+                "precipitation": _as_float(raw.get("precipitation_sum")),
+                "precipitation_probability": _as_int(
+                    raw.get("precipitation_probability_max")
+                ),
+                "wind_speed": _as_float(raw.get("wind_speed_10m_max")),
+                "wind_bearing": _as_float(raw.get("wind_direction_10m_dominant")),
+                "wind_gust_speed": _as_float(raw.get("wind_gusts_10m_max")),
+                "weather_code": code,
+                "condition": wmo_condition(code, True),
+            }
+        )
+    return observations
+
+
+def _average(values: list[float]) -> float | None:
+    """Return the arithmetic mean of available values."""
+    return sum(values) / len(values) if values else None
+
+
+def _aggregate_forecast_period(
+    observations: list[WeatherObservation], is_daytime: bool
+) -> WeatherObservation:
+    """Aggregate cached hourly observations into one day or night period."""
+    temperatures = [
+        value
+        for observation in observations
+        if (value := _as_float(observation.get("temperature"))) is not None
+    ]
+    if not temperatures:
+        return {}
+    precipitation = [
+        value
+        for observation in observations
+        if (value := _as_float(observation.get("precipitation"))) is not None
+    ]
+    probabilities = [
+        value
+        for observation in observations
+        if (value := _as_int(observation.get("precipitation_probability"))) is not None
+    ]
+    humidities = [
+        value
+        for observation in observations
+        if (value := _as_float(observation.get("humidity"))) is not None
+    ]
+    cloud_coverages = [
+        value
+        for observation in observations
+        if (value := _as_float(observation.get("cloud_coverage"))) is not None
+    ]
+    weather_codes = [
+        value
+        for observation in observations
+        if (value := _as_int(observation.get("weather_code"))) is not None
+    ]
+    wind_observation = max(
+        observations,
+        key=lambda observation: _as_float(observation.get("wind_speed")) or 0,
+    )
+    wind_speeds = [
+        value
+        for observation in observations
+        if (value := _as_float(observation.get("wind_speed"))) is not None
+    ]
+    wind_gusts = [
+        value
+        for observation in observations
+        if (value := _as_float(observation.get("wind_gust_speed"))) is not None
+    ]
+    code = max(weather_codes) if weather_codes else None
+    return {
+        "datetime": observations[0]["datetime"],
+        "temperature": max(temperatures),
+        "temperature_low": min(temperatures),
+        "humidity": _average(humidities),
+        "cloud_coverage": _as_int(_average(cloud_coverages)),
+        "precipitation": round(sum(precipitation), 3) if precipitation else None,
+        "precipitation_probability": max(probabilities) if probabilities else None,
+        "wind_speed": max(wind_speeds) if wind_speeds else None,
+        "wind_bearing": _as_float(wind_observation.get("wind_bearing")),
+        "wind_gust_speed": max(wind_gusts) if wind_gusts else None,
+        "weather_code": code,
+        "condition": wmo_condition(code, is_daytime),
+        "is_daytime": is_daytime,
+    }
+
+
+def _twice_daily_observations(
+    hourly: list[WeatherObservation], utc_offset_seconds: int = 0
+) -> list[WeatherObservation]:
+    """Aggregate hourly data into local day and night forecast periods."""
+    grouped: dict[tuple[str, bool], list[WeatherObservation]] = {}
+    for observation in hourly:
+        timestamp = _parse_utc_datetime(observation.get("datetime"))
+        is_daytime = observation.get("is_daytime")
+        if timestamp is None or not isinstance(is_daytime, bool):
+            continue
+        local_date = (timestamp + timedelta(seconds=utc_offset_seconds)).date()
+        grouped.setdefault((local_date.isoformat(), is_daytime), []).append(observation)
+    return [
+        forecast
+        for (_, is_daytime), observations in grouped.items()
+        if (forecast := _aggregate_forecast_period(observations, is_daytime))
+    ]
+
+
+def _circuit_metadata(race: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Build stable next-race metadata for both entity platforms."""
+    if not race:
+        return {}
+    circuit = race.get("Circuit") or {}
+    location = circuit.get("Location") or {}
+    return {
+        "season": race.get("season"),
+        "round": race.get("round"),
+        "race_name": race.get("raceName"),
+        "race_url": race.get("url"),
+        "circuit_id": circuit.get("circuitId"),
+        "circuit_name": circuit.get("circuitName"),
+        "circuit_url": circuit.get("url"),
+        "circuit_lat": location.get("lat"),
+        "circuit_long": location.get("long"),
+        "circuit_locality": location.get("locality"),
+        "circuit_country": location.get("country"),
+    }
+
+
+def empty_race_weather_data(
+    race: Mapping[str, Any] | None = None,
+) -> RaceWeatherData:
+    """Return a valid empty snapshot for a missing or changing forecast."""
+    race_start = _race_start_utc(race)
+    return {
+        "race_key": race_key(race),
+        "race_start": race_start.isoformat() if race_start else None,
+        "circuit": _circuit_metadata(race),
+        "current": {},
+        "daily": [],
+        "hourly": [],
+        "twice_daily": [],
+        "race": {},
+    }
+
+
+def _closest_race_observation(
+    observations: list[WeatherObservation], race_start: datetime | None
+) -> WeatherObservation:
+    """Return a forecast only when it genuinely covers the race start."""
+    if race_start is None:
+        return {}
+    candidates: list[tuple[timedelta, WeatherObservation]] = []
+    for observation in observations:
+        timestamp = _parse_utc_datetime(observation.get("datetime"))
+        if timestamp is not None:
+            candidates.append((abs(timestamp - race_start), observation))
+    if not candidates:
+        return {}
+    difference, observation = min(candidates, key=lambda item: item[0])
+    return dict(observation) if difference <= RACE_FORECAST_TOLERANCE else {}
+
+
+def legacy_weather_observation(
+    observation: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Adapt normalized data to the established weather sensor attributes."""
+    observation = observation or {}
+    precipitation = observation.get("precipitation")
+    if observation and precipitation is None:
+        precipitation = 0
+    bearing = observation.get("wind_bearing")
+    return {
+        "temperature": observation.get("temperature"),
+        "temperature_unit": "celsius",
+        "humidity": observation.get("humidity"),
+        "humidity_unit": "%",
+        "cloud_cover": observation.get("cloud_coverage"),
+        "cloud_cover_unit": "%",
+        "precipitation": precipitation,
+        "precipitation_amount_min": precipitation,
+        "precipitation_amount_max": precipitation,
+        "precipitation_probability": observation.get("precipitation_probability"),
+        "precipitation_probability_unit": "%",
+        "precipitation_unit": "mm",
+        "wind_speed": observation.get("wind_speed"),
+        "wind_speed_unit": "m/s",
+        "wind_direction": wind_direction_abbreviation(bearing),
+        "wind_from_direction_degrees": bearing,
+        "wind_from_direction_unit": "degrees",
+        "wind_gusts": observation.get("wind_gust_speed"),
+        "wind_gusts_unit": "m/s",
+        "visibility": observation.get("visibility"),
+        "visibility_unit": "m",
+        "weather_code": observation.get("weather_code"),
+        "weather_source": "open-meteo" if observation else None,
+    }
+
+
+class F1RaceWeatherCoordinator(DataUpdateCoordinator[RaceWeatherData]):
+    """Fetch and cache Open-Meteo data for the next race circuit."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        race_coordinator: DataUpdateCoordinator[Any],
+        *,
+        session: ClientSession,
+        config_entry: ConfigEntry,
+    ) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="F1 Next Race Weather Coordinator",
+            update_interval=timedelta(hours=1),
+            config_entry=config_entry,
+        )
+        self._race_coordinator = race_coordinator
+        self._session = session
+        self._race_unsub = None
+        self._observed_race_key: str | None = None
+
+    def _scheduled_race(self) -> dict[str, Any] | None:
+        """Return the race currently selected by the schedule coordinator."""
+        data = getattr(self._race_coordinator, "data", None)
+        return _next_race(data if isinstance(data, Mapping) else None)
+
+    @callback
+    def async_start(self) -> None:
+        """Listen for a target race change after initial setup."""
+        if self._race_unsub is not None:
+            return
+        self._observed_race_key = race_key(self._scheduled_race())
+        self._race_unsub = self._race_coordinator.async_add_listener(
+            self._handle_schedule_update
+        )
+
+    async def async_close(self) -> None:
+        """Release the schedule listener on config entry unload."""
+        if self._race_unsub is not None:
+            self._race_unsub()
+            self._race_unsub = None
+
+    @callback
+    def _handle_schedule_update(self) -> None:
+        """Clear old-circuit data immediately and fetch the new circuit."""
+        race = self._scheduled_race()
+        new_key = race_key(race)
+        if new_key == self._observed_race_key:
+            return
+        self._observed_race_key = new_key
+        self.async_set_updated_data(empty_race_weather_data(race))
+        self.config_entry.async_create_task(
+            self.hass,
+            self.async_request_refresh(),
+        )
+
+    async def _async_update_data(self) -> RaceWeatherData:
+        """Fetch current conditions and cached next-race forecasts."""
+        race = self._scheduled_race()
+        base_data = empty_race_weather_data(race)
+        self._observed_race_key = base_data["race_key"]
+        if race is None:
+            return base_data
+
+        location = (race.get("Circuit") or {}).get("Location") or {}
+        latitude = location.get("lat")
+        longitude = location.get("long")
+        if latitude is None or longitude is None:
+            return base_data
+
+        fields = ",".join(WEATHER_FIELDS)
+        params = {
+            "latitude": str(latitude),
+            "longitude": str(longitude),
+            "current": fields,
+            "daily": ",".join(DAILY_WEATHER_FIELDS),
+            "hourly": fields,
+            "wind_speed_unit": "ms",
+            "timezone": "auto",
+            "forecast_days": str(FORECAST_DAYS),
+        }
+
+        try:
+            async with asyncio.timeout(10):
+                async with self._session.get(
+                    OPEN_METEO_FORECAST_URL, params=params
+                ) as response:
+                    response.raise_for_status()
+                    payload = await response.json()
+        except (TimeoutError, ClientError, ValueError, TypeError) as err:
+            raise UpdateFailed(f"Error fetching race weather: {err}") from err
+
+        if not isinstance(payload, Mapping):
+            raise UpdateFailed("Error fetching race weather: invalid response payload")
+        current_raw = payload.get("current")
+        daily_raw = payload.get("daily")
+        hourly_raw = payload.get("hourly")
+        if not isinstance(current_raw, Mapping) or not isinstance(hourly_raw, Mapping):
+            raise UpdateFailed("Error fetching race weather: missing weather data")
+
+        utc_offset_seconds = _as_int(payload.get("utc_offset_seconds")) or 0
+        if not -86400 < utc_offset_seconds < 86400:
+            utc_offset_seconds = 0
+        current = _normalize_observation(
+            current_raw, utc_offset_seconds=utc_offset_seconds
+        )
+        if current.get("temperature") is None or current.get("condition") is None:
+            raise UpdateFailed(
+                "Error fetching race weather: incomplete current weather"
+            )
+        hourly = _hourly_observations(hourly_raw, utc_offset_seconds)
+        daily = (
+            _daily_observations(daily_raw, utc_offset_seconds)
+            if isinstance(daily_raw, Mapping)
+            else []
+        )
+        race_start = _race_start_utc(race)
+        return {
+            **base_data,
+            "current": current,
+            "daily": daily,
+            "hourly": hourly,
+            "twice_daily": _twice_daily_observations(hourly, utc_offset_seconds),
+            "race": _closest_race_observation(hourly, race_start),
+        }

--- a/custom_components/f1_sensor/select.py
+++ b/custom_components/f1_sensor/select.py
@@ -7,6 +7,7 @@ import logging
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -16,7 +17,7 @@ from .const import (
     LIVE_DELAY_REFERENCE_LAP_SYNC,
     LIVE_DELAY_REFERENCE_SESSION,
 )
-from .entity import F1AuxEntity, default_object_id, set_suggested_object_id
+from .entity import F1AuxEntity, default_object_id, set_default_entity_id
 from .live_delay import LiveDelayReferenceController
 from .replay_entities import (
     F1ReplaySessionSelect,
@@ -50,7 +51,9 @@ async def async_setup_entry(
             entry.entry_id,
             name,
         )
-        set_suggested_object_id(entity, default_object_id("live_delay_reference"))
+        set_default_entity_id(
+            entity, Platform.SELECT, default_object_id("live_delay_reference")
+        )
         entities.append(entity)
 
     # Replay session selector
@@ -62,7 +65,7 @@ async def async_setup_entry(
             entry.entry_id,
             name,
         )
-        set_suggested_object_id(entity, default_object_id("replay_year"))
+        set_default_entity_id(entity, Platform.SELECT, default_object_id("replay_year"))
         entities.append(entity)
         entity = F1ReplaySessionSelect(
             replay_controller,
@@ -70,7 +73,9 @@ async def async_setup_entry(
             entry.entry_id,
             name,
         )
-        set_suggested_object_id(entity, default_object_id("replay_session"))
+        set_default_entity_id(
+            entity, Platform.SELECT, default_object_id("replay_session")
+        )
         entities.append(entity)
         start_reference_controller = registry.get("replay_start_reference_controller")
         if start_reference_controller is not None:
@@ -80,7 +85,11 @@ async def async_setup_entry(
                 entry.entry_id,
                 name,
             )
-            set_suggested_object_id(entity, default_object_id("replay_start_reference"))
+            set_default_entity_id(
+                entity,
+                Platform.SELECT,
+                default_object_id("replay_start_reference"),
+            )
             entities.append(entity)
 
     if entities:

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -15,7 +15,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.event import (
     async_call_later,
@@ -63,40 +62,10 @@ from .helpers import (
     get_timezone,
     normalize_track_status,
 )
+from .race_weather import legacy_weather_observation, weather_icon
 from .replay_entities import F1ReplayStatusSensor
 
 TEAM_RADIO_STATIC_BASE = "https://livetiming.formula1.com/static"
-
-WMO_CODE_TO_MDI = {
-    0: "mdi:weather-sunny",
-    1: "mdi:weather-partly-cloudy",
-    2: "mdi:weather-partly-cloudy",
-    3: "mdi:weather-cloudy",
-    45: "mdi:weather-fog",
-    48: "mdi:weather-fog",
-    51: "mdi:weather-rainy",
-    53: "mdi:weather-rainy",
-    55: "mdi:weather-rainy",
-    56: "mdi:weather-snowy-rainy",
-    57: "mdi:weather-snowy-rainy",
-    61: "mdi:weather-rainy",
-    63: "mdi:weather-rainy",
-    65: "mdi:weather-pouring",
-    66: "mdi:weather-snowy-rainy",
-    67: "mdi:weather-snowy-rainy",
-    71: "mdi:weather-snowy",
-    73: "mdi:weather-snowy",
-    75: "mdi:weather-snowy",
-    77: "mdi:weather-snowy",
-    80: "mdi:weather-rainy",
-    81: "mdi:weather-rainy",
-    82: "mdi:weather-pouring",
-    85: "mdi:weather-snowy",
-    86: "mdi:weather-snowy",
-    95: "mdi:weather-lightning",
-    96: "mdi:weather-lightning-rainy",
-    99: "mdi:weather-lightning-rainy",
-}
 
 
 class _ReplayOrAuthGatedStreamMixin:
@@ -235,7 +204,7 @@ async def async_setup_entry(
             F1ConstructorStandingsSensor,
             data["constructor_coordinator"],
         ),
-        "weather": (F1WeatherSensor, data["race_coordinator"]),
+        "weather": (F1WeatherSensor, data.get("race_weather_coordinator")),
         "track_weather": (F1TrackWeatherSensor, data.get("weather_data_coordinator")),
         "race_lap_count": (F1RaceLapCountSensor, data.get("lap_count_coordinator")),
         "last_race_results": (F1LastRaceSensor, data["last_race_coordinator"]),
@@ -1160,216 +1129,54 @@ class F1ConstructorStandingsSensor(F1BaseEntity, SensorEntity):
         }
 
 
-class F1WeatherSensor(_NextRaceMixin, F1BaseEntity, SensorEntity):
-    """Sensor for current and race-start weather."""
+class F1WeatherSensor(F1BaseEntity, SensorEntity):
+    """Backward-compatible sensor for current and race-start weather."""
 
     _device_category = "race"
-
     _attr_translation_key = "weather"
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator, unique_id, entry_id, device_name):
-        super().__init__(coordinator, unique_id, entry_id, device_name)
-        self._attr_icon = "mdi:weather-partly-cloudy"
-        self._attr_device_class = SensorDeviceClass.TEMPERATURE
-        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-        self._current = {}
-        self._race = {}
-        self._circuit = {}
+    @property
+    def _weather_data(self) -> dict:
+        """Return the shared coordinator snapshot."""
+        data = self.coordinator.data
+        return data if isinstance(data, dict) else {}
 
-    async def async_added_to_hass(self):
-        await super().async_added_to_hass()
-        removal = self.coordinator.async_add_listener(
-            lambda: self.hass.async_create_task(self._update_weather())
-        )
-        self.async_on_remove(removal)
-        await self._update_weather()
+    @property
+    def available(self) -> bool:
+        """Return whether current next-race weather is available."""
+        current = self._weather_data.get("current", {})
+        return super().available and current.get("temperature") is not None
 
-    async def _update_weather(self):
-        race = self._get_next_race()
-        # Store which circuit this weather is for, so the UI can show context even
-        # when only temperature is used as the sensor state.
-        if race:
-            circuit = race.get("Circuit", {}) or {}
-            loc = circuit.get("Location", {}) or {}
-            self._circuit = {
-                "season": race.get("season"),
-                "round": race.get("round"),
-                "race_name": race.get("raceName"),
-                "race_url": race.get("url"),
-                "circuit_id": circuit.get("circuitId"),
-                "circuit_name": circuit.get("circuitName"),
-                "circuit_url": circuit.get("url"),
-                "circuit_lat": loc.get("lat"),
-                "circuit_long": loc.get("long"),
-                "circuit_locality": loc.get("locality"),
-                "circuit_country": loc.get("country"),
-            }
-        else:
-            self._circuit = {}
-        loc = race.get("Circuit", {}).get("Location", {}) if race else {}
-        lat, lon = loc.get("lat"), loc.get("long")
-        if lat is None or lon is None:
-            return
-        session = async_get_clientsession(self.hass)
-        current_vars = ",".join(
-            [
-                "temperature_2m",
-                "relative_humidity_2m",
-                "precipitation",
-                "precipitation_probability",
-                "cloud_cover",
-                "wind_speed_10m",
-                "wind_direction_10m",
-                "wind_gusts_10m",
-                "visibility",
-                "weather_code",
-            ]
-        )
-        hourly_vars = current_vars
-        url = (
-            f"https://api.open-meteo.com/v1/forecast"
-            f"?latitude={lat}&longitude={lon}"
-            f"&current={current_vars}"
-            f"&hourly={hourly_vars}"
-            f"&wind_speed_unit=ms"
-            f"&timezone=UTC"
-            f"&forecast_days=16"
-        )
-        try:
-            async with asyncio.timeout(10):
-                async with session.get(url) as resp:
-                    resp.raise_for_status()
-                    data = await resp.json()
-        except Exception:
-            # Avoid showing stale weather when a refresh fails.
-            self._current = {}
-            self._race = {}
-            self._attr_icon = "mdi:weather-partly-cloudy"
-            self.async_write_ha_state()
-            return
-
-        # Parse current conditions from the dedicated current block.
-        current_block = data.get("current", {})
-        self._current = self._extract(current_block)
-        current_code = current_block.get("weather_code")
-        self._attr_icon = WMO_CODE_TO_MDI.get(current_code, "mdi:weather-partly-cloudy")
-
-        # Build an index over the hourly time series for race-start lookup.
-        hourly = data.get("hourly", {})
-        hourly_times = hourly.get("time", [])
-        hourly_vars_keys = [
-            "temperature_2m",
-            "relative_humidity_2m",
-            "precipitation",
-            "precipitation_probability",
-            "cloud_cover",
-            "wind_speed_10m",
-            "wind_direction_10m",
-            "wind_gusts_10m",
-            "visibility",
-            "weather_code",
-        ]
-        hourly_entries = []
-        for i, t in enumerate(hourly_times):
-            entry = {"time": t}
-            for key in hourly_vars_keys:
-                vals = hourly.get(key, [])
-                entry[key] = vals[i] if i < len(vals) else None
-            hourly_entries.append(entry)
-
-        start_iso = (
-            _combine_date_time(race.get("date"), race.get("time")) if race else None
-        )
-        self._race = dict.fromkeys(self._current)
-        if start_iso and hourly_entries:
-            start_dt = datetime.datetime.fromisoformat(start_iso)
-            # Ensure start_dt is UTC-aware for comparison.
-            if start_dt.tzinfo is None:
-                start_dt = start_dt.replace(tzinfo=datetime.UTC)
-            closest = min(
-                hourly_entries,
-                key=lambda e: abs(
-                    datetime.datetime.fromisoformat(e["time"]).replace(
-                        tzinfo=datetime.UTC
-                    )
-                    - start_dt
-                ),
-            )
-            self._race = self._extract(closest)
-            race_code = closest.get("weather_code")
-            race_icon = WMO_CODE_TO_MDI.get(race_code, self._attr_icon)
-            self._race["weather_icon"] = race_icon
-        self.async_write_ha_state()
-
-    def _extract(self, d):
-        wd = d.get("wind_direction_10m")
-        precip = d.get("precipitation", 0) or 0
-        return {
-            "temperature": d.get("temperature_2m"),
-            "temperature_unit": "celsius",
-            "humidity": d.get("relative_humidity_2m"),
-            "humidity_unit": "%",
-            "cloud_cover": d.get("cloud_cover"),
-            "cloud_cover_unit": "%",
-            "precipitation": precip,
-            # open-meteo gives an exact forecast value, not a range; expose the
-            # same value for min/max to preserve backwards compatibility.
-            "precipitation_amount_min": precip,
-            "precipitation_amount_max": precip,
-            "precipitation_probability": d.get("precipitation_probability"),
-            "precipitation_probability_unit": "%",
-            "precipitation_unit": "mm",
-            "wind_speed": d.get("wind_speed_10m"),
-            "wind_speed_unit": "m/s",
-            "wind_direction": self._abbr(wd),
-            "wind_from_direction_degrees": wd,
-            "wind_from_direction_unit": "degrees",
-            "wind_gusts": d.get("wind_gusts_10m"),
-            "wind_gusts_unit": "m/s",
-            "visibility": d.get("visibility"),
-            "visibility_unit": "m",
-            "weather_code": d.get("weather_code"),
-            "weather_source": "open-meteo",
-        }
-
-    def _abbr(self, deg):
-        if deg is None:
-            return None
-        dirs = [
-            (i * 22.5, d)
-            for i, d in enumerate(
-                [
-                    "N",
-                    "NNE",
-                    "NE",
-                    "ENE",
-                    "E",
-                    "ESE",
-                    "SE",
-                    "SSE",
-                    "S",
-                    "SSW",
-                    "SW",
-                    "WSW",
-                    "W",
-                    "WNW",
-                    "NW",
-                    "NNW",
-                    "N",
-                ]
-            )
-        ]
-        return min(dirs, key=lambda x: abs(deg - x[0]))[1]
+    @property
+    def icon(self):
+        """Return an icon matching the current normalized condition."""
+        current = self._weather_data.get("current", {})
+        return weather_icon(current.get("weather_code"), current.get("is_daytime"))
 
     @property
     def native_value(self):
-        return self._current.get("temperature")
+        """Return the current circuit temperature."""
+        return self._weather_data.get("current", {}).get("temperature")
 
     @property
     def extra_state_attributes(self):
-        attrs = dict(self._circuit or {})
-        attrs.update({f"current_{k}": v for k, v in self._current.items()})
-        attrs.update({f"race_{k}": v for k, v in self._race.items()})
+        """Preserve the established current_* and race_* sensor attributes."""
+        data = self._weather_data
+        current = legacy_weather_observation(data.get("current"))
+        race = legacy_weather_observation(data.get("race"))
+        race["weather_icon"] = (
+            weather_icon(
+                data.get("race", {}).get("weather_code"),
+                data.get("race", {}).get("is_daytime"),
+            )
+            if data.get("race")
+            else None
+        )
+        attrs = dict(data.get("circuit", {}))
+        attrs.update({f"current_{key}": value for key, value in current.items()})
+        attrs.update({f"race_{key}": value for key, value in race.items()})
         return attrs
 
 

--- a/custom_components/f1_sensor/sensor.py
+++ b/custom_components/f1_sensor/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import EntityCategory
@@ -51,7 +51,7 @@ from .entity import (
     is_auth_gated_stream_active,
     is_no_spoiler_live_state,
     is_replay_only_stream_active,
-    set_suggested_object_id,
+    set_default_entity_id,
 )
 from .helpers import (
     get_circuit_map_url,
@@ -314,7 +314,7 @@ async def async_setup_entry(
                     base,
                     pos,
                 )
-                set_suggested_object_id(sensor, object_id)
+                set_default_entity_id(sensor, Platform.SENSOR, object_id)
                 sensors.append(sensor)
         elif key == "championship_prediction":
             if not coord:
@@ -325,8 +325,10 @@ async def async_setup_entry(
                 entry.entry_id,
                 base,
             )
-            set_suggested_object_id(
-                drivers_sensor, default_object_id("championship_prediction_drivers")
+            set_default_entity_id(
+                drivers_sensor,
+                Platform.SENSOR,
+                default_object_id("championship_prediction_drivers"),
             )
             sensors.append(drivers_sensor)
             teams_sensor = F1ChampionshipPredictionTeamsSensor(
@@ -335,8 +337,10 @@ async def async_setup_entry(
                 entry.entry_id,
                 base,
             )
-            set_suggested_object_id(
-                teams_sensor, default_object_id("championship_prediction_teams")
+            set_default_entity_id(
+                teams_sensor,
+                Platform.SENSOR,
+                default_object_id("championship_prediction_teams"),
             )
             sensors.append(teams_sensor)
         elif key == "live_timing_diagnostics":
@@ -347,7 +351,9 @@ async def async_setup_entry(
                     entry.entry_id,
                     base,
                 )
-                set_suggested_object_id(sensor, default_object_id("live_timing_mode"))
+                set_default_entity_id(
+                    sensor, Platform.SENSOR, default_object_id("live_timing_mode")
+                )
                 sensors.append(sensor)
         elif cls and coord:
             sensor = cls(
@@ -356,18 +362,22 @@ async def async_setup_entry(
                 entry.entry_id,
                 base,
             )
-            set_suggested_object_id(sensor, default_object_id(key))
+            set_default_entity_id(sensor, Platform.SENSOR, default_object_id(key))
             sensors.append(sensor)
 
     auth_status = data.get(AUTH_RUNTIME_STATUS)
     if isinstance(auth_status, F1TvAuthStatus) and is_auth_health_visible(auth_status):
         status_sensor = F1TvTokenStatusSensor(hass, entry.entry_id, base)
-        set_suggested_object_id(status_sensor, default_object_id("f1tv_token_status"))
+        set_default_entity_id(
+            status_sensor, Platform.SENSOR, default_object_id("f1tv_token_status")
+        )
         sensors.append(status_sensor)
 
         expires_sensor = F1TvTokenExpiresAtSensor(hass, entry.entry_id, base)
-        set_suggested_object_id(
-            expires_sensor, default_object_id("f1tv_token_expires_at")
+        set_default_entity_id(
+            expires_sensor,
+            Platform.SENSOR,
+            default_object_id("f1tv_token_expires_at"),
         )
         sensors.append(expires_sensor)
 
@@ -380,7 +390,9 @@ async def async_setup_entry(
             entry.entry_id,
             base,
         )
-        set_suggested_object_id(sensor, default_object_id("replay_status"))
+        set_default_entity_id(
+            sensor, Platform.SENSOR, default_object_id("replay_status")
+        )
         sensors.append(sensor)
 
     async_add_entities(sensors, True)

--- a/custom_components/f1_sensor/switch.py
+++ b/custom_components/f1_sensor/switch.py
@@ -6,12 +6,13 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 
 from .calibration import LiveDelayCalibrationManager
 from .const import DOMAIN
-from .entity import F1AuxEntity, default_object_id, set_suggested_object_id
+from .entity import F1AuxEntity, default_object_id, set_default_entity_id
 from .no_spoiler import NoSpoilerModeManager
 
 _NO_SPOILER_SWITCH_ENTRY_KEY = "no_spoiler_switch_entry_id"
@@ -36,7 +37,9 @@ async def async_setup_entry(
             entry.entry_id,
             name,
         )
-        set_suggested_object_id(entity, default_object_id("delay_calibration"))
+        set_default_entity_id(
+            entity, Platform.SWITCH, default_object_id("delay_calibration")
+        )
         entities.append(entity)
 
     # No Spoiler Mode switch — global, registered only by the first entry that loads.
@@ -57,7 +60,9 @@ async def async_setup_entry(
             entry.entry_id,
             name,
         )
-        set_suggested_object_id(entity, default_object_id("no_spoiler_mode"))
+        set_default_entity_id(
+            entity, Platform.SWITCH, default_object_id("no_spoiler_mode")
+        )
         entities.append(entity)
 
     if entities:

--- a/custom_components/f1_sensor/tests/test_entity_naming.py
+++ b/custom_components/f1_sensor/tests/test_entity_naming.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from unittest.mock import Mock
 
+from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import EntityComponent
 import pytest
@@ -31,7 +32,9 @@ from custom_components.f1_sensor.const import (
 )
 from custom_components.f1_sensor.entity import (
     async_prepare_translation_names,
+    default_object_id,
     register_entry_name_settings,
+    set_default_entity_id,
 )
 from custom_components.f1_sensor.helpers import format_entity_name
 from custom_components.f1_sensor.number import F1LiveDelayNumber
@@ -98,6 +101,38 @@ async def test_sensor_setup_entry_uses_translation_key_for_track_status(hass) ->
     assert entity.unique_id == f"{entry.entry_id}_track_status"
     assert entity._attr_translation_key == "track_status"
     assert entity._attr_suggested_object_id == "f1_track_status"
+    assert entity.entity_id == "sensor.f1_track_status"
+
+
+@pytest.mark.asyncio
+async def test_new_driver_list_uses_documented_entity_id(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "sensor_name": "F1 Drivers",
+            "disabled_sensors": sorted(SUPPORTED_SENSOR_KEYS - {"driver_list"}),
+        },
+    )
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "constructor_coordinator": Mock(),
+        "driver_coordinator": Mock(),
+        "drivers_coordinator": Mock(),
+        "last_race_coordinator": Mock(),
+        "race_coordinator": Mock(),
+        "season_results_coordinator": Mock(),
+        "sprint_results_coordinator": Mock(),
+    }
+
+    async_add_entities = Mock()
+    await sensor_platform.async_setup_entry(hass, entry, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    entity = entities[0]
+    assert entity.unique_id == f"{entry.entry_id}_driver_list"
+    assert entity.suggested_object_id == "f1_driver_list"
+    assert entity.entity_id == "sensor.f1_driver_list"
 
 
 @pytest.mark.asyncio
@@ -134,6 +169,7 @@ async def test_sensor_setup_entry_uses_translation_key_for_lap_position_progress
     assert entity.unique_id == f"{entry.entry_id}_lap_position_progression"
     assert entity._attr_translation_key == "lap_position_progression"
     assert entity._attr_suggested_object_id == "f1_lap_position_progression"
+    assert entity.entity_id == "sensor.f1_lap_position_progression"
 
 
 @pytest.mark.asyncio
@@ -206,6 +242,7 @@ async def test_binary_sensor_setup_entry_uses_translation_keys(
     object_ids = {
         entity.unique_id: entity._attr_suggested_object_id for entity in entities
     }
+    entity_ids = {entity.unique_id: entity.entity_id for entity in entities}
 
     assert translation_keys[f"{entry.entry_id}_race_week"] == "race_week"
     assert (
@@ -213,6 +250,10 @@ async def test_binary_sensor_setup_entry_uses_translation_keys(
     )
     assert object_ids[f"{entry.entry_id}_race_week"] == "f1_race_week"
     assert object_ids[f"{entry.entry_id}_live_timing_online"] == "f1_live_timing_online"
+    assert entity_ids[f"{entry.entry_id}_race_week"] == "binary_sensor.f1_race_week"
+    assert entity_ids[f"{entry.entry_id}_live_timing_online"] == (
+        "binary_sensor.f1_live_timing_online"
+    )
 
 
 @pytest.mark.asyncio
@@ -337,6 +378,7 @@ async def test_localized_aux_entity_keeps_english_entity_id(hass) -> None:
     state = hass.states.get(entity.entity_id)
     assert state is not None
     assert state.attributes["friendly_name"] == "Livefördröjning"
+    await component._async_reset()
 
 
 @pytest.mark.asyncio
@@ -390,6 +432,7 @@ async def test_legacy_entry_keeps_english_name_and_entity_id(hass) -> None:
     state = hass.states.get(entity.entity_id)
     assert state is not None
     assert state.attributes["friendly_name"] == "Live delay"
+    await component._async_reset()
 
 
 def test_mode_entities_use_standard_english_object_ids() -> None:
@@ -432,6 +475,7 @@ async def test_aux_platforms_use_standard_english_object_ids(hass) -> None:
     await number_platform.async_setup_entry(hass, entry, add_number_entities)
     number_entities = add_number_entities.call_args[0][0]
     assert number_entities[0].suggested_object_id == "f1_live_delay"
+    assert number_entities[0].entity_id == "number.f1_live_delay"
 
     add_select_entities = Mock()
     await select_platform.async_setup_entry(hass, entry, add_select_entities)
@@ -449,6 +493,12 @@ async def test_aux_platforms_use_standard_english_object_ids(hass) -> None:
     assert select_entities[f"{entry.entry_id}_replay_start_reference"] == (
         "f1_replay_start_reference"
     )
+    assert {entity.entity_id for entity in add_select_entities.call_args[0][0]} == {
+        "select.f1_live_delay_reference",
+        "select.f1_replay_session",
+        "select.f1_replay_start_reference",
+        "select.f1_replay_year",
+    }
 
     add_button_entities = Mock()
     await button_platform.async_setup_entry(hass, entry, add_button_entities)
@@ -468,6 +518,17 @@ async def test_aux_platforms_use_standard_english_object_ids(hass) -> None:
     )
     assert button_entities[f"{entry.entry_id}_replay_stop"] == "f1_replay_stop"
     assert button_entities[f"{entry.entry_id}_replay_refresh"] == "f1_replay_refresh"
+    assert {entity.entity_id for entity in add_button_entities.call_args[0][0]} == {
+        "button.f1_delay_calibration_match",
+        "button.f1_refresh_f1tv_access",
+        "button.f1_replay_back_30",
+        "button.f1_replay_forward_30",
+        "button.f1_replay_load",
+        "button.f1_replay_pause",
+        "button.f1_replay_play",
+        "button.f1_replay_refresh",
+        "button.f1_replay_stop",
+    }
 
     add_switch_entities = Mock()
     await switch_platform.async_setup_entry(hass, entry, add_switch_entities)
@@ -479,6 +540,10 @@ async def test_aux_platforms_use_standard_english_object_ids(hass) -> None:
         "f1_delay_calibration"
     )
     assert switch_entities["f1_sensor_no_spoiler_mode"] == "f1_no_spoiler_mode"
+    assert {entity.entity_id for entity in add_switch_entities.call_args[0][0]} == {
+        "switch.f1_delay_calibration",
+        "switch.f1_no_spoiler_mode",
+    }
 
     add_media_player_entities = Mock()
     await media_player_platform.async_setup_entry(
@@ -486,11 +551,86 @@ async def test_aux_platforms_use_standard_english_object_ids(hass) -> None:
     )
     media_player_entities = add_media_player_entities.call_args[0][0]
     assert media_player_entities[0].suggested_object_id == "f1_replay_player"
+    assert media_player_entities[0].entity_id == "media_player.f1_replay_player"
 
     add_calendar_entities = Mock()
     await calendar_platform.async_setup_entry(hass, entry, add_calendar_entities)
     calendar_entities = add_calendar_entities.call_args[0][0]
     assert calendar_entities[0].suggested_object_id == "f1_season_calendar"
+    assert calendar_entities[0].entity_id == "calendar.f1_season_calendar"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "existing_entity_id",
+    [
+        "number.f1_drivers_f1_live_delay",
+        "number.my_custom_delay",
+    ],
+)
+async def test_existing_registry_entity_id_is_preserved(
+    hass, existing_entity_id: str
+) -> None:
+    unique_id = "existing_live_delay"
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        Platform.NUMBER,
+        Platform.NUMBER,
+        unique_id,
+        suggested_object_id=existing_entity_id.removeprefix("number."),
+    )
+    entity = F1LiveDelayNumber(
+        controller=_DummyDelayController(5),
+        calibration=None,
+        unique_id=unique_id,
+        entry_id="existing_entry",
+        device_name="Drivers",
+    )
+    set_default_entity_id(
+        entity,
+        Platform.NUMBER,
+        default_object_id("live_delay"),
+    )
+
+    component = EntityComponent(_LOGGER, Platform.NUMBER, hass)
+    await component.async_add_entities([entity])
+    await hass.async_block_till_done()
+
+    assert entity.entity_id == existing_entity_id
+    registry_entry = registry.async_get(existing_entity_id)
+    assert registry_entry is not None
+    assert registry_entry.unique_id == unique_id
+    await component._async_reset()
+
+
+@pytest.mark.asyncio
+async def test_new_default_entity_id_collision_gets_suffix(hass) -> None:
+    entities = [
+        F1LiveDelayNumber(
+            controller=_DummyDelayController(index),
+            calibration=None,
+            unique_id=f"new_live_delay_{index}",
+            entry_id=f"new_entry_{index}",
+            device_name=f"RaceHub {index}",
+        )
+        for index in range(2)
+    ]
+    for entity in entities:
+        set_default_entity_id(
+            entity,
+            Platform.NUMBER,
+            default_object_id("live_delay"),
+        )
+
+    component = EntityComponent(_LOGGER, Platform.NUMBER, hass)
+    await component.async_add_entities(entities)
+    await hass.async_block_till_done()
+
+    assert {entity.entity_id for entity in entities} == {
+        "number.f1_live_delay",
+        "number.f1_live_delay_2",
+    }
+    await component._async_reset()
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -191,15 +191,6 @@ class _LiveState:
         self.is_live = is_live
 
 
-class _TimeoutSession:
-    def __init__(self) -> None:
-        self.calls = 0
-
-    def get(self, *_args, **_kwargs):
-        self.calls += 1
-        raise TimeoutError
-
-
 def _build_coordinator(hass, data: dict | None) -> DataUpdateCoordinator:
     coordinator = DataUpdateCoordinator(
         hass,
@@ -2439,7 +2430,7 @@ async def test_standings_sensor_counts_expandable(hass) -> None:
 
 
 def test_weather_sensor_uses_celsius_unit(hass) -> None:
-    coordinator = _build_coordinator(hass, {"MRData": {"RaceTable": {"Races": []}}})
+    coordinator = _build_coordinator(hass, {"current": {}})
     entry_id = "test_entry"
     _set_entry_context(hass, entry_id)
 
@@ -2457,47 +2448,12 @@ def test_weather_sensor_uses_celsius_unit(hass) -> None:
 @pytest.mark.asyncio
 async def test_weather_sensor_converts_native_temperature_to_ha_unit(hass) -> None:
     hass.config.units = US_CUSTOMARY_SYSTEM
-    coordinator = _build_coordinator(hass, {"MRData": {"RaceTable": {"Races": []}}})
-    entry_id = "test_entry"
-    _set_entry_context(hass, entry_id)
-
-    sensor = F1WeatherSensor(
-        coordinator,
-        f"{entry_id}_weather",
-        entry_id,
-        "F1",
-    )
-    sensor._current = {"temperature": 21.0}
-
-    state = await _add_sensor_and_get_state(hass, sensor)
-
-    assert state.state == "69.8"
-    assert state.attributes["unit_of_measurement"] == UnitOfTemperature.FAHRENHEIT
-
-
-@pytest.mark.asyncio
-async def test_weather_sensor_timeout_clears_stale_state(hass, monkeypatch) -> None:
     coordinator = _build_coordinator(
         hass,
         {
-            "MRData": {
-                "RaceTable": {
-                    "Races": [
-                        {
-                            "season": "2026",
-                            "round": "1",
-                            "raceName": "Australian Grand Prix",
-                            "date": "2099-03-20",
-                            "time": "05:00:00Z",
-                            "Circuit": {
-                                "circuitId": "albert_park",
-                                "circuitName": "Albert Park",
-                                "Location": {"lat": "-37.8497", "long": "144.968"},
-                            },
-                        }
-                    ]
-                }
-            }
+            "circuit": {},
+            "current": {"temperature": 21.0, "weather_code": 1},
+            "race": {},
         },
     )
     entry_id = "test_entry"
@@ -2509,25 +2465,66 @@ async def test_weather_sensor_timeout_clears_stale_state(hass, monkeypatch) -> N
         entry_id,
         "F1",
     )
-    sensor._current = {"temperature": 31.2, "weather_source": "stale"}
-    sensor._race = {"temperature": 27.5, "weather_source": "stale"}
-    sensor._attr_icon = "mdi:weather-sunny"
-    timeout_session = _TimeoutSession()
+    state = await _add_sensor_and_get_state(hass, sensor)
 
-    monkeypatch.setattr(
-        "custom_components.f1_sensor.sensor.async_get_clientsession",
-        lambda _hass: timeout_session,
+    assert state.state == "69.8"
+    assert state.attributes["unit_of_measurement"] == UnitOfTemperature.FAHRENHEIT
+
+
+@pytest.mark.asyncio
+async def test_weather_sensor_preserves_legacy_attributes(hass) -> None:
+    coordinator = _build_coordinator(
+        hass,
+        {
+            "circuit": {
+                "season": "2026",
+                "round": "1",
+                "race_name": "Australian Grand Prix",
+                "circuit_id": "albert_park",
+                "circuit_name": "Albert Park",
+            },
+            "current": {
+                "temperature": 31.2,
+                "humidity": 40,
+                "cloud_coverage": 10,
+                "precipitation": 0.0,
+                "precipitation_probability": 2,
+                "wind_speed": 3.2,
+                "wind_bearing": 304.0,
+                "wind_gust_speed": 8.3,
+                "visibility": 34840.0,
+                "weather_code": 1,
+                "is_daytime": True,
+            },
+            "race": {
+                "temperature": 27.5,
+                "precipitation": 1.2,
+                "weather_code": 3,
+                "is_daytime": True,
+            },
+        },
     )
-    sensor._hass = hass
-    sensor.async_write_ha_state = MagicMock()
+    entry_id = "test_entry"
+    _set_entry_context(hass, entry_id)
 
-    await sensor._update_weather()
+    sensor = F1WeatherSensor(
+        coordinator,
+        f"{entry_id}_weather",
+        entry_id,
+        "F1",
+    )
 
-    assert timeout_session.calls == 1
-    assert sensor._current == {}
-    assert sensor._race == {}
-    assert sensor._attr_icon == "mdi:weather-partly-cloudy"
-    sensor.async_write_ha_state.assert_called_once()
+    state = await _add_sensor_and_get_state(hass, sensor)
+
+    assert state.state == "31.2"
+    assert state.attributes["race_name"] == "Australian Grand Prix"
+    assert state.attributes["current_weather_source"] == "open-meteo"
+    assert state.attributes["current_wind_direction"] == "NW"
+    assert state.attributes["current_visibility_unit"] == "m"
+    assert state.attributes["race_temperature"] == 27.5
+    assert state.attributes["race_precipitation_amount_min"] == 1.2
+    assert state.attributes["race_precipitation_amount_max"] == 1.2
+    assert state.attributes["race_weather_icon"] == "mdi:weather-cloudy"
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_setup.py
+++ b/custom_components/f1_sensor/tests/test_setup.py
@@ -530,6 +530,7 @@ async def test_async_setup_entry_minimal(hass, mock_config_entry) -> None:
     assert isinstance(mock_config_entry.runtime_data, TrackMapRuntimeData)
     assert isinstance(entry_data["track_map_store"], TrackMapStore)
     assert isinstance(entry_data["track_map_replay_adapter"], TrackMapReplayAdapter)
+    assert entry_data["race_weather_coordinator"] is not None
     assert (
         entry_data["track_map_store"] is mock_config_entry.runtime_data.track_map_store
     )
@@ -632,6 +633,7 @@ async def test_async_setup_entry_skips_lap_position_coordinator_when_disabled(
     assert result is True
     entry_data = hass.data[DOMAIN][entry.entry_id]
     assert entry_data["lap_position_progression_coordinator"] is None
+    assert entry_data["race_weather_coordinator"] is None
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_weather.py
+++ b/custom_components/f1_sensor/tests/test_weather.py
@@ -1,0 +1,548 @@
+"""Tests for the native next-race weather entity and shared coordinator."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock
+
+from homeassistant.components.weather import DATA_COMPONENT, WeatherEntityFeature
+from homeassistant.const import Platform, UnitOfSpeed, UnitOfTemperature
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.setup import async_setup_component
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.f1_sensor import weather as weather_platform
+from custom_components.f1_sensor.const import (
+    CONF_OPERATION_MODE,
+    DOMAIN,
+    OPERATION_MODE_DEVELOPMENT,
+)
+from custom_components.f1_sensor.entity import default_object_id, set_default_entity_id
+from custom_components.f1_sensor.race_weather import (
+    DAILY_WEATHER_FIELDS,
+    WEATHER_FIELDS,
+    F1RaceWeatherCoordinator,
+    wmo_condition,
+)
+from custom_components.f1_sensor.sensor import F1WeatherSensor
+from custom_components.f1_sensor.weather import F1RaceWeatherEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _Response:
+    def __init__(self, payload) -> None:
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, *responses) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, *, params: dict):
+        self.calls.append((url, params))
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return _Response(response)
+
+
+def _race(
+    *,
+    round_number: str = "1",
+    race_name: str = "Australian Grand Prix",
+    circuit_id: str = "albert_park",
+    circuit_name: str = "Albert Park",
+    date: str = "2099-03-20",
+    time: str = "05:00:00Z",
+    latitude: str = "-37.8497",
+    longitude: str = "144.968",
+) -> dict:
+    return {
+        "season": "2099",
+        "round": round_number,
+        "raceName": race_name,
+        "date": date,
+        "time": time,
+        "Circuit": {
+            "circuitId": circuit_id,
+            "circuitName": circuit_name,
+            "Location": {
+                "lat": latitude,
+                "long": longitude,
+                "locality": "Melbourne",
+                "country": "Australia",
+            },
+        },
+    }
+
+
+def _schedule(race: dict | None) -> dict:
+    return {
+        "MRData": {
+            "RaceTable": {
+                "Races": [race] if race is not None else [],
+            }
+        }
+    }
+
+
+def _payload(date: str = "2099-03-20", *, current_temperature: float = 23.2):
+    times = [f"{date}T04:00", f"{date}T05:00", f"{date}T06:00"]
+    return {
+        "utc_offset_seconds": 0,
+        "current": {
+            "time": times[0],
+            "temperature_2m": current_temperature,
+            "relative_humidity_2m": 28,
+            "precipitation": 0.0,
+            "precipitation_probability": 2,
+            "cloud_cover": 34,
+            "wind_speed_10m": 3.2,
+            "wind_direction_10m": 304,
+            "wind_gusts_10m": 8.3,
+            "visibility": 34840.0,
+            "weather_code": 1,
+            "is_day": 1,
+        },
+        "hourly": {
+            "time": times,
+            "temperature_2m": [20.0, 32.1, 31.4],
+            "relative_humidity_2m": [30, 25, 27],
+            "precipitation": [0.0, 0.4, 0.1],
+            "precipitation_probability": [2, 26, 12],
+            "cloud_cover": [34, 83, 70],
+            "wind_speed_10m": [3.2, 4.92, 4.3],
+            "wind_direction_10m": [304, 199, 205],
+            "wind_gusts_10m": [8.3, 13.0, 11.2],
+            "visibility": [34840.0, 41580.0, 40000.0],
+            "weather_code": [1, 3, 61],
+            "is_day": [0, 1, 1],
+        },
+        "daily": {
+            "time": [date],
+            "weather_code": [61],
+            "temperature_2m_max": [32.1],
+            "temperature_2m_min": [20.0],
+            "precipitation_sum": [0.5],
+            "precipitation_probability_max": [26],
+            "wind_speed_10m_max": [4.92],
+            "wind_gusts_10m_max": [13.0],
+            "wind_direction_10m_dominant": [199],
+        },
+    }
+
+
+def _coordinators(hass, session: _Session, race: dict | None = None):
+    entry = MockConfigEntry(domain=DOMAIN, data={"sensor_name": "F1"})
+    entry.add_to_hass(hass)
+    race_coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="race schedule",
+        config_entry=entry,
+    )
+    race_coordinator.async_set_updated_data(_schedule(race or _race()))
+    weather_coordinator = F1RaceWeatherCoordinator(
+        hass,
+        race_coordinator,
+        session=session,  # type: ignore[arg-type]
+        config_entry=entry,
+    )
+    return entry, race_coordinator, weather_coordinator
+
+
+@pytest.mark.parametrize(
+    ("code", "is_daytime", "expected"),
+    [
+        (0, True, "sunny"),
+        (0, False, "clear-night"),
+        (2, True, "partlycloudy"),
+        (3, True, "cloudy"),
+        (45, True, "fog"),
+        (61, True, "rainy"),
+        (65, True, "pouring"),
+        (67, True, "snowy-rainy"),
+        (75, True, "snowy"),
+        (95, True, "lightning"),
+        (99, True, "lightning-rainy"),
+        (123, True, "exceptional"),
+        (None, True, None),
+    ],
+)
+def test_wmo_condition_mapping(code, is_daytime, expected) -> None:
+    assert wmo_condition(code, is_daytime) == expected
+
+
+@pytest.mark.asyncio
+async def test_weather_coordinator_fetches_and_normalizes_race_forecast(hass) -> None:
+    session = _Session(_payload())
+    _, _, coordinator = _coordinators(hass, session)
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert len(session.calls) == 1
+    _, params = session.calls[0]
+    assert params["latitude"] == "-37.8497"
+    assert params["longitude"] == "144.968"
+    assert params["timezone"] == "auto"
+    assert params["forecast_days"] == "16"
+    assert set(params["current"].split(",")) == set(WEATHER_FIELDS)
+    assert set(params["daily"].split(",")) == set(DAILY_WEATHER_FIELDS)
+    assert coordinator.data["current"]["condition"] == "partlycloudy"
+    assert coordinator.data["current"]["temperature"] == 23.2
+    assert coordinator.data["daily"][0]["condition"] == "rainy"
+    assert coordinator.data["daily"][0]["temperature"] == 32.1
+    assert coordinator.data["daily"][0]["temperature_low"] == 20.0
+    assert len(coordinator.data["twice_daily"]) == 2
+    assert coordinator.data["twice_daily"][0]["is_daytime"] is False
+    assert coordinator.data["twice_daily"][1]["is_daytime"] is True
+    assert coordinator.data["race"]["datetime"] == "2099-03-20T05:00:00+00:00"
+    assert coordinator.data["race"]["condition"] == "cloudy"
+    assert coordinator.data["race"]["temperature"] == 32.1
+
+
+@pytest.mark.asyncio
+async def test_weather_coordinator_normalizes_circuit_local_time_to_utc(hass) -> None:
+    payload = _payload()
+    payload["utc_offset_seconds"] = 36000
+    session = _Session(payload)
+    _, _, coordinator = _coordinators(
+        hass,
+        session,
+        _race(date="2099-03-19", time="19:00:00Z"),
+    )
+
+    await coordinator.async_refresh()
+
+    assert coordinator.data["hourly"][1]["datetime"] == ("2099-03-19T19:00:00+00:00")
+    assert coordinator.data["daily"][0]["datetime"] == ("2099-03-19T14:00:00+00:00")
+    assert coordinator.data["race"]["datetime"] == "2099-03-19T19:00:00+00:00"
+    assert len(coordinator.data["twice_daily"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_weather_coordinator_does_not_label_out_of_range_hour_as_race(
+    hass,
+) -> None:
+    session = _Session(_payload("2099-03-01"))
+    _, _, coordinator = _coordinators(
+        hass,
+        session,
+        _race(date="2099-03-20"),
+    )
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success
+    assert len(coordinator.data["hourly"]) == 3
+    assert coordinator.data["race"] == {}
+
+
+@pytest.mark.asyncio
+async def test_weather_coordinator_marks_failed_request_unavailable(hass) -> None:
+    session = _Session(TimeoutError())
+    _, _, coordinator = _coordinators(hass, session)
+
+    await coordinator.async_refresh()
+
+    assert not coordinator.last_update_success
+    assert coordinator.data is None
+
+
+@pytest.mark.asyncio
+async def test_weather_coordinator_refreshes_when_target_race_changes(hass) -> None:
+    session = _Session(
+        _payload(),
+        _payload("2099-04-02", current_temperature=18.5),
+    )
+    _, race_coordinator, coordinator = _coordinators(hass, session)
+    await coordinator.async_refresh()
+    coordinator.async_start()
+
+    race_coordinator.async_set_updated_data(
+        _schedule(
+            _race(
+                round_number="2",
+                race_name="Japanese Grand Prix",
+                circuit_id="suzuka",
+                circuit_name="Suzuka",
+                date="2099-04-02",
+                latitude="34.8431",
+                longitude="136.541",
+            )
+        )
+    )
+    await hass.async_block_till_done()
+
+    assert len(session.calls) == 2
+    assert coordinator.data["race_key"] == "2099:2:suzuka"
+    assert coordinator.data["circuit"]["race_name"] == "Japanese Grand Prix"
+    assert coordinator.data["current"]["temperature"] == 18.5
+    await coordinator.async_close()
+
+    race_coordinator.async_set_updated_data(
+        _schedule(_race(round_number="3", circuit_id="silverstone"))
+    )
+    await hass.async_block_till_done()
+    assert len(session.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_weather_platform_adds_entity_with_stable_identity(hass) -> None:
+    session = _Session(_payload())
+    entry, _, coordinator = _coordinators(hass, session)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "race_weather_coordinator": coordinator,
+    }
+    async_add_entities = Mock()
+
+    await weather_platform.async_setup_entry(hass, entry, async_add_entities)
+
+    async_add_entities.assert_called_once()
+    entity = async_add_entities.call_args.args[0][0]
+    assert isinstance(entity, F1RaceWeatherEntity)
+    assert entity.unique_id == f"{entry.entry_id}_weather_entity"
+    assert entity.entity_id == "weather.f1_weather"
+    assert entity.has_entity_name is False
+    assert entity.device_info is None
+
+
+@pytest.mark.asyncio
+async def test_weather_entity_name_uses_location_fallbacks(hass) -> None:
+    session = _Session()
+    entry, _, coordinator = _coordinators(hass, session)
+    entity = F1RaceWeatherEntity(
+        coordinator,
+        f"{entry.entry_id}_weather_entity",
+        entry.entry_id,
+        "F1",
+    )
+
+    coordinator.async_set_updated_data(
+        {
+            "race_key": None,
+            "race_start": None,
+            "circuit": {"circuit_locality": "Melbourne"},
+            "current": {},
+            "hourly": [],
+            "race": {},
+        }
+    )
+    assert entity.name == "Melbourne"
+
+    coordinator.async_set_updated_data(
+        {
+            "race_key": None,
+            "race_start": None,
+            "circuit": {
+                "race_name": "Australian Grand Prix",
+                "circuit_country": "Australia",
+            },
+            "current": {},
+            "hourly": [],
+            "race": {},
+        }
+    )
+    assert entity.name == "Australian Grand Prix · Australia"
+
+    coordinator.async_set_updated_data(
+        {
+            "race_key": None,
+            "race_start": None,
+            "circuit": {},
+            "current": {},
+            "hourly": [],
+            "race": {},
+        }
+    )
+    assert entity.name == "Weather"
+
+
+@pytest.mark.asyncio
+async def test_weather_entity_exposes_native_state_and_forecast_service(hass) -> None:
+    session = _Session(_payload())
+    entry, _, coordinator = _coordinators(hass, session)
+    await coordinator.async_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        CONF_OPERATION_MODE: OPERATION_MODE_DEVELOPMENT,
+    }
+
+    entity = F1RaceWeatherEntity(
+        coordinator,
+        f"{entry.entry_id}_weather_entity",
+        entry.entry_id,
+        "F1",
+    )
+    set_default_entity_id(entity, Platform.WEATHER, default_object_id("weather"))
+
+    assert await async_setup_component(hass, "weather", {})
+    component = hass.data[DATA_COMPONENT]
+    await component.async_add_entities([entity])
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == "partlycloudy"
+    assert state.attributes["temperature"] == 23.2
+    assert state.attributes["temperature_unit"] == UnitOfTemperature.CELSIUS
+    assert state.attributes["humidity"] == 28
+    assert state.attributes["cloud_coverage"] == 34
+    assert state.attributes["visibility"] == 34.84
+    assert state.attributes["race_forecast_available"] is True
+    assert state.attributes["race_name"] == "Australian Grand Prix"
+    assert state.attributes["friendly_name"] == "Albert Park · Melbourne"
+    assert entity.supported_features == (
+        WeatherEntityFeature.FORECAST_DAILY
+        | WeatherEntityFeature.FORECAST_HOURLY
+        | WeatherEntityFeature.FORECAST_TWICE_DAILY
+    )
+
+    response = await hass.services.async_call(
+        "weather",
+        "get_forecasts",
+        {"entity_id": entity.entity_id, "type": "hourly"},
+        blocking=True,
+        return_response=True,
+    )
+    forecast = response[entity.entity_id]["forecast"]
+    assert len(forecast) == 3
+    assert forecast[1]["datetime"] == "2099-03-20T05:00:00+00:00"
+    assert forecast[1]["condition"] == "cloudy"
+    assert forecast[1]["temperature"] == 32.1
+    assert forecast[1]["precipitation_probability"] == 26
+    assert forecast[1]["precipitation"] == 0.4
+
+    response = await hass.services.async_call(
+        "weather",
+        "get_forecasts",
+        {"entity_id": entity.entity_id, "type": "daily"},
+        blocking=True,
+        return_response=True,
+    )
+    forecast = response[entity.entity_id]["forecast"]
+    assert len(forecast) == 1
+    assert forecast[0]["datetime"] == "2099-03-20T00:00:00+00:00"
+    assert forecast[0]["condition"] == "rainy"
+    assert forecast[0]["temperature"] == 32.1
+    assert forecast[0]["templow"] == 20.0
+    assert forecast[0]["precipitation"] == 0.5
+
+    response = await hass.services.async_call(
+        "weather",
+        "get_forecasts",
+        {"entity_id": entity.entity_id, "type": "twice_daily"},
+        blocking=True,
+        return_response=True,
+    )
+    forecast = response[entity.entity_id]["forecast"]
+    assert len(forecast) == 2
+    assert forecast[0]["is_daytime"] is False
+    assert forecast[0]["temperature"] == 20.0
+    assert forecast[1]["is_daytime"] is True
+    assert forecast[1]["condition"] == "rainy"
+    assert forecast[1]["temperature"] == 32.1
+    assert forecast[1]["templow"] == 31.4
+    assert forecast[1]["precipitation"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_weather_entity_converts_native_values_to_us_units(hass) -> None:
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    session = _Session(_payload())
+    entry, _, coordinator = _coordinators(hass, session)
+    await coordinator.async_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        CONF_OPERATION_MODE: OPERATION_MODE_DEVELOPMENT,
+    }
+    entity = F1RaceWeatherEntity(
+        coordinator,
+        f"{entry.entry_id}_weather_entity",
+        entry.entry_id,
+        "F1",
+    )
+    set_default_entity_id(entity, Platform.WEATHER, default_object_id("weather"))
+
+    assert await async_setup_component(hass, "weather", {})
+    component = hass.data[DATA_COMPONENT]
+    await component.async_add_entities([entity])
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.attributes["temperature"] == 74
+    assert state.attributes["temperature_unit"] == UnitOfTemperature.FAHRENHEIT
+    assert state.attributes["visibility_unit"] == "mi"
+    assert state.attributes["wind_speed_unit"] == UnitOfSpeed.MILES_PER_HOUR
+
+    response = await hass.services.async_call(
+        "weather",
+        "get_forecasts",
+        {"entity_id": entity.entity_id, "type": "daily"},
+        blocking=True,
+        return_response=True,
+    )
+    forecast = response[entity.entity_id]["forecast"][0]
+    assert forecast["temperature"] == 90
+    assert forecast["templow"] == 68
+    assert forecast["precipitation"] == 0.02
+
+
+@pytest.mark.asyncio
+async def test_sensor_and_weather_entity_share_one_coordinator_fetch(hass) -> None:
+    session = _Session(_payload())
+    entry, _, coordinator = _coordinators(hass, session)
+    await coordinator.async_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        CONF_OPERATION_MODE: OPERATION_MODE_DEVELOPMENT,
+    }
+
+    weather = F1RaceWeatherEntity(
+        coordinator,
+        f"{entry.entry_id}_weather_entity",
+        entry.entry_id,
+        "F1",
+    )
+    sensor = F1WeatherSensor(
+        coordinator,
+        f"{entry.entry_id}_weather",
+        entry.entry_id,
+        "F1",
+    )
+
+    assert weather.native_temperature == 23.2
+    assert sensor.native_value == 23.2
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_race_schedule_without_future_race_does_not_call_weather_api(
+    hass,
+) -> None:
+    session = _Session()
+    _, race_coordinator, coordinator = _coordinators(hass, session)
+    race_coordinator.async_set_updated_data(_schedule(None))
+
+    await coordinator.async_refresh()
+
+    assert coordinator.data["current"] == {}
+    assert coordinator.data["daily"] == []
+    assert coordinator.data["hourly"] == []
+    assert coordinator.data["twice_daily"] == []
+    assert session.calls == []

--- a/custom_components/f1_sensor/tests/test_weather_card.py
+++ b/custom_components/f1_sensor/tests/test_weather_card.py
@@ -1,0 +1,69 @@
+"""Structural regression tests for the standalone F1 weather card."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CARD_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "www"
+    / "f1-sensor-live-data-card"
+    / "f1-sensor-live-data-card.js"
+)
+
+
+def _source() -> str:
+    return CARD_PATH.read_text(encoding="utf-8")
+
+
+def test_weather_card_is_registered_with_editor_and_picker_metadata() -> None:
+    source = _source()
+
+    assert "class F1WeatherCard extends LitElement" in source
+    assert "class F1WeatherCardEditor extends LitElement" in source
+    assert "customElements.define('f1-weather-card', F1WeatherCard)" in source
+    assert (
+        "customElements.define('f1-weather-card-editor', F1WeatherCardEditor)" in source
+    )
+    assert "type: 'custom:f1-weather-card'" in source
+    assert "type: 'f1-weather-card'" in source
+    assert "name: 'F1 Race Weather'" in source
+
+
+def test_weather_card_uses_family_theme_responsive_layout_and_auto_height() -> None:
+    source = _source()
+
+    assert "static styles = [F1_THEME_STYLES" in source
+    assert "radial-gradient(circle at 15% 10%, var(--f1-card-chip)" in source
+    assert "font-family: var(--f1-card-heading-font-family" in source
+    assert "font-family: var(--f1-card-display-font-family" in source
+    assert 'class="fw-card" data-layout=${layoutMode}' in source
+    assert ".fw-card[data-layout='narrow'] .fw-grid" in source
+    assert "@media (prefers-reduced-motion: reduce)" in source
+    assert "installSectionsAutoHeight(F1WeatherCard" in source
+    assert "F1WeatherCard," in source
+
+
+def test_weather_card_uses_compact_container_relative_visual_scale() -> None:
+    source = _source()
+
+    assert "--fw-card-title-size: clamp(14px, 2.2cqw, 18px);" in source
+    assert "--fw-panel-title-size: clamp(11px, 3.5cqw, 13px);" in source
+    assert "--fw-icon-box-size: clamp(40px, 12cqw, 46px);" in source
+    assert "--fw-icon-size: clamp(24px, 7cqw, 28px);" in source
+    assert "--fw-temperature-size: clamp(25px, 9cqw, 34px);" in source
+    assert "font-size: var(--fw-temperature-size);" in source
+    assert "--mdc-icon-size: var(--fw-icon-size);" in source
+
+
+def test_weather_card_exposes_current_and_race_start_weather_semantics() -> None:
+    source = _source()
+
+    assert "Now at circuit" in source
+    assert "Race start" in source
+    assert "Current circuit weather is not available" in source
+    assert "Race-start forecast is not available" in source
+    assert "prefer_live_weather: true" in source
+    assert "resolveF1WeatherComparison(" in source
+    assert 'role="meter"' in source
+    assert "aria-label=${label}" in source

--- a/custom_components/f1_sensor/tests/test_weather_card_units.py
+++ b/custom_components/f1_sensor/tests/test_weather_card_units.py
@@ -48,6 +48,26 @@ function extractFunction(signature) {
   return source.slice(start, end + 1);
 }
 
+function extractStatement(signature) {
+  const start = source.indexOf(signature);
+  if (start === -1) {
+    throw new Error(`Statement signature not found: ${signature}`);
+  }
+  const end = source.indexOf(";", start);
+  return source.slice(start, end + 1);
+}
+
+function extractConstFunction(signature) {
+  const start = source.indexOf(signature);
+  if (start === -1) {
+    throw new Error(`Const function signature not found: ${signature}`);
+  }
+  const arrow = source.indexOf("=>", start);
+  const braceStart = source.indexOf("{", arrow);
+  const end = findMatchingBrace(source, braceStart);
+  return source.slice(start, source.indexOf(";", end) + 1);
+}
+
 function extractClass(signature) {
   const start = source.indexOf(signature);
   if (start === -1) {
@@ -69,14 +89,24 @@ function extractMethod(classSource, signature) {
 }
 
 const helpers = [
+  extractConstFunction("const formatHassDateTime = (hass, date, options = {}, fallback = '') =>"),
   extractFunction("function getF1UnitSystemUnit(hass, key, fallback) {"),
   extractFunction("function getF1TemperatureUnit(hass, entity) {"),
   extractFunction("function convertF1Temperature(value, fromUnit, toUnit) {"),
   extractFunction("function convertF1Speed(value, fromUnit, toUnit) {"),
+  extractStatement("const F1_WEATHER_ACTIVE_SESSION_STATES ="),
+  extractStatement("const F1_WMO_CONDITIONS ="),
+  extractFunction("function toF1FiniteNumber(value) {"),
+  extractFunction("function getF1WeatherCondition(code, rainfall = null, isLive = false) {"),
+  extractFunction("function hasF1TrackWeather(trackWeatherState) {"),
+  extractFunction("function hasF1ForecastWeather(weatherState) {"),
+  extractFunction("function f1WeatherBlockHasData(block) {"),
+  extractFunction("function resolveF1WeatherComparison("),
 ];
 
 const liveClass = extractClass("class F1LiveSessionCard extends LitElement {");
 const nextRaceClass = extractClass("class F1NextRaceCard extends LitElement {");
+const weatherClass = extractClass("class F1WeatherCard extends LitElement {");
 
 const Harness = new Function(
   `
@@ -113,6 +143,7 @@ const Harness = new Function(
     ${extractMethod(nextRaceClass, "_formatTemperature(value, unit) {")}
     ${extractMethod(nextRaceClass, "_formatWind(speed, directionDegrees, unit) {")}
     ${extractMethod(nextRaceClass, "_windDirectionToCardinal(degrees) {")}
+    ${extractMethod(weatherClass, "_formatRaceStart(nextRace) {")}
   }
 
   return Harness;
@@ -135,6 +166,8 @@ if (payload.action === "live") {
     temperature: harness._formatTemperature(payload.temperature, payload.temperatureUnit),
     wind: harness._formatWind(payload.wind, payload.windDirection, payload.windUnit),
   };
+} else if (payload.action === "race_start") {
+  result = harness._formatRaceStart(payload.nextRace || {});
 } else {
   throw new Error(`Unknown action: ${payload.action}`);
 }
@@ -288,3 +321,84 @@ def test_weather_formatters_render_selected_units() -> None:
         "temperature": "77.0 °F",
         "wind": "22.4 mph E",
     }
+
+
+def test_weather_prefers_live_track_feed_during_active_weekend() -> None:
+    result = _run_probe(
+        {
+            "action": "next_race",
+            "hass": _hass(temperature="°C", wind_speed="m/s"),
+            "weatherState": {
+                "state": "16.7",
+                "attributes": {
+                    "unit_of_measurement": "°C",
+                    "current_weather_code": 0,
+                    "race_temperature": 17,
+                    "race_weather_code": 61,
+                },
+            },
+            "trackWeatherState": {
+                "state": "18.1",
+                "attributes": {
+                    "unit_of_measurement": "°C",
+                    "track_temperature": 36.5,
+                    "rainfall": 0,
+                },
+            },
+            "sessionStatus": {"state": "pre"},
+        }
+    )
+
+    assert result["usingLiveNow"] is True
+    assert result["now"]["source"] == "LIVE"
+    assert result["now"]["condition"] == "Dry track"
+    assert result["race"]["condition"] == "Light rain"
+
+
+def test_weather_returns_to_forecast_after_weekend() -> None:
+    result = _run_probe(
+        {
+            "action": "next_race",
+            "hass": _hass(temperature="°C", wind_speed="m/s"),
+            "weatherState": {
+                "state": "12",
+                "attributes": {
+                    "unit_of_measurement": "°C",
+                    "current_weather_code": 3,
+                    "race_temperature": 13,
+                },
+            },
+            "trackWeatherState": {
+                "state": "20",
+                "attributes": {"unit_of_measurement": "°C", "rainfall": 1},
+            },
+            "sessionStatus": {"state": "ended"},
+        }
+    )
+
+    assert result["usingLiveNow"] is False
+    assert result["now"]["source"] == "FORECAST"
+    assert result["now"]["condition"] == "Overcast"
+    assert result["now"]["temperature"] == 12
+
+
+@pytest.mark.parametrize(
+    ("time_format", "expected_fragment"),
+    [("24", "15:00"), ("12", "3:00")],
+)
+def test_weather_formats_race_start_with_home_assistant_clock(
+    time_format: str, expected_fragment: str
+) -> None:
+    hass = _hass()
+    hass["locale"] = {"time_format": time_format, "language": "en-GB"}
+    hass["config"]["time_zone"] = "Europe/Stockholm"
+
+    result = _run_probe(
+        {
+            "action": "race_start",
+            "hass": hass,
+            "nextRace": {"race_start_utc": "2026-07-19T13:00:00Z"},
+        }
+    )
+
+    assert expected_fragment in result

--- a/custom_components/f1_sensor/translations/da.json
+++ b/custom_components/f1_sensor/translations/da.json
@@ -176,6 +176,11 @@
         "name": "Ingen Spoiler-tilstand"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Vejr"
+      }
+    },
     "button": {
       "clear_f1tv_access": {
         "name": "Clear F1TV access"

--- a/custom_components/f1_sensor/translations/de.json
+++ b/custom_components/f1_sensor/translations/de.json
@@ -176,6 +176,11 @@
         "name": "Kein-Spoiler-Modus"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Wetter"
+      }
+    },
     "button": {
       "clear_f1tv_access": {
         "name": "Clear F1TV access"

--- a/custom_components/f1_sensor/translations/en.json
+++ b/custom_components/f1_sensor/translations/en.json
@@ -273,6 +273,11 @@
         "name": "Replay status"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Weather"
+      }
+    },
     "button": {
       "delay_calibration_match": {
         "name": "Match live delay"

--- a/custom_components/f1_sensor/translations/fi.json
+++ b/custom_components/f1_sensor/translations/fi.json
@@ -239,6 +239,11 @@
         "name": "F1TV token expires at"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Sää"
+      }
+    },
     "button": {
       "delay_calibration_match": {
         "name": "Kohdista live-viiveeseen"

--- a/custom_components/f1_sensor/translations/fr.json
+++ b/custom_components/f1_sensor/translations/fr.json
@@ -176,6 +176,11 @@
         "name": "Mode sans spoilers"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Météo"
+      }
+    },
     "button": {
       "clear_f1tv_access": {
         "name": "Clear F1TV access"

--- a/custom_components/f1_sensor/translations/it.json
+++ b/custom_components/f1_sensor/translations/it.json
@@ -262,6 +262,11 @@
         "name": "Stato replay"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Meteo"
+      }
+    },
     "button": {
       "delay_calibration_match": {
         "name": "Imposta ritardo diretta"

--- a/custom_components/f1_sensor/translations/nl.json
+++ b/custom_components/f1_sensor/translations/nl.json
@@ -176,6 +176,11 @@
         "name": "Geen-spoilermodus"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Weer"
+      }
+    },
     "button": {
       "clear_f1tv_access": {
         "name": "Clear F1TV access"

--- a/custom_components/f1_sensor/translations/no.json
+++ b/custom_components/f1_sensor/translations/no.json
@@ -176,6 +176,11 @@
         "name": "Ingen spoiler-modus"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Vær"
+      }
+    },
     "button": {
       "clear_f1tv_access": {
         "name": "Clear F1TV access"

--- a/custom_components/f1_sensor/translations/pt.json
+++ b/custom_components/f1_sensor/translations/pt.json
@@ -176,6 +176,11 @@
         "name": "Modo sem spoilers"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Clima"
+      }
+    },
     "button": {
       "clear_f1tv_access": {
         "name": "Clear F1TV access"

--- a/custom_components/f1_sensor/translations/sv.json
+++ b/custom_components/f1_sensor/translations/sv.json
@@ -269,6 +269,11 @@
         "name": "Replay-status"
       }
     },
+    "weather": {
+      "weather": {
+        "name": "Väder"
+      }
+    },
     "button": {
       "delay_calibration_match": {
         "name": "Matcha livefördröjning"

--- a/custom_components/f1_sensor/weather.py
+++ b/custom_components/f1_sensor/weather.py
@@ -1,0 +1,235 @@
+"""Weather platform for the circuit hosting the next Formula 1 race."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.weather import (
+    Forecast,
+    WeatherEntity,
+    WeatherEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    Platform,
+    UnitOfLength,
+    UnitOfPrecipitationDepth,
+    UnitOfSpeed,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
+from .entity import F1BaseEntity, default_object_id, set_default_entity_id
+from .race_weather import (
+    F1RaceWeatherCoordinator,
+    RaceWeatherData,
+    WeatherObservation,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up the next-race weather entity."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data.get("race_weather_coordinator")
+    if not isinstance(coordinator, F1RaceWeatherCoordinator):
+        return
+
+    entity = F1RaceWeatherEntity(
+        coordinator,
+        f"{entry.entry_id}_weather_entity",
+        entry.entry_id,
+        entry.data.get("sensor_name", "F1"),
+    )
+    set_default_entity_id(entity, Platform.WEATHER, default_object_id("weather"))
+    async_add_entities([entity])
+
+
+class F1RaceWeatherEntity(F1BaseEntity, WeatherEntity):
+    """Represent current weather and forecasts at the next race circuit."""
+
+    _device_category = "race"
+    _attr_has_entity_name = False
+    _attr_translation_key = "weather"
+    _attr_attribution = "Weather data by Open-Meteo.com"
+    _attr_supported_features = (
+        WeatherEntityFeature.FORECAST_DAILY
+        | WeatherEntityFeature.FORECAST_HOURLY
+        | WeatherEntityFeature.FORECAST_TWICE_DAILY
+    )
+    _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
+    _attr_native_wind_speed_unit = UnitOfSpeed.METERS_PER_SECOND
+    _attr_native_visibility_unit = UnitOfLength.KILOMETERS
+
+    def __init__(
+        self,
+        coordinator: F1RaceWeatherCoordinator,
+        unique_id: str,
+        entry_id: str,
+        device_name: str,
+    ) -> None:
+        super().__init__(coordinator, unique_id, entry_id, device_name)
+        self._apply_coordinator_data()
+
+    @property
+    def available(self) -> bool:
+        """Return whether current conditions are valid for the target race."""
+        data = self._coordinator_data
+        current = data.get("current", {})
+        return (
+            super().available
+            and current.get("temperature") is not None
+            and current.get("condition") is not None
+        )
+
+    @property
+    def device_info(self) -> None:
+        """Keep the destination weather independent of the race device name."""
+        return None
+
+    @property
+    def name(self) -> str | None:
+        """Return a recognizable destination for the next race."""
+        circuit = self._coordinator_data.get("circuit", {})
+        circuit_name = str(circuit.get("circuit_name") or "").strip()
+        race_name = str(circuit.get("race_name") or "").strip()
+        locality = str(circuit.get("circuit_locality") or "").strip()
+        country = str(circuit.get("circuit_country") or "").strip()
+
+        destination_name = circuit_name or race_name
+        destination_place = locality or country
+        if destination_name and destination_place:
+            if destination_name.casefold() == destination_place.casefold():
+                return destination_name
+            return f"{destination_name} · {destination_place}"
+        return destination_name or destination_place or super().name
+
+    @property
+    def _coordinator_data(self) -> RaceWeatherData:
+        """Return a shape-safe coordinator snapshot."""
+        data = self.coordinator.data
+        if isinstance(data, dict):
+            return data
+        return {
+            "race_key": None,
+            "race_start": None,
+            "circuit": {},
+            "current": {},
+            "daily": [],
+            "hourly": [],
+            "twice_daily": [],
+            "race": {},
+        }
+
+    def _apply_coordinator_data(self) -> None:
+        """Copy current native observations into WeatherEntity properties."""
+        data = self._coordinator_data
+        current = data.get("current", {})
+        self._attr_condition = current.get("condition")
+        self._attr_native_temperature = current.get("temperature")
+        self._attr_humidity = current.get("humidity")
+        self._attr_cloud_coverage = current.get("cloud_coverage")
+        self._attr_native_wind_speed = current.get("wind_speed")
+        self._attr_native_wind_gust_speed = current.get("wind_gust_speed")
+        self._attr_wind_bearing = current.get("wind_bearing")
+        visibility_m = current.get("visibility")
+        self._attr_native_visibility = (
+            float(visibility_m) / 1000 if visibility_m is not None else None
+        )
+
+        race_forecast = data.get("race", {})
+        circuit = data.get("circuit", {})
+        self._attr_extra_state_attributes = {
+            "race_start": data.get("race_start"),
+            "race_forecast_available": bool(race_forecast),
+            "season": circuit.get("season"),
+            "round": circuit.get("round"),
+            "race_name": circuit.get("race_name"),
+            "circuit_id": circuit.get("circuit_id"),
+            "circuit_name": circuit.get("circuit_name"),
+            "circuit_locality": circuit.get("circuit_locality"),
+            "circuit_country": circuit.get("circuit_country"),
+        }
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Write current conditions and push updated forecast subscriptions."""
+        self._apply_coordinator_data()
+        super()._handle_coordinator_update()
+        self.hass.async_create_task(
+            self.async_update_listeners(("daily", "hourly", "twice_daily"))
+        )
+
+    @staticmethod
+    def _native_forecast(
+        observation: WeatherObservation,
+        *,
+        include_temperature_low: bool = False,
+        include_is_daytime: bool = False,
+    ) -> Forecast | None:
+        """Convert one cached observation to Home Assistant forecast data."""
+        timestamp = observation.get("datetime")
+        if not timestamp or observation.get("temperature") is None:
+            return None
+        forecast: Forecast = {
+            "datetime": timestamp,
+            "condition": observation.get("condition"),
+            "native_temperature": observation.get("temperature"),
+            "humidity": observation.get("humidity"),
+            "cloud_coverage": observation.get("cloud_coverage"),
+            "native_precipitation": observation.get("precipitation"),
+            "precipitation_probability": observation.get("precipitation_probability"),
+            "native_wind_speed": observation.get("wind_speed"),
+            "native_wind_gust_speed": observation.get("wind_gust_speed"),
+            "wind_bearing": observation.get("wind_bearing"),
+        }
+        if include_temperature_low:
+            forecast["native_templow"] = observation.get("temperature_low")
+        if include_is_daytime:
+            is_daytime = observation.get("is_daytime")
+            if not isinstance(is_daytime, bool):
+                return None
+            forecast["is_daytime"] = is_daytime
+        return forecast
+
+    async def async_forecast_daily(self) -> list[Forecast] | None:
+        """Return the cached daily forecast in native units."""
+        return [
+            forecast
+            for observation in self._coordinator_data.get("daily", [])
+            if (
+                forecast := self._native_forecast(
+                    observation, include_temperature_low=True
+                )
+            )
+        ]
+
+    async def async_forecast_hourly(self) -> list[Forecast] | None:
+        """Return the cached hourly forecast in native units."""
+        return [
+            forecast
+            for observation in self._coordinator_data.get("hourly", [])
+            if (forecast := self._native_forecast(observation))
+        ]
+
+    async def async_forecast_twice_daily(self) -> list[Forecast] | None:
+        """Return the cached local day and night forecast in native units."""
+        return [
+            forecast
+            for observation in self._coordinator_data.get("twice_daily", [])
+            if (
+                forecast := self._native_forecast(
+                    observation,
+                    include_temperature_low=True,
+                    include_is_daytime=True,
+                )
+            )
+        ]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose stable race context alongside native weather attributes."""
+        return self._attr_extra_state_attributes

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -17935,6 +17935,235 @@ class F1ReplayControlCardEditor extends LitElement {
 }
 
 // ============================================================================
+// Shared F1 weather model
+// ============================================================================
+
+const F1_WEATHER_ACTIVE_SESSION_STATES = new Set(['pre', 'live', 'suspended', 'break']);
+
+const F1_WMO_CONDITIONS = new Map([
+  [0, 'Clear sky'],
+  [1, 'Mainly clear'],
+  [2, 'Partly cloudy'],
+  [3, 'Overcast'],
+  [45, 'Fog'],
+  [48, 'Rime fog'],
+  [51, 'Light drizzle'],
+  [53, 'Drizzle'],
+  [55, 'Heavy drizzle'],
+  [56, 'Light freezing drizzle'],
+  [57, 'Freezing drizzle'],
+  [61, 'Light rain'],
+  [63, 'Rain'],
+  [65, 'Heavy rain'],
+  [66, 'Light freezing rain'],
+  [67, 'Freezing rain'],
+  [71, 'Light snow'],
+  [73, 'Snow'],
+  [75, 'Heavy snow'],
+  [77, 'Snow grains'],
+  [80, 'Light rain showers'],
+  [81, 'Rain showers'],
+  [82, 'Heavy rain showers'],
+  [85, 'Light snow showers'],
+  [86, 'Snow showers'],
+  [95, 'Thunderstorm'],
+  [96, 'Thunderstorm with hail'],
+  [99, 'Severe thunderstorm with hail'],
+]);
+
+function toF1FiniteNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function getF1WeatherCondition(code, rainfall = null, isLive = false) {
+  const rain = toF1FiniteNumber(rainfall);
+  if (isLive && rain !== null) {
+    return rain > 0 ? 'Rain detected' : 'Dry track';
+  }
+  const numericCode = toF1FiniteNumber(code);
+  return numericCode === null
+    ? 'Conditions unavailable'
+    : F1_WMO_CONDITIONS.get(numericCode) || 'Conditions unavailable';
+}
+
+function hasF1TrackWeather(trackWeatherState) {
+  const attrs = trackWeatherState?.attributes || {};
+  return [
+    trackWeatherState?.state,
+    attrs.air_temperature,
+    attrs.track_temperature,
+    attrs.wind_speed,
+    attrs.rainfall,
+  ].some((value) => toF1FiniteNumber(value) !== null);
+}
+
+function hasF1ForecastWeather(weatherState) {
+  const attrs = weatherState?.attributes || {};
+  return [
+    weatherState?.state,
+    attrs.current_temperature,
+    attrs.race_temperature,
+    attrs.current_precipitation_probability,
+    attrs.race_precipitation_probability,
+  ].some((value) => toF1FiniteNumber(value) !== null);
+}
+
+function f1WeatherBlockHasData(block) {
+  if (!block) return false;
+  return [
+    block.temperature,
+    block.trackTemperature,
+    block.windSpeed,
+    block.windGusts,
+    block.rainfall,
+    block.precipitationProbability,
+    block.cloudCover,
+    block.humidity,
+    block.pressure,
+  ].some((value) => toF1FiniteNumber(value) !== null);
+}
+
+function resolveF1WeatherComparison(
+  hass,
+  config,
+  weatherState,
+  trackWeatherState,
+  sessionStatus,
+) {
+  const weatherAttrs = weatherState?.attributes || {};
+  const trackAttrs = trackWeatherState?.attributes || {};
+  const weatherTemperatureUnit = getF1TemperatureUnit(hass, weatherState);
+  const trackTemperatureUnit = getF1TemperatureUnit(hass, trackWeatherState);
+  const windSpeedUnit = getF1UnitSystemUnit(hass, 'wind_speed', 'm/s');
+  const weatherStateTemperature = toF1FiniteNumber(weatherState?.state);
+  const trackStateTemperature = toF1FiniteNumber(trackWeatherState?.state);
+  const status = String(sessionStatus?.state || '').toLowerCase();
+  const hasLiveTrackFeed = hasF1TrackWeather(trackWeatherState);
+  const useLiveNow = config?.prefer_live_weather !== false
+    && F1_WEATHER_ACTIVE_SESSION_STATES.has(status)
+    && hasLiveTrackFeed;
+  const fallbackToLiveNow = config?.prefer_live_weather !== false
+    && !sessionStatus
+    && hasLiveTrackFeed;
+  const preferLiveNow = useLiveNow || fallbackToLiveNow;
+
+  const liveRainfall = toF1FiniteNumber(trackAttrs.rainfall);
+  const now = preferLiveNow
+    ? {
+        icon: liveRainfall !== null && liveRainfall > 0
+          ? 'mdi:weather-rainy'
+          : weatherAttrs.icon || 'mdi:weather-partly-cloudy',
+        title: 'Now at circuit',
+        status: 'Live track feed',
+        source: 'LIVE',
+        isLive: true,
+        weatherCode: toF1FiniteNumber(weatherAttrs.current_weather_code),
+        condition: getF1WeatherCondition(null, liveRainfall, true),
+        temperature: trackStateTemperature ?? toF1FiniteNumber(convertF1Temperature(
+          trackAttrs.air_temperature,
+          '°C',
+          trackTemperatureUnit,
+        )),
+        trackTemperature: toF1FiniteNumber(convertF1Temperature(
+          trackAttrs.track_temperature,
+          '°C',
+          trackTemperatureUnit,
+        )),
+        temperatureUnit: trackTemperatureUnit,
+        windSpeed: toF1FiniteNumber(convertF1Speed(trackAttrs.wind_speed, 'm/s', windSpeedUnit)),
+        windGusts: null,
+        windSpeedUnit,
+        windDirection: toF1FiniteNumber(trackAttrs.wind_from_direction_degrees),
+        rainfall: liveRainfall,
+        precipitationProbability: null,
+        cloudCover: null,
+        humidity: toF1FiniteNumber(trackAttrs.humidity),
+        pressure: toF1FiniteNumber(trackAttrs.pressure),
+      }
+    : {
+        icon: weatherAttrs.icon || 'mdi:weather-partly-cloudy',
+        title: 'Now at circuit',
+        status: 'Current forecast',
+        source: 'FORECAST',
+        isLive: false,
+        weatherCode: toF1FiniteNumber(weatherAttrs.current_weather_code),
+        condition: getF1WeatherCondition(weatherAttrs.current_weather_code),
+        temperature: weatherStateTemperature ?? toF1FiniteNumber(convertF1Temperature(
+          weatherAttrs.current_temperature,
+          '°C',
+          weatherTemperatureUnit,
+        )),
+        trackTemperature: null,
+        temperatureUnit: weatherTemperatureUnit,
+        windSpeed: toF1FiniteNumber(convertF1Speed(
+          weatherAttrs.current_wind_speed,
+          'm/s',
+          windSpeedUnit,
+        )),
+        windGusts: toF1FiniteNumber(convertF1Speed(
+          weatherAttrs.current_wind_gusts,
+          'm/s',
+          windSpeedUnit,
+        )),
+        windSpeedUnit,
+        windDirection: toF1FiniteNumber(weatherAttrs.current_wind_from_direction_degrees),
+        rainfall: toF1FiniteNumber(weatherAttrs.current_precipitation),
+        precipitationProbability: toF1FiniteNumber(
+          weatherAttrs.current_precipitation_probability,
+        ),
+        cloudCover: toF1FiniteNumber(weatherAttrs.current_cloud_cover),
+        humidity: toF1FiniteNumber(weatherAttrs.current_humidity),
+        pressure: null,
+      };
+
+  const race = {
+    icon: weatherAttrs.race_weather_icon || weatherAttrs.icon || 'mdi:weather-partly-cloudy',
+    title: 'Race start',
+    status: 'Race start forecast',
+    source: 'FORECAST',
+    isLive: false,
+    weatherCode: toF1FiniteNumber(weatherAttrs.race_weather_code),
+    condition: getF1WeatherCondition(weatherAttrs.race_weather_code),
+    temperature: toF1FiniteNumber(convertF1Temperature(
+      weatherAttrs.race_temperature,
+      '°C',
+      weatherTemperatureUnit,
+    )),
+    trackTemperature: null,
+    temperatureUnit: weatherTemperatureUnit,
+    windSpeed: toF1FiniteNumber(convertF1Speed(
+      weatherAttrs.race_wind_speed,
+      'm/s',
+      windSpeedUnit,
+    )),
+    windGusts: toF1FiniteNumber(convertF1Speed(
+      weatherAttrs.race_wind_gusts,
+      'm/s',
+      windSpeedUnit,
+    )),
+    windSpeedUnit,
+    windDirection: toF1FiniteNumber(weatherAttrs.race_wind_from_direction_degrees),
+    rainfall: toF1FiniteNumber(weatherAttrs.race_precipitation),
+    precipitationProbability: toF1FiniteNumber(
+      weatherAttrs.race_precipitation_probability,
+    ),
+    cloudCover: toF1FiniteNumber(weatherAttrs.race_cloud_cover),
+    humidity: toF1FiniteNumber(weatherAttrs.race_humidity),
+    pressure: null,
+  };
+
+  return {
+    show: f1WeatherBlockHasData(now) || f1WeatherBlockHasData(race),
+    now: f1WeatherBlockHasData(now) ? now : null,
+    race: f1WeatherBlockHasData(race) ? race : null,
+    hasForecast: hasF1ForecastWeather(weatherState),
+    usingLiveNow: preferLiveNow,
+  };
+}
+
+// ============================================================================
 // F1 Next Race Overview Card
 // ============================================================================
 
@@ -19549,130 +19778,25 @@ class F1NextRaceCard extends LitElement {
   }
 
   _hasTrackWeather(trackWeatherState) {
-    const attrs = trackWeatherState?.attributes || {};
-    return attrs.air_temperature !== undefined
-      || attrs.track_temperature !== undefined
-      || attrs.wind_speed !== undefined;
+    return hasF1TrackWeather(trackWeatherState);
   }
 
   _hasForecastWeather(weatherState) {
-    const attrs = weatherState?.attributes || {};
-    return attrs.current_temperature !== undefined
-      || attrs.race_temperature !== undefined;
+    return hasF1ForecastWeather(weatherState);
   }
 
   _weatherBlockHasData(block) {
-    if (!block) return false;
-    return [
-      block.temperature,
-      block.trackTemperature,
-      block.windSpeed,
-      block.rainfall,
-      block.precipitationProbability,
-      block.cloudCover,
-      block.humidity,
-      block.pressure,
-    ].some((value) => value !== null && value !== undefined && value !== '');
+    return f1WeatherBlockHasData(block);
   }
 
   _resolveWeatherComparison(weatherState, trackWeatherState, sessionStatus) {
-    const weatherAttrs = weatherState?.attributes || {};
-    const trackAttrs = trackWeatherState?.attributes || {};
-    const weatherTemperatureUnit = getF1TemperatureUnit(this.hass, weatherState);
-    const trackTemperatureUnit = getF1TemperatureUnit(this.hass, trackWeatherState);
-    const windSpeedUnit = getF1UnitSystemUnit(this.hass, 'wind_speed', 'm/s');
-    const weatherStateTemperature = Number(weatherState?.state);
-    const trackStateTemperature = Number(trackWeatherState?.state);
-    const status = String(sessionStatus?.state || '').toLowerCase();
-    const weekendActive = ['pre', 'live', 'suspended', 'break'].includes(status);
-    const useLiveNow = this.config.prefer_live_weather !== false
-      && weekendActive
-      && this._hasTrackWeather(trackWeatherState);
-    const fallbackToLiveNow = this.config.prefer_live_weather !== false
-      && !sessionStatus
-      && this._hasTrackWeather(trackWeatherState);
-    const preferLiveNow = useLiveNow || fallbackToLiveNow;
-
-    const now = preferLiveNow
-      ? {
-          icon: weatherAttrs.icon || 'mdi:weather-partly-cloudy',
-          title: 'Now at circuit',
-          status: 'Live track feed',
-          temperature: Number.isFinite(trackStateTemperature)
-            ? trackStateTemperature
-            : convertF1Temperature(
-              trackAttrs.air_temperature,
-              '°C',
-              trackTemperatureUnit,
-            ),
-          trackTemperature: convertF1Temperature(
-            trackAttrs.track_temperature,
-            '°C',
-            trackTemperatureUnit,
-          ),
-          temperatureUnit: trackTemperatureUnit,
-          windSpeed: convertF1Speed(trackAttrs.wind_speed, 'm/s', windSpeedUnit),
-          windSpeedUnit,
-          windDirection: trackAttrs.wind_from_direction_degrees,
-          rainfall: trackAttrs.rainfall,
-          precipitationProbability: null,
-          cloudCover: null,
-          humidity: trackAttrs.humidity,
-          pressure: trackAttrs.pressure,
-        }
-      : {
-          icon: weatherAttrs.icon || 'mdi:weather-partly-cloudy',
-          title: 'Now at circuit',
-          status: 'Current forecast',
-          temperature: Number.isFinite(weatherStateTemperature)
-            ? weatherStateTemperature
-            : convertF1Temperature(
-              weatherAttrs.current_temperature,
-              '°C',
-              weatherTemperatureUnit,
-            ),
-          trackTemperature: null,
-          temperatureUnit: weatherTemperatureUnit,
-          windSpeed: convertF1Speed(
-            weatherAttrs.current_wind_speed,
-            'm/s',
-            windSpeedUnit,
-          ),
-          windSpeedUnit,
-          windDirection: weatherAttrs.current_wind_from_direction_degrees,
-          rainfall: weatherAttrs.current_precipitation,
-          precipitationProbability: weatherAttrs.current_precipitation_probability,
-          cloudCover: weatherAttrs.current_cloud_cover,
-          humidity: weatherAttrs.current_humidity,
-          pressure: null,
-        };
-
-    const race = {
-      icon: weatherAttrs.race_weather_icon || weatherAttrs.icon || 'mdi:weather-partly-cloudy',
-      title: 'Race start',
-      status: 'Race start forecast',
-      temperature: convertF1Temperature(
-        weatherAttrs.race_temperature,
-        '°C',
-        weatherTemperatureUnit,
-      ),
-      trackTemperature: null,
-      temperatureUnit: weatherTemperatureUnit,
-      windSpeed: convertF1Speed(weatherAttrs.race_wind_speed, 'm/s', windSpeedUnit),
-      windSpeedUnit,
-      windDirection: weatherAttrs.race_wind_from_direction_degrees,
-      rainfall: weatherAttrs.race_precipitation,
-      precipitationProbability: weatherAttrs.race_precipitation_probability,
-      cloudCover: weatherAttrs.race_cloud_cover,
-      humidity: weatherAttrs.race_humidity,
-      pressure: null,
-    };
-
-    return {
-      show: this._weatherBlockHasData(now) || this._weatherBlockHasData(race),
-      now: this._weatherBlockHasData(now) ? now : null,
-      race: this._weatherBlockHasData(race) ? race : null,
-    };
+    return resolveF1WeatherComparison(
+      this.hass,
+      this.config,
+      weatherState,
+      trackWeatherState,
+      sessionStatus,
+    );
   }
 
   _windDirectionToCardinal(degrees) {
@@ -20848,6 +20972,914 @@ class F1NextRaceCardEditor extends LitElement {
         @value-changed=${this._formValueChanged}
       ></ha-form>
       ${helper ? html`<div class="helper">${helper}</div>` : ''}
+    `;
+  }
+
+  _formValueChanged(ev) {
+    if (!this._config) return;
+    const value = ev.detail?.value || {};
+    const newConfig = { ...this._config, ...value };
+    this._config = newConfig;
+    this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: newConfig } }));
+  }
+}
+
+// ============================================================================
+// F1 Race Weather Card
+// ============================================================================
+
+class F1WeatherCard extends LitElement {
+  static properties = {
+    hass: {},
+    config: {},
+  };
+
+  static styles = [F1_THEME_STYLES, css`
+    @keyframes fwLivePulse {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50% { opacity: 0.62; transform: scale(0.82); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    :host {
+      --fw-bg: var(--f1-card-bg);
+      --fw-bg-soft: var(--f1-card-bg-soft);
+      --fw-bg-end: var(--f1-card-bg-end);
+      --fw-border: var(--f1-card-border);
+      --fw-panel: var(--f1-card-panel);
+      --fw-panel-soft: var(--f1-card-panel-soft);
+      --fw-text: var(--f1-card-text);
+      --fw-muted: var(--f1-card-muted);
+      --fw-soft: var(--f1-card-soft);
+      --fw-accent: #e10600;
+      --fw-rain: #49a7ff;
+      --fw-shadow: var(--f1-card-shadow);
+      --fw-card-title-size: clamp(14px, 2.2cqw, 18px);
+      --fw-panel-title-size: clamp(11px, 3.5cqw, 13px);
+      --fw-icon-box-size: clamp(40px, 12cqw, 46px);
+      --fw-icon-size: clamp(24px, 7cqw, 28px);
+      --fw-temperature-size: clamp(25px, 9cqw, 34px);
+      --fw-condition-size: clamp(9px, 2.5cqw, 10px);
+      display: block;
+      font-family: var(--f1-card-body-font-family, 'Formula1 Display', 'Titillium Web', Arial, sans-serif);
+    }
+
+    ha-card {
+      padding: 0;
+      background: transparent;
+      box-shadow: none;
+      border: none;
+    }
+
+    .fw-card {
+      position: relative;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      gap: clamp(8px, 1.2cqw, 10px);
+      padding: clamp(8px, 1.5cqw, 12px) clamp(10px, 1.8cqw, 14px);
+      border: 1px solid var(--fw-border);
+      border-radius: var(--ha-card-border-radius, 12px);
+      background:
+        radial-gradient(circle at 15% 10%, var(--f1-card-chip), transparent 45%),
+        linear-gradient(160deg, var(--fw-bg) 0%, var(--fw-bg-soft) 60%, var(--fw-bg-end) 100%);
+      box-shadow: var(--fw-shadow);
+      color: var(--fw-text);
+      container-type: inline-size;
+    }
+
+    .fw-header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 10px 16px;
+      align-items: end;
+      padding: 2px 2px 10px;
+      border-bottom: 1px solid var(--f1-card-divider);
+    }
+
+    .fw-identity,
+    .fw-start {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+    }
+
+    .fw-start {
+      align-items: flex-end;
+      text-align: right;
+    }
+
+    .fw-kicker,
+    .fw-panel-kicker,
+    .fw-metric-label,
+    .fw-rain-label,
+    .fw-start-label {
+      color: var(--fw-muted);
+      font-size: 8px;
+      font-weight: 700;
+      line-height: 1.2;
+      letter-spacing: var(--f1-card-label-letter-spacing, 0.08em);
+      text-transform: uppercase;
+    }
+
+    .fw-kicker {
+      color: var(--fw-accent);
+    }
+
+    .fw-title {
+      margin: 0;
+      font-family: var(--f1-card-heading-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
+      font-size: var(--fw-card-title-size);
+      line-height: 1.08;
+      letter-spacing: var(--f1-card-heading-letter-spacing, 0.02em);
+      text-wrap: balance;
+    }
+
+    .fw-location,
+    .fw-start-value {
+      color: var(--fw-muted);
+      font-size: clamp(9px, 1.3cqw, 10px);
+      line-height: 1.3;
+    }
+
+    .fw-start-value {
+      color: var(--fw-text);
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .fw-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: clamp(8px, 1.5cqw, 12px);
+    }
+
+    .fw-panel {
+      position: relative;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      min-width: 0;
+      padding: clamp(10px, 1.5cqw, 12px);
+      border: 1px solid var(--f1-card-divider);
+      border-radius: 12px;
+      background:
+        linear-gradient(145deg, var(--fw-panel) 0%, var(--fw-panel-soft) 100%);
+      container-type: inline-size;
+    }
+
+    .fw-panel.race::before {
+      position: absolute;
+      inset: 0 auto 0 0;
+      width: 3px;
+      background: var(--fw-accent);
+      content: '';
+    }
+
+    .fw-panel-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+      align-items: flex-start;
+    }
+
+    .fw-panel-title-wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      min-width: 0;
+    }
+
+    .fw-panel-title {
+      margin: 0;
+      font-family: var(--f1-card-heading-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
+      font-size: var(--fw-panel-title-size);
+      line-height: 1.1;
+      letter-spacing: var(--f1-card-heading-letter-spacing, 0.02em);
+    }
+
+    .fw-source {
+      display: inline-flex;
+      gap: 5px;
+      align-items: center;
+      flex: 0 0 auto;
+      padding: 3px 6px;
+      border: 1px solid var(--f1-card-divider);
+      border-radius: 999px;
+      background: var(--f1-card-chip);
+      color: var(--fw-muted);
+      font-size: 8px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+    }
+
+    .fw-source.live {
+      border-color: color-mix(in srgb, var(--fw-accent) 45%, transparent);
+      color: var(--fw-text);
+    }
+
+    .fw-live-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--fw-accent);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--fw-accent) 18%, transparent);
+      animation: fwLivePulse 1.6s ease-in-out infinite;
+    }
+
+    .fw-hero {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      gap: 10px;
+      align-items: center;
+    }
+
+    .fw-weather-icon {
+      display: grid;
+      width: var(--fw-icon-box-size);
+      height: var(--fw-icon-box-size);
+      place-items: center;
+      border: 1px solid var(--f1-card-divider);
+      border-radius: 11px;
+      background: var(--f1-card-chip);
+      color: var(--fw-text);
+    }
+
+    .fw-weather-icon ha-icon {
+      --mdc-icon-size: var(--fw-icon-size);
+    }
+
+    .fw-temperature-wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      min-width: 0;
+    }
+
+    .fw-temperature {
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
+      font-size: var(--fw-temperature-size);
+      line-height: 1;
+      letter-spacing: var(--f1-card-display-letter-spacing, -0.02em);
+      white-space: nowrap;
+    }
+
+    .fw-temperature-unit {
+      padding-left: 2px;
+      color: var(--fw-muted);
+      font-size: 0.38em;
+      letter-spacing: 0;
+      vertical-align: top;
+    }
+
+    .fw-condition {
+      overflow: hidden;
+      color: var(--fw-muted);
+      font-size: var(--fw-condition-size);
+      line-height: 1.3;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .fw-rain {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+      padding: 8px;
+      border: 1px solid var(--f1-card-divider);
+      border-radius: 10px;
+      background: var(--f1-card-chip);
+    }
+
+    .fw-rain-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .fw-rain-value {
+      font-family: var(--f1-card-display-font-family, 'Formula1 Wide', 'Formula1 Display', 'Noto Sans', sans-serif);
+      font-size: 10px;
+      line-height: 1;
+    }
+
+    .fw-rain-track {
+      overflow: hidden;
+      height: 4px;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--fw-muted) 18%, transparent);
+    }
+
+    .fw-rain-fill {
+      width: var(--fw-rain-level, 0%);
+      height: 100%;
+      border-radius: inherit;
+      background: linear-gradient(90deg, #167bc2, var(--fw-rain));
+      transition: width 300ms ease;
+    }
+
+    .fw-rain-caption {
+      color: var(--fw-muted);
+      font-size: 8px;
+      line-height: 1.25;
+    }
+
+    .fw-metrics {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1px;
+      overflow: hidden;
+      margin-top: auto;
+      border: 1px solid var(--f1-card-divider);
+      border-radius: 10px;
+      background: var(--f1-card-divider);
+    }
+
+    .fw-metric {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      gap: 6px;
+      align-items: center;
+      min-width: 0;
+      padding: 7px 8px;
+      background: var(--fw-panel);
+    }
+
+    .fw-metric ha-icon {
+      --mdc-icon-size: 15px;
+      color: var(--fw-muted);
+    }
+
+    .fw-metric-copy {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      min-width: 0;
+    }
+
+    .fw-metric-value {
+      overflow: hidden;
+      color: var(--fw-text);
+      font-size: 9px;
+      font-weight: 600;
+      line-height: 1.2;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .fw-empty-panel,
+    .fw-unavailable {
+      display: grid;
+      min-height: 180px;
+      place-items: center;
+      color: var(--fw-muted);
+      font-size: 11px;
+      text-align: center;
+    }
+
+    .fw-unavailable {
+      min-height: 108px;
+    }
+
+    .fw-card[data-layout='narrow'] {
+      padding: 8px 9px;
+    }
+
+    .fw-card[data-layout='narrow'] .fw-header,
+    .fw-card[data-layout='narrow'] .fw-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .fw-card[data-layout='narrow'] .fw-start {
+      align-items: flex-start;
+      text-align: left;
+    }
+
+    .fw-card[data-layout='narrow'] .fw-start-value {
+      white-space: normal;
+    }
+
+    .fw-card[data-layout='narrow'] .fw-empty-panel {
+      min-height: 120px;
+    }
+
+    @container (max-width: 560px) {
+      .fw-header,
+      .fw-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .fw-start {
+        align-items: flex-start;
+        text-align: left;
+      }
+    }
+  `];
+
+  connectedCallback() {
+    super.connectedCallback();
+    ensureF1Fonts();
+  }
+
+  setConfig(config) {
+    this.config = {
+      theme_mode: DEFAULT_F1_THEME_MODE,
+      weather_entity: 'sensor.f1_weather',
+      track_weather_entity: 'sensor.f1_track_weather',
+      next_race_entity: 'sensor.f1_next_race',
+      session_status_entity: 'sensor.f1_session_status',
+      prefer_live_weather: true,
+      show_header: true,
+      ...config,
+    };
+    applyF1ThemeMode(this, this.config);
+  }
+
+  static getConfigElement() {
+    return document.createElement('f1-weather-card-editor');
+  }
+
+  static getStubConfig() {
+    return {
+      type: 'custom:f1-weather-card',
+      weather_entity: 'sensor.f1_weather',
+      track_weather_entity: 'sensor.f1_track_weather',
+      next_race_entity: 'sensor.f1_next_race',
+      session_status_entity: 'sensor.f1_session_status',
+      prefer_live_weather: true,
+      show_header: true,
+    };
+  }
+
+  getCardSize() {
+    return 3;
+  }
+
+  getGridOptions() {
+    return {
+      columns: 12,
+      min_columns: 6,
+      max_columns: 12,
+      min_rows: 3,
+    };
+  }
+
+  _responsiveLayoutBreakpoints() {
+    return {
+      narrow: 560,
+      medium: 920,
+    };
+  }
+
+  _configuredEntityId(key, legacyDefault = null) {
+    if (!this.config || typeof this.config !== 'object') return legacyDefault;
+    const hasKey = Object.prototype.hasOwnProperty.call(this.config, key);
+    const value = this.config[key];
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) return trimmed;
+      return hasKey ? null : legacyDefault;
+    }
+    if (value != null) return value;
+    return hasKey ? null : legacyDefault;
+  }
+
+  _getEntityState(key, legacyDefault) {
+    const entityId = this._configuredEntityId(key, legacyDefault);
+    if (!entityId) return null;
+    const entity = getEntityStateWithFallback(this.hass, entityId);
+    return entity && !isUnavailableLikeEntityState(entity) ? entity : null;
+  }
+
+  _getWeatherState() {
+    return this._getEntityState('weather_entity', 'sensor.f1_weather');
+  }
+
+  _getTrackWeatherState() {
+    return this._getEntityState('track_weather_entity', 'sensor.f1_track_weather');
+  }
+
+  _getSessionStatusState() {
+    return this._getEntityState('session_status_entity', 'sensor.f1_session_status');
+  }
+
+  _getNextRaceData() {
+    const entity = this._getEntityState('next_race_entity', 'sensor.f1_next_race');
+    return entity ? { state: entity.state, ...entity.attributes } : null;
+  }
+
+  _windDirectionToCardinal(degrees) {
+    const number = toF1FiniteNumber(degrees);
+    if (number === null) return '';
+    const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+    return directions[Math.round(number / 45) % 8];
+  }
+
+  _formatTemperatureValue(value) {
+    const number = toF1FiniteNumber(value);
+    return number === null ? null : number.toFixed(1);
+  }
+
+  _formatNumber(value, suffix = '', digits = 0) {
+    const number = toF1FiniteNumber(value);
+    return number === null ? null : `${number.toFixed(digits)}${suffix}`;
+  }
+
+  _formatWind(block) {
+    const speed = toF1FiniteNumber(block?.windSpeed);
+    if (speed === null) return null;
+    const direction = this._windDirectionToCardinal(block?.windDirection);
+    return `${speed.toFixed(1)} ${block?.windSpeedUnit || 'm/s'}${direction ? ` ${direction}` : ''}`;
+  }
+
+  _formatRaceStart(nextRace) {
+    const raw = nextRace?.race_start_utc || nextRace?.race_start || nextRace?.state;
+    if (!raw) return null;
+    const date = new Date(raw);
+    if (Number.isNaN(date.getTime())) return null;
+    return formatHassDateTime(
+      this.hass,
+      date,
+      {
+        weekday: 'short',
+        day: 'numeric',
+        month: 'short',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone: this.hass?.config?.time_zone || undefined,
+      },
+      null,
+    );
+  }
+
+  _getRaceIdentity(nextRace, weatherState) {
+    const attrs = weatherState?.attributes || {};
+    const raceName = nextRace?.race_name || attrs.race_name || nextRace?.state || 'Race weather';
+    const circuit = nextRace?.circuit_name || attrs.circuit_name || attrs.circuit || null;
+    const locality = nextRace?.circuit_locality || attrs.circuit_locality || null;
+    const country = nextRace?.circuit_country || attrs.circuit_country || attrs.country || null;
+    const location = [circuit, [locality, country].filter(Boolean).join(', ')]
+      .filter(Boolean)
+      .join(' · ');
+    return { raceName, location };
+  }
+
+  _renderMetric(icon, label, value) {
+    if (!value) return null;
+    return html`
+      <div class="fw-metric">
+        <ha-icon .icon=${icon} aria-hidden="true"></ha-icon>
+        <div class="fw-metric-copy">
+          <span class="fw-metric-label">${label}</span>
+          <span class="fw-metric-value">${value}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderRain(block) {
+    const probability = toF1FiniteNumber(block?.precipitationProbability);
+    const rainfall = toF1FiniteNumber(block?.rainfall);
+    const level = Math.max(0, Math.min(100, probability ?? (rainfall !== null && rainfall > 0 ? 100 : 0)));
+    const label = block?.isLive ? 'Track surface' : 'Rain risk';
+    const value = block?.isLive
+      ? (rainfall !== null && rainfall > 0 ? 'RAIN DETECTED' : 'DRY')
+      : (probability !== null ? `${probability.toFixed(0)}%` : 'NO ESTIMATE');
+    const caption = rainfall !== null
+      ? `${block?.isLive ? 'Measured' : 'Expected'} precipitation ${rainfall.toFixed(1)} mm`
+      : (block?.isLive ? 'Based on live track telemetry' : 'Forecast precipitation unavailable');
+
+    return html`
+      <div class="fw-rain" style=${`--fw-rain-level: ${level}%`}>
+        <div class="fw-rain-head">
+          <span class="fw-rain-label">${label}</span>
+          <span class="fw-rain-value">${value}</span>
+        </div>
+        <div class="fw-rain-track" role="meter" aria-label=${label} aria-valuemin="0" aria-valuemax="100" aria-valuenow=${String(level)}>
+          <div class="fw-rain-fill"></div>
+        </div>
+        <span class="fw-rain-caption">${caption}</span>
+      </div>
+    `;
+  }
+
+  _renderPanel(block, variant) {
+    const isRace = variant === 'race';
+    if (!block) {
+      return html`
+        <section class="fw-panel ${variant} fw-empty-panel">
+          ${isRace ? 'Race-start forecast is not available' : 'Current circuit weather is not available'}
+        </section>
+      `;
+    }
+
+    const metrics = [
+      block.trackTemperature !== null
+        ? this._renderMetric(
+            'mdi:road-variant',
+            'Track',
+            `${this._formatTemperatureValue(block.trackTemperature)} ${block.temperatureUnit || '°C'}`,
+          )
+        : null,
+      this._renderMetric('mdi:water-percent', 'Humidity', this._formatNumber(block.humidity, '%')),
+      this._renderMetric('mdi:weather-windy', 'Wind', this._formatWind(block)),
+      this._renderMetric('mdi:weather-windy-variant', 'Gusts', this._formatNumber(
+        block.windGusts,
+        ` ${block.windSpeedUnit || 'm/s'}`,
+        1,
+      )),
+      this._renderMetric('mdi:weather-cloudy', 'Cloud cover', this._formatNumber(block.cloudCover, '%')),
+      this._renderMetric('mdi:gauge', 'Pressure', this._formatNumber(block.pressure, ' hPa', 1)),
+    ].filter(Boolean);
+    const temperature = this._formatTemperatureValue(block.temperature);
+
+    return html`
+      <section class="fw-panel ${variant}">
+        <div class="fw-panel-head">
+          <div class="fw-panel-title-wrap">
+            <span class="fw-panel-kicker">${isRace ? 'Forecast' : 'Circuit conditions'}</span>
+            <h3 class="fw-panel-title">${block.title}</h3>
+          </div>
+          <span class="fw-source ${block.isLive ? 'live' : ''}">
+            ${block.isLive ? html`<span class="fw-live-dot" aria-hidden="true"></span>` : null}
+            ${block.source}
+          </span>
+        </div>
+
+        <div class="fw-hero">
+          <div class="fw-weather-icon">
+            <ha-icon .icon=${block.icon} aria-hidden="true"></ha-icon>
+          </div>
+          <div class="fw-temperature-wrap">
+            <div class="fw-temperature">
+              ${temperature ?? '—'}<span class="fw-temperature-unit">${temperature ? block.temperatureUnit || '°C' : ''}</span>
+            </div>
+            <span class="fw-condition">${block.condition}</span>
+          </div>
+        </div>
+
+        ${this._renderRain(block)}
+        ${metrics.length ? html`<div class="fw-metrics">${metrics}</div>` : null}
+      </section>
+    `;
+  }
+
+  render() {
+    if (!this.hass || !this.config) {
+      return html`<ha-card><div class="fw-card fw-unavailable">Loading weather…</div></ha-card>`;
+    }
+
+    const weatherState = this._getWeatherState();
+    const trackWeatherState = this._getTrackWeatherState();
+    const sessionStatus = this._getSessionStatusState();
+    const nextRace = this._getNextRaceData();
+    const weather = resolveF1WeatherComparison(
+      this.hass,
+      this.config,
+      weatherState,
+      trackWeatherState,
+      sessionStatus,
+    );
+    if (!weather.show) {
+      return html`
+        <ha-card>
+          <div class="fw-card fw-unavailable">No current or race-start weather data available</div>
+        </ha-card>
+      `;
+    }
+
+    const identity = this._getRaceIdentity(nextRace, weatherState);
+    const raceStart = this._formatRaceStart(nextRace);
+    const layoutMode = getResponsiveLayoutMode(this);
+    return html`
+      <ha-card>
+        <div class="fw-card" data-layout=${layoutMode}>
+          ${this.config.show_header !== false ? html`
+            <header class="fw-header">
+              <div class="fw-identity">
+                <span class="fw-kicker">Race weather</span>
+                <h2 class="fw-title">${identity.raceName}</h2>
+                ${identity.location ? html`<span class="fw-location">${identity.location}</span>` : null}
+              </div>
+              ${raceStart ? html`
+                <div class="fw-start">
+                  <span class="fw-start-label">Race start</span>
+                  <span class="fw-start-value">${raceStart}</span>
+                </div>
+              ` : null}
+            </header>
+          ` : null}
+          <div class="fw-grid">
+            ${this._renderPanel(weather.now, 'now')}
+            ${this._renderPanel(weather.race, 'race')}
+          </div>
+        </div>
+      </ha-card>
+    `;
+  }
+}
+
+class F1WeatherCardEditor extends LitElement {
+  static properties = {
+    hass: {},
+    _config: {},
+    _activeTab: { state: true },
+  };
+
+  static styles = css`
+    .card-config,
+    .section,
+    .display-section {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .tabs {
+      display: flex;
+      margin-bottom: 16px;
+      border-bottom: 1px solid var(--divider-color);
+    }
+
+    .tabs button {
+      flex: 1;
+      padding: 12px;
+      border: none;
+      background: none;
+      color: var(--primary-text-color);
+      cursor: pointer;
+      font: inherit;
+      font-size: 14px;
+    }
+
+    .tabs button.active {
+      margin-bottom: -1px;
+      border-bottom: 2px solid var(--primary-color);
+      color: var(--primary-color);
+    }
+
+    .section {
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+
+    .display-section {
+      gap: 12px;
+    }
+
+    .section-header {
+      margin-top: 8px;
+      color: var(--secondary-text-color);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .helper,
+    .warning {
+      padding-left: 16px;
+      color: var(--secondary-text-color);
+      font-size: 12px;
+      line-height: 1.4;
+    }
+
+    .warning {
+      color: var(--error-color);
+    }
+
+    ha-form {
+      width: 100%;
+    }
+  `;
+
+  constructor() {
+    super();
+    this._activeTab = 'sources';
+  }
+
+  setConfig(config) {
+    this._config = {
+      weather_entity: 'sensor.f1_weather',
+      track_weather_entity: 'sensor.f1_track_weather',
+      next_race_entity: 'sensor.f1_next_race',
+      session_status_entity: 'sensor.f1_session_status',
+      prefer_live_weather: true,
+      show_header: true,
+      ...config,
+    };
+  }
+
+  render() {
+    if (!this.hass || !this._config) return html``;
+    return html`
+      <div class="card-config">
+        <div class="tabs">
+          <button class=${this._activeTab === 'sources' ? 'active' : ''} @click=${() => this._activeTab = 'sources'}>
+            Data Sources
+          </button>
+          <button class=${this._activeTab === 'display' ? 'active' : ''} @click=${() => this._activeTab = 'display'}>
+            Display
+          </button>
+        </div>
+        ${this._activeTab === 'sources' ? this._renderSources() : this._renderDisplay()}
+      </div>
+    `;
+  }
+
+  _renderSources() {
+    return html`
+      <div class="section">
+        <div class="section-header">Required sensor</div>
+        ${this._renderEntityPicker(
+          'weather_entity',
+          'Race Weather Sensor',
+          'Provides the current forecast and the forecast for race start.',
+          true,
+        )}
+      </div>
+      <div class="section">
+        <div class="section-header">Optional sensors</div>
+        ${this._renderEntityPicker(
+          'track_weather_entity',
+          'Live Track Weather Sensor',
+          'Replaces current forecast values with live circuit measurements during an active weekend.',
+          false,
+        )}
+        ${this._renderEntityPicker(
+          'next_race_entity',
+          'Next Race Sensor',
+          'Adds the race name, circuit location, and localized race-start time.',
+          false,
+        )}
+        ${this._renderEntityPicker(
+          'session_status_entity',
+          'Session Status Sensor',
+          'Controls when live track measurements are preferred over the current forecast.',
+          false,
+        )}
+      </div>
+    `;
+  }
+
+  _renderDisplay() {
+    return html`
+      <div class="display-section">
+        ${renderThemeModeSelect(this)}
+        ${this._renderSwitch('show_header', 'Show race header')}
+        ${this._renderSwitch(
+          'prefer_live_weather',
+          'Prefer live track weather when weekend is active',
+          'Uses the live sensor for “Now at circuit” in pre, live, suspended, and break states.',
+        )}
+      </div>
+    `;
+  }
+
+  _renderEntityPicker(name, label, helper, required) {
+    const showWarning = required && !this._config[name];
+    const schema = [{ name, label, required, selector: { entity: { domain: 'sensor' } } }];
+    return html`
+      <div class="field">
+        <ha-form
+          .hass=${this.hass}
+          .data=${this._config}
+          .schema=${schema}
+          .computeLabel=${() => label}
+          @value-changed=${this._formValueChanged}
+        ></ha-form>
+        <div class="helper">${helper}</div>
+        ${showWarning ? html`<div class="warning">This sensor is required for the card to function</div>` : null}
+      </div>
+    `;
+  }
+
+  _renderSwitch(name, label, helper = null) {
+    const schema = [{ name, label, selector: { boolean: {} } }];
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${schema}
+        .computeLabel=${() => label}
+        @value-changed=${this._formValueChanged}
+      ></ha-form>
+      ${helper ? html`<div class="helper">${helper}</div>` : null}
     `;
   }
 
@@ -32121,6 +33153,13 @@ installSectionsAutoHeight(F1NextRaceCard, {
   min_rows: 5,
 });
 
+installSectionsAutoHeight(F1WeatherCard, {
+  columns: 12,
+  min_columns: 6,
+  max_columns: 12,
+  min_rows: 3,
+});
+
 installSectionsAutoHeight(F1SeasonCalendarCard, {
   columns: 12,
   min_columns: 4,
@@ -32205,6 +33244,7 @@ const F1_FONT_STYLE_CARD_CLASSES = [
   F1LiveSessionCard,
   F1ReplayControlCard,
   F1NextRaceCard,
+  F1WeatherCard,
   F1SeasonCalendarCard,
   F1RaceControlCard,
   F1FiaDocumentsCard,
@@ -32341,6 +33381,14 @@ if (!customElements.get('f1-next-race-card')) {
 
 if (!customElements.get('f1-next-race-card-editor')) {
   customElements.define('f1-next-race-card-editor', F1NextRaceCardEditor);
+}
+
+if (!customElements.get('f1-weather-card')) {
+  customElements.define('f1-weather-card', F1WeatherCard);
+}
+
+if (!customElements.get('f1-weather-card-editor')) {
+  customElements.define('f1-weather-card-editor', F1WeatherCardEditor);
 }
 
 if (!customElements.get('f1-season-calendar-card')) {
@@ -32508,6 +33556,14 @@ window.customCards.push({
   type: 'f1-next-race-card',
   name: 'F1 Next Race Overview',
   description: 'Next race overview with countdown, track map, weekend schedule, weather, and history',
+  configurable: true,
+  preview: true,
+});
+
+window.customCards.push({
+  type: 'f1-weather-card',
+  name: 'F1 Race Weather',
+  description: 'Current circuit conditions and the weather forecast for race start',
   configurable: true,
   preview: true,
 });


### PR DESCRIPTION
<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [X] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [X] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [X] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [X] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [X] Tested locally with a real Home Assistant instance
- [X] Existing automations and dashboards still work as expected after the change

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [X] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [X] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [X] Tests have been added or updated and pass locally — if applicable
- [X] Translations updated if new UI strings were added — if applicable
- [X] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
