### PR TITLE
fix: **Prevent incomplete F1 results and improve Jolpica API reliabil…

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -42,7 +42,11 @@ from .auth import (
     is_auth_transport_enabled,
     rejected_f1tv_auth_status,
 )
-from .auth_http import async_setup_f1tv_auth_http
+from .auth_http import (
+    AUTH_HTTP_VIEW_REGISTERED,
+    AUTH_PAIRING_SESSIONS,
+    async_setup_f1tv_auth_http,
+)
 from .calibration import LiveDelayCalibrationManager
 from .const import (
     API_URL,
@@ -107,7 +111,25 @@ from .incident_detection import (
     SessionMetadata,
     normalize_stream,
 )
-from .lap_position_websocket import async_register_lap_position_websocket
+from .jolpica import (
+    JOLPICA_CLIENT_KEY,
+    JolpicaClient,
+    JolpicaRouteNotFoundError,
+)
+from .jolpica_pagination import (
+    JolpicaPaginationError,
+    async_paginate_jolpica,
+    lap_leaf_keys,
+    merge_result_pages,
+    race_leaf_keys,
+    result_leaf_keys,
+    standings_leaf_keys,
+    validate_single_page_jolpica,
+)
+from .lap_position_websocket import (
+    LAP_POSITION_WS_MARKER,
+    async_register_lap_position_websocket,
+)
 from .live_delay import LiveDelayController, LiveDelayReferenceController
 from .live_window import (
     EventTrackerScheduleSource,
@@ -150,6 +172,7 @@ def _format_update_error(err: Exception) -> str:
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _JOLPICA_STATS_KEY = "__jolpica_stats__"
+_JOLPICA_CLIENT_INIT_TASK_KEY = "__jolpica_client_init_task__"
 _REPLAY_DELAY_REASONS = frozenset({"replay", "replay-mode", "replay-preparing"})
 _REPLAY_ONLY_ACTIVE_REASONS = frozenset({"replay", "replay-mode"})
 _ACTIVITY_LOG_EXCLUDED_SENSOR_SUFFIXES = (
@@ -197,8 +220,13 @@ _INCIDENT_BOOTSTRAP_SKIP_STREAMS = frozenset({"RaceControlMessages", "TrackStatu
 _DOMAIN_ROOT_INTERNAL_KEYS = frozenset(
     {
         _JOLPICA_STATS_KEY,
+        JOLPICA_CLIENT_KEY,
+        _JOLPICA_CLIENT_INIT_TASK_KEY,
         _RC_LOG_SERVICE_MARKER,
         _RC_LOG_WS_MARKER,
+        AUTH_HTTP_VIEW_REGISTERED,
+        AUTH_PAIRING_SESSIONS,
+        LAP_POSITION_WS_MARKER,
         TRACK_MAP_WS_MARKER,
     }
 )
@@ -1397,6 +1425,36 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
+async def _async_get_shared_jolpica_client(
+    hass: HomeAssistant,
+    session: Any,
+    user_agent: str,
+) -> JolpicaClient:
+    """Return the one domain-wide initialized Jolpica client."""
+    domain_root = hass.data.setdefault(DOMAIN, {})
+    client = domain_root.get(JOLPICA_CLIENT_KEY)
+    if isinstance(client, JolpicaClient):
+        return client
+
+    init_task = domain_root.get(_JOLPICA_CLIENT_INIT_TASK_KEY)
+    if not isinstance(init_task, asyncio.Task):
+
+        async def _async_initialize() -> JolpicaClient:
+            initialized = JolpicaClient(hass, session, user_agent)
+            await initialized.async_initialize()
+            domain_root[JOLPICA_CLIENT_KEY] = initialized
+            return initialized
+
+        init_task = hass.loop.create_task(_async_initialize())
+        domain_root[_JOLPICA_CLIENT_INIT_TASK_KEY] = init_task
+
+    try:
+        return await asyncio.shield(init_task)
+    finally:
+        if domain_root.get(_JOLPICA_CLIENT_INIT_TASK_KEY) is init_task:
+            domain_root.pop(_JOLPICA_CLIENT_INIT_TASK_KEY, None)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up integration via config flow."""
     # Dev-only: periodically report how many Jolpica requests actually hit the network.
@@ -1477,6 +1535,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # this UA per request in the coordinators instead.
     ua_string = await build_user_agent(hass)
     http_session = async_get_clientsession(hass)
+    jolpica_client = await _async_get_shared_jolpica_client(
+        hass,
+        http_session,
+        ua_string,
+    )
     _LOGGER.debug(
         "Configured User-Agent for Jolpica/Ergast (per-request): %s", ua_string
     )
@@ -1546,7 +1609,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             data = v.get("data") if isinstance(v, dict) else None
             if data is None:
                 continue
-            ttl = int(_startup_ttl_for_key(str(k)) or 0)
+            stored_ttl = v.get("ttl_seconds") if isinstance(v, dict) else None
+            try:
+                ttl = max(1, int(stored_ttl))
+            except (TypeError, ValueError):
+                ttl = int(_startup_ttl_for_key(str(k)) or 0)
             saved_at = None
             try:
                 saved_at = float(v.get("saved_at")) if isinstance(v, dict) else None
@@ -2206,6 +2273,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "http_session": http_session,
         "user_agent": ua_string,
+        "jolpica_client": jolpica_client,
+        "http_persistent_cache": persisted,
         "http_cache": http_cache,
         "http_inflight": http_inflight,
         "http_persist": persisted_map,
@@ -6312,6 +6381,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for name, obj in list(data.items()):
                 if obj is None:
                     continue
+                if name == "jolpica_client":
+                    continue
                 close = getattr(obj, "async_close", None)
                 if callable(close):
                     try:
@@ -6346,6 +6417,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     with suppress(Exception):
                         unsub()
                 data_root.pop(_JOLPICA_STATS_KEY, None)
+                shared_client = data_root.pop(JOLPICA_CLIENT_KEY, None)
+                close = getattr(shared_client, "async_close", None)
+                if callable(close):
+                    with suppress(Exception):
+                        await close()
     except Exception as err:  # noqa: BLE001
         _LOGGER.debug("Error during entry data cleanup: %s", err)
     return unload_ok
@@ -6624,17 +6700,41 @@ class F1DataCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Fetch data from the F1 API."""
         try:
+            from yarl import URL
+
+            request_url = str(URL(self._url).update_query({"limit": "100"}))
+
+            def _validate(payload: dict[str, Any]) -> None:
+                if "/driverstandings.json" in request_url:
+                    validate_single_page_jolpica(
+                        payload,
+                        lambda data: standings_leaf_keys(data, "DriverStandings"),
+                    )
+                elif "/constructorstandings.json" in request_url:
+                    validate_single_page_jolpica(
+                        payload,
+                        lambda data: standings_leaf_keys(data, "ConstructorStandings"),
+                    )
+                elif "/results.json" in request_url:
+                    validate_single_page_jolpica(
+                        payload,
+                        lambda data: result_leaf_keys(data, "Results"),
+                    )
+                else:
+                    validate_single_page_jolpica(payload, race_leaf_keys)
+
             async with asyncio.timeout(10):
                 data = await fetch_json(
                     self.hass,
                     self._session,
-                    self._url,
+                    request_url,
                     headers=self._headers,
                     ttl_seconds=self._ttl,
                     cache=self._cache,
                     inflight=self._inflight,
                     persist_map=self._persist,
                     persist_save=self._persist_save,
+                    validator=_validate,
                 )
                 # Detect season rollovers in current.json and clear stale caches if needed.
                 self._handle_season_rollover_if_needed(data)
@@ -6928,18 +7028,38 @@ class F1NextRaceHistoryCoordinator(DataUpdateCoordinator):
         )
 
     async def _fetch_url(self, url: str) -> Any:
+        from yarl import URL
+
+        request_url = str(URL(url).update_query({"limit": "100"}))
+
+        def _validate(payload: dict[str, Any]) -> None:
+            if "/qualifying.json" in request_url:
+                validate_single_page_jolpica(
+                    payload,
+                    lambda data: result_leaf_keys(data, "QualifyingResults"),
+                )
+            elif "/results" in request_url:
+                validate_single_page_jolpica(
+                    payload,
+                    lambda data: result_leaf_keys(data, "Results"),
+                )
+            else:
+                validate_single_page_jolpica(payload, race_leaf_keys)
+
         async with asyncio.timeout(10):
-            return await fetch_json(
+            payload = await fetch_json(
                 self.hass,
                 self._session,
-                url,
+                request_url,
                 headers=self._headers,
                 ttl_seconds=self._ttl,
                 cache=self._cache,
                 inflight=self._inflight,
                 persist_map=self._persist,
                 persist_save=self._persist_save,
+                validator=_validate,
             )
+        return payload
 
     def _target_race(self) -> dict[str, Any] | None:
         payload = getattr(self._race_coordinator, "data", None) or {}
@@ -7364,82 +7484,62 @@ class F1SeasonResultsCoordinator(DataUpdateCoordinator):
             return base.replace(marker, f"/ergast/f1/{season}/")
         return base
 
-    def _ttl_for_offset(self, offset: int, last_offset: int, page_size: int) -> int:
-        """Return TTL for a given results page offset.
-
-        - Stable pages (older part of season): very long TTL.
-        - Recent pages: daily.
-        - Latest page: every few hours.
-        """
-        try:
-            o = int(offset)
-            last = int(last_offset)
-            size = max(1, int(page_size))
-        except Exception:
-            return self._ttl_latest
-        if last <= 0:
-            return self._ttl_latest
-        if o >= last:
-            return self._ttl_latest
-        if o >= max(0, last - size):
-            return self._ttl_recent
-        return self._ttl_stable
-
     async def _fetch_page(
-        self, limit: int, offset: int, *, ttl_seconds: int | None = None
-    ):
+        self,
+        limit: int,
+        offset: int,
+        ttl_seconds: int,
+        force_refresh: bool = False,
+        validator: Callable[[dict[str, Any]], None] | None = None,
+    ) -> dict[str, Any]:
         from yarl import URL
 
-        ttl = int(ttl_seconds or self._ttl_latest)
+        if not 1 <= int(limit) <= 100:
+            raise JolpicaPaginationError(
+                f"Refusing Jolpica request with invalid limit {limit}"
+            )
 
-        # Primary: season-scoped URL when we can derive season from current.json.
         primary_base = self._effective_base_url()
         primary_url = str(
             URL(primary_base).with_query({"limit": str(limit), "offset": str(offset)})
         )
-
-        async with asyncio.timeout(10):
-            try:
+        try:
+            async with asyncio.timeout(15):
                 return await fetch_json(
                     self.hass,
                     self._session,
                     primary_url,
                     headers=self._headers,
-                    ttl_seconds=ttl,
+                    ttl_seconds=ttl_seconds,
                     cache=self._cache,
                     inflight=self._inflight,
                     persist_map=self._persist,
                     persist_save=self._persist_save,
+                    force_refresh=force_refresh,
+                    validator=validator,
                 )
-            except Exception:
-                # Fallback: legacy /current/ URL (in case the API doesn't support season-scoped paths)
-                fallback_url = str(
-                    URL(str(self._base_url)).with_query(
-                        {"limit": str(limit), "offset": str(offset)}
-                    )
+        except JolpicaRouteNotFoundError:
+            fallback_url = str(
+                URL(str(self._base_url)).with_query(
+                    {"limit": str(limit), "offset": str(offset)}
                 )
-                if fallback_url == primary_url:
-                    raise
+            )
+            if fallback_url == primary_url:
+                raise
+            async with asyncio.timeout(15):
                 return await fetch_json(
                     self.hass,
                     self._session,
                     fallback_url,
                     headers=self._headers,
-                    ttl_seconds=ttl,
+                    ttl_seconds=ttl_seconds,
                     cache=self._cache,
                     inflight=self._inflight,
                     persist_map=self._persist,
                     persist_save=self._persist_save,
+                    force_refresh=force_refresh,
+                    validator=validator,
                 )
-
-    @staticmethod
-    def _race_key(r: dict) -> tuple:
-        season = r.get("season")
-        round_ = r.get("round")
-        return (
-            str(season) if season is not None else "",
-            str(round_) if round_ is not None else "",
-        )
 
     @staticmethod
     def _empty_result() -> dict[str, Any]:
@@ -7447,111 +7547,14 @@ class F1SeasonResultsCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         try:
-            # Start with a large page size; use API-returned limit/offset/total for correctness
-            request_limit = 200
-            offset = 0
-
-            races_by_key: dict[tuple, dict] = {}
-            order: list[tuple] = []
-
-            def merge_page(page_races: list[dict]):
-                for race in page_races or []:
-                    key = self._race_key(race)
-                    existing = races_by_key.get(key)
-                    if not existing:
-                        copy = dict(race)
-                        copy["Results"] = list(race.get("Results", []) or [])
-                        races_by_key[key] = copy
-                        order.append(key)
-                    else:
-                        seen = {
-                            (res.get("Driver", {}).get("driverId"), res.get("position"))
-                            for res in existing.get("Results", [])
-                        }
-                        for res in race.get("Results", []) or []:
-                            ident = (
-                                res.get("Driver", {}).get("driverId"),
-                                res.get("position"),
-                            )
-                            if ident not in seen:
-                                existing["Results"].append(res)
-                                seen.add(ident)
-
-            # Fetch first page (use recent TTL; we'll apply more specific TTLs
-            # for additional pages once we know the total/last offset).
-            first = await self._fetch_page(
-                request_limit, offset, ttl_seconds=self._ttl_recent
+            paginated = await async_paginate_jolpica(
+                self._fetch_page,
+                lambda payload: result_leaf_keys(payload, "Results"),
+                ttl_stable=self._ttl_stable,
+                ttl_recent=self._ttl_recent,
+                ttl_latest=self._ttl_latest,
             )
-            mr = (first or {}).get("MRData", {})
-            total = int(mr.get("total") or "0")
-            limit_used = int(mr.get("limit") or request_limit)
-            offset_used = int(mr.get("offset") or offset)
-
-            merge_page((mr.get("RaceTable", {}) or {}).get("Races", []) or [])
-
-            # Determine last page offset for TTL selection
-            try:
-                last_page_offset = (max(0, total - 1) // max(1, limit_used)) * max(
-                    1, limit_used
-                )
-            except Exception:
-                last_page_offset = offset_used
-
-            # Defensive cap for pagination loop, based on server-reported totals.
-            max_loops = 50
-            if total > 0 and limit_used > 0:
-                max_loops = max(1, ((total + limit_used - 1) // limit_used) + 1)
-
-            # Iterate deterministically using server-reported paging
-            next_offset = offset_used + limit_used
-            # Cap loop iterations defensively
-            safety = 0
-            while next_offset < total and safety < max_loops:
-                page_ttl = self._ttl_for_offset(
-                    next_offset, last_page_offset, limit_used
-                )
-                page = await self._fetch_page(
-                    limit_used, next_offset, ttl_seconds=page_ttl
-                )
-                pmr = (page or {}).get("MRData", {})
-                praces = (pmr.get("RaceTable", {}) or {}).get("Races", []) or []
-                merge_page(praces)
-                with suppress(Exception):
-                    limit_used = int(pmr.get("limit") or limit_used)
-                    offset_used = int(pmr.get("offset") or next_offset)
-                    total = int(pmr.get("total") or total)
-                    if total > 0 and limit_used > 0:
-                        max_loops = max(
-                            max_loops,
-                            max(1, ((total + limit_used - 1) // limit_used) + 1),
-                        )
-                next_offset = offset_used + limit_used
-                safety += 1
-
-            # Assemble and sort by season then numeric round
-            assembled_races = [races_by_key[k] for k in order]
-            assembled_races.sort(
-                key=lambda r: (str(r.get("season")), int(str(r.get("round") or 0)))
-            )
-            # Warn only if pagination was cut short by the safety cap, meaning
-            # some result rows were not fetched. Note: `total` counts individual
-            # driver-race result rows, not races, so comparing len(assembled_races)
-            # to total would be a false positive whenever there are fewer races
-            # than classified finishers per race.
-            if safety >= max_loops and next_offset < total:
-                _LOGGER.warning(
-                    "Season results pagination incomplete: safety cap reached "
-                    "at offset %s, total reported as %s",
-                    next_offset,
-                    total,
-                )
-            result = {
-                "MRData": {
-                    "RaceTable": {
-                        "Races": assembled_races,
-                    }
-                }
-            }
+            result = merge_result_pages(paginated, "Results")
             # No-spoiler: keep cache warm but don't deliver new data to entities.
             if _is_no_spoiler_jolpica_blocked(self):
                 blocked_data = self.data
@@ -7567,8 +7570,8 @@ class F1SeasonResultsCoordinator(DataUpdateCoordinator):
             ) from err
 
 
-class F1SprintResultsCoordinator(DataUpdateCoordinator):
-    """Fetch sprint results for the current season (single, non-paginated endpoint)."""
+class F1SprintResultsCoordinator(F1SeasonResultsCoordinator):
+    """Fetch complete sprint results for the current season."""
 
     def __init__(
         self,
@@ -7586,41 +7589,36 @@ class F1SprintResultsCoordinator(DataUpdateCoordinator):
     ):
         super().__init__(
             hass,
-            _LOGGER,
-            name=name,
-            update_interval=timedelta(hours=1),
+            url,
+            name,
+            session=session,
+            user_agent=user_agent,
+            cache=cache,
+            inflight=inflight,
+            ttl_seconds=ttl_seconds,
+            ttl_stable=ttl_seconds,
+            ttl_recent=ttl_seconds,
+            ttl_latest=ttl_seconds,
+            persist_map=persist_map,
+            persist_save=persist_save,
             config_entry=config_entry,
         )
-        self._session = session or async_get_clientsession(hass)
-        self._headers = {"User-Agent": str(user_agent)} if user_agent else None
-        self._url = url
-        self._cache = cache
-        self._inflight = inflight
-        self._ttl = int(ttl_seconds or 60)
-        self._persist = persist_map
-        self._persist_save = persist_save
-
-    async def async_close(self, *_):
-        return
 
     async def _async_update_data(self):
         try:
-            async with asyncio.timeout(10):
-                data = await fetch_json(
-                    self.hass,
-                    self._session,
-                    self._url,
-                    headers=self._headers,
-                    ttl_seconds=self._ttl,
-                    cache=self._cache,
-                    inflight=self._inflight,
-                    persist_map=self._persist,
-                    persist_save=self._persist_save,
+            paginated = await async_paginate_jolpica(
+                self._fetch_page,
+                lambda payload: result_leaf_keys(payload, "SprintResults"),
+                ttl_stable=self._ttl_stable,
+                ttl_recent=self._ttl_recent,
+                ttl_latest=self._ttl_latest,
+            )
+            data = merge_result_pages(paginated, "SprintResults")
+            if _is_no_spoiler_jolpica_blocked(self):
+                return (
+                    self.data if isinstance(self.data, dict) else self._empty_result()
                 )
-                # No-spoiler: keep cache warm but don't deliver new data to entities.
-                if _is_no_spoiler_jolpica_blocked(self):
-                    return self.data
-                return data
+            return data
         except Exception as err:
             raise UpdateFailed(
                 f"Error fetching sprint results: {_format_update_error(err)}"
@@ -7813,9 +7811,15 @@ class F1LapPositionProgressionCoordinator(DataUpdateCoordinator):
         limit: int,
         offset: int,
         ttl_seconds: int,
+        force_refresh: bool = False,
+        validator: Callable[[dict[str, Any]], None] | None = None,
     ) -> dict:
         from yarl import URL
 
+        if not 1 <= int(limit) <= 100:
+            raise JolpicaPaginationError(
+                f"Refusing Jolpica request with invalid limit {limit}"
+            )
         url = str(
             URL(
                 self._LAPS_BASE_URL.format(
@@ -7835,6 +7839,8 @@ class F1LapPositionProgressionCoordinator(DataUpdateCoordinator):
                 inflight=self._inflight,
                 persist_map=self._persist,
                 persist_save=self._persist_save,
+                force_refresh=force_refresh,
+                validator=validator,
             )
 
     async def _fetch_laps_for_race(
@@ -7844,31 +7850,38 @@ class F1LapPositionProgressionCoordinator(DataUpdateCoordinator):
         if not season or not round_number:
             return None, [], False
 
-        request_limit = 100
-        offset = 0
         ttl_seconds = self._page_ttl(race, latest_round)
         lap_timings: dict[int, dict[str, dict]] = {}
         race_meta: dict | None = None
-        total = 0
-        limit_used = request_limit
-        safety = 0
-        max_loops = 1
 
-        while safety < max_loops:
-            page = await self._fetch_lap_page(
-                season, round_number, limit_used, offset, ttl_seconds
+        async def _fetch_page(
+            limit: int,
+            offset: int,
+            page_ttl: int,
+            force_refresh: bool,
+            validator: Callable[[dict[str, Any]], None],
+        ) -> dict[str, Any]:
+            return await self._fetch_lap_page(
+                season,
+                round_number,
+                limit,
+                offset,
+                page_ttl,
+                force_refresh,
+                validator,
             )
-            mr = (page or {}).get("MRData", {})
-            with suppress(Exception):
-                total = int(mr.get("total") or total or 0)
-            with suppress(Exception):
-                limit_used = int(mr.get("limit") or limit_used or request_limit)
-            with suppress(Exception):
-                offset = int(mr.get("offset") or offset)
-            if total > 0 and limit_used > 0:
-                max_loops = max(1, ((total + limit_used - 1) // limit_used) + 1)
 
-            page_races = self._race_table_races(page)
+        paginated = await async_paginate_jolpica(
+            _fetch_page,
+            lap_leaf_keys,
+            ttl_stable=ttl_seconds,
+            ttl_recent=ttl_seconds,
+            ttl_latest=ttl_seconds,
+            ttl_probe=self._ttl_pending,
+        )
+
+        for validated_page in paginated.pages:
+            page_races = self._race_table_races(validated_page.payload)
             for page_race in page_races:
                 if race_meta is None:
                     race_meta = {
@@ -7895,12 +7908,6 @@ class F1LapPositionProgressionCoordinator(DataUpdateCoordinator):
                             continue
                         timings_by_driver[driver_id] = dict(timing)
 
-            next_offset = offset + max(1, limit_used)
-            if total <= 0 or next_offset >= total:
-                break
-            offset = next_offset
-            safety += 1
-
         laps = []
         for lap_number in sorted(lap_timings):
             timings = sorted(
@@ -7908,7 +7915,7 @@ class F1LapPositionProgressionCoordinator(DataUpdateCoordinator):
                 key=self._sort_timing_key,
             )
             laps.append({"number": str(lap_number), "Timings": timings})
-        return race_meta, laps, total > 0
+        return race_meta, laps, paginated.total > 0
 
     def _result_metadata(self, race: dict) -> dict[str, dict]:
         metadata = {}

--- a/custom_components/f1_sensor/button.py
+++ b/custom_components/f1_sensor/button.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from inspect import isawaitable
 import logging
 import time
@@ -91,7 +90,7 @@ async def async_setup_entry(
         )
         entities.append(entity)
 
-    if const.ENABLE_DEVELOPMENT_MODE_UI and registry.get("http_session") is not None:
+    if const.ENABLE_DEVELOPMENT_MODE_UI and registry.get("jolpica_client") is not None:
         entity = F1JolpicaUserAgentTestButton(
             hass=hass,
             entry_id=entry.entry_id,
@@ -274,7 +273,7 @@ class F1MatchDelayButton(F1AuxEntity, ButtonEntity):
 
 
 class F1JolpicaUserAgentTestButton(F1AuxEntity, ButtonEntity):
-    """Diagnostic button that performs a single Jolpica call and logs the UA used."""
+    """Diagnostic button that performs a limiter-controlled Jolpica call."""
 
     _device_category = "system"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -296,20 +295,9 @@ class F1JolpicaUserAgentTestButton(F1AuxEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         reg = self.hass.data.get(DOMAIN, {}).get(self._entry_id, {}) or {}
-        session = reg.get("http_session")
-        ua_configured = reg.get("user_agent")
-        ua_session = None
-        try:
-            ua_session = (
-                session.headers.get("User-Agent")
-                if session is not None and getattr(session, "headers", None) is not None
-                else None
-            )
-        except Exception:
-            ua_session = None
-
-        if session is None:
-            msg = "No dedicated Jolpica HTTP session found; reload the integration."
+        client = reg.get("jolpica_client")
+        if client is None:
+            msg = "No Jolpica API client found; reload the integration."
             _LOGGER.warning(msg)
             res = persistent_notification.async_create(
                 self.hass,
@@ -321,38 +309,29 @@ class F1JolpicaUserAgentTestButton(F1AuxEntity, ButtonEntity):
                 await res
             return
 
-        # Make an actual network request so the remote server sees the UA.
-        # Use a small valid query to keep payload tiny.
-        status = None
         err = None
-        started = time.time()
-        headers = {"User-Agent": str(ua_configured)} if ua_configured else None
+        started = time.monotonic()
         try:
-            async with asyncio.timeout(10):
-                async with session.get(
-                    API_URL, params={"limit": "1"}, headers=headers
-                ) as resp:
-                    status = resp.status
-                    # Drain response to keep session healthy; ignore content.
-                    await resp.text()
+            await client.async_get_json(
+                API_URL,
+                params={"limit": "1", "offset": "0"},
+                timeout=10,
+                retry_on_rate_limit=False,
+            )
         except Exception as e:  # noqa: BLE001
             err = str(e)
 
-        elapsed_ms = int(round((time.time() - started) * 1000))
+        elapsed_ms = int(round((time.monotonic() - started) * 1000))
         if err is not None:
-            log = (
-                f"Jolpica UA test FAILED (elapsed={elapsed_ms}ms) "
-                f"ua_configured={ua_configured!r} ua_session={ua_session!r} ua_sent={headers.get('User-Agent') if isinstance(headers, dict) else None!r} error={err}"
+            _LOGGER.warning(
+                "Jolpica API test failed after %sms: %s",
+                elapsed_ms,
+                err,
             )
-            _LOGGER.warning(log)
-            message = log
+            message = f"Jolpica API test FAILED (elapsed={elapsed_ms}ms) error={err}"
         else:
-            log = (
-                f"Jolpica UA test OK (status={status}, elapsed={elapsed_ms}ms) "
-                f"ua_configured={ua_configured!r} ua_session={ua_session!r} ua_sent={headers.get('User-Agent') if isinstance(headers, dict) else None!r} url={API_URL}"
-            )
-            _LOGGER.info(log)
-            message = log
+            _LOGGER.info("Jolpica API test succeeded in %sms", elapsed_ms)
+            message = f"Jolpica API test OK (elapsed={elapsed_ms}ms)"
 
         res = persistent_notification.async_create(
             self.hass,

--- a/custom_components/f1_sensor/diagnostics.py
+++ b/custom_components/f1_sensor/diagnostics.py
@@ -46,6 +46,23 @@ _TRACKED_STREAMS = (
     "Position.z",
     "PitStopSeries",
 )
+_JOLPICA_DIAGNOSTIC_KEYS = frozenset(
+    {
+        "blocked_requests",
+        "cache_entries",
+        "cooldown_remaining_seconds",
+        "hour_limit",
+        "inflight_requests",
+        "latest_429",
+        "max_queue_wait_seconds",
+        "queue_length",
+        "requests_last_hour",
+        "requests_last_second",
+        "second_limit",
+        "user_agent_configured",
+    }
+)
+_DIAGNOSTIC_SCALAR_TYPES = (bool, float, int, str)
 
 
 def _sorted_strings(value: object) -> list[str] | None:
@@ -135,6 +152,26 @@ def _serialize_track_map_runtime(track_map_store: object) -> dict[str, Any]:
     return payload
 
 
+def _serialize_jolpica_runtime(client: object) -> dict[str, Any]:
+    """Return only safe, documented Jolpica transport counters."""
+    diagnostics = getattr(client, "diagnostics", None)
+    if not callable(diagnostics):
+        return {}
+
+    payload: object = {}
+    with suppress(Exception):
+        payload = diagnostics()
+    if not isinstance(payload, dict):
+        return {}
+
+    return {
+        key: value
+        for key, value in payload.items()
+        if key in _JOLPICA_DIAGNOSTIC_KEYS
+        and (value is None or isinstance(value, _DIAGNOSTIC_SCALAR_TYPES))
+    }
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -181,6 +218,15 @@ async def async_get_config_entry_diagnostics(
     track_map_store = entry_runtime.get("track_map_store")
     if track_map_store is not None:
         runtime["track_map"] = _serialize_track_map_runtime(track_map_store)
+
+    jolpica_client = entry_runtime.get("jolpica_client")
+    if jolpica_client is not None:
+        jolpica_runtime = _serialize_jolpica_runtime(jolpica_client)
+        http_cache = entry_runtime.get("http_cache")
+        if http_cache is not None:
+            with suppress(Exception):
+                jolpica_runtime["cache_entries"] = len(http_cache)
+        runtime["jolpica"] = jolpica_runtime
 
     entry_data = dict(entry.data)
     if not include_auth_transport:

--- a/custom_components/f1_sensor/helpers.py
+++ b/custom_components/f1_sensor/helpers.py
@@ -42,9 +42,6 @@ except ImportError:  # pragma: no cover - handled gracefully when dependency mis
 
 _LOGGER = logging.getLogger(__name__)
 
-# Avoid log spam: only log Jolpica cache-hit UA once per cache key per runtime.
-_JOLPICA_UA_HIT_LOGGED: set[str] = set()
-_JOLPICA_UA_TEXT_HIT_LOGGED: set[str] = set()
 _ENTITY_NAME_ACRONYMS = {"f1": "F1", "fia": "FIA"}
 CARDATA_MAX_LINE_BYTES = 256 * 1024
 CARDATA_MAX_DECOMPRESSED_BYTES = 2 * 1024 * 1024
@@ -320,6 +317,8 @@ async def fetch_json(
     inflight: dict[str, asyncio.Future] | None = None,
     persist_map: dict[str, Any] | None = None,
     persist_save: Callable[[], None] | None = None,
+    force_refresh: bool = False,
+    validator: Callable[[Any], None] | None = None,
 ) -> Any:
     """Fetch JSON with TTL cache and in-flight request de-duplication.
 
@@ -334,40 +333,31 @@ async def fetch_json(
     )
     persist_store: dict[str, Any] = persist_map if isinstance(persist_map, dict) else {}
 
+    if force_refresh:
+        cache_map.pop(key, None)
+        if persist_store.pop(key, None) is not None and callable(persist_save):
+            persist_save()
+
     # Cache hit
     try:
         exp, data = cache_map.get(key, (0.0, None))
         if exp and now < exp:
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                is_jolpica = "api.jolpi.ca" in str(url) or "/ergast/" in str(url)
-                if is_jolpica:
-                    # ua_sent: prefer explicit per-request headers when provided
-                    ua_sent = None
-                    try:
-                        if isinstance(headers, dict) and headers.get("User-Agent"):
-                            ua_sent = headers.get("User-Agent")
-                        else:
-                            ua_sent = (
-                                session.headers.get("User-Agent")
-                                if getattr(session, "headers", None) is not None
-                                else None
-                            )
-                    except Exception:
-                        ua_sent = None
-                    # Log cache-hit UA once per key to keep logs readable
-                    if key not in _JOLPICA_UA_HIT_LOGGED:
-                        _JOLPICA_UA_HIT_LOGGED.add(key)
+            try:
+                if callable(validator):
+                    validator(data)
+            except Exception:
+                cache_map.pop(key, None)
+                persist_store.pop(key, None)
+                if callable(persist_save):
+                    persist_save()
+            else:
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    is_jolpica = "api.jolpi.ca" in str(url) or "/ergast/" in str(url)
+                    if not is_jolpica:
                         _LOGGER.debug(
-                            "Jolpica cache HIT key=%s ttl_left=%.1fs ua_sent=%s",
-                            key,
-                            exp - now,
-                            ua_sent,
+                            "HTTP cache HIT key=%s ttl_left=%.1fs", key, exp - now
                         )
-                else:
-                    _LOGGER.debug(
-                        "HTTP cache HIT key=%s ttl_left=%.1fs", key, exp - now
-                    )
-            return data
+                return data
     except Exception:
         _LOGGER.debug("Cache lookup failed for key=%s", key, exc_info=True)
 
@@ -376,46 +366,48 @@ async def fetch_json(
     if fut is not None and not fut.done():
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug("HTTP request COALESCED key=%s (awaiting in-flight)", key)
-        return await asyncio.shield(fut)
+        data = await asyncio.shield(fut)
+        try:
+            if callable(validator):
+                validator(data)
+        except Exception:
+            cache_map.pop(key, None)
+            persist_store.pop(key, None)
+            if callable(persist_save):
+                persist_save()
+            raise
+        return data
 
     # First requester: perform network call
     loop = hass.loop
     fut = loop.create_future()
     inflight_map[key] = fut
     try:
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            ua_sent = None
-            try:
-                if isinstance(headers, dict) and headers.get("User-Agent"):
-                    ua_sent = headers.get("User-Agent")
-                else:
-                    # aiohttp ClientSession exposes default headers via `.headers`
-                    ua_sent = (
-                        session.headers.get("User-Agent")
-                        if getattr(session, "headers", None) is not None
-                        else None
-                    )
-            except Exception:
-                ua_sent = None
-            if "api.jolpi.ca" in str(url) or "/ergast/" in str(url):
-                _LOGGER.debug(
-                    "Jolpica request MISS -> url=%s ua_sent=%s key=%s",
-                    url,
-                    ua_sent,
-                    key,
-                )
-            else:
-                _LOGGER.debug("HTTP cache MISS key=%s -> fetching", key)
+        if _LOGGER.isEnabledFor(logging.DEBUG) and not (
+            "api.jolpi.ca" in str(url) or "/ergast/" in str(url)
+        ):
+            _LOGGER.debug("HTTP cache MISS key=%s -> fetching", key)
         if "api.jolpi.ca" in str(url) or "/ergast/" in str(url):
             _record_jolpica_miss(hass, key)
-        async with asyncio.timeout(30):
-            async with session.get(url, params=params, headers=headers) as resp:
-                resp.raise_for_status()
-                text = await resp.text()
-        data = json.loads(text.lstrip("\ufeff"))
+        parsed_url = urlparse(str(url))
+        if parsed_url.hostname == "api.jolpi.ca":
+            from .jolpica import JOLPICA_CLIENT_KEY
+
+            client = (hass.data.get(DOMAIN) or {}).get(JOLPICA_CLIENT_KEY)
+            if client is None:
+                raise RuntimeError("Shared Jolpica client is not initialized")
+            data = await client.async_get_json(url, params=params, timeout=30)
+        else:
+            async with asyncio.timeout(30):
+                async with session.get(url, params=params, headers=headers) as resp:
+                    resp.raise_for_status()
+                    text = await resp.text()
+            data = json.loads(text.lstrip("\ufeff"))
+        if callable(validator):
+            validator(data)
         # Update cache
         try:
-            cache_map[key] = (now + max(1, int(ttl_seconds)), data)
+            cache_map[key] = (time.monotonic() + max(1, int(ttl_seconds)), data)
         except Exception:
             _LOGGER.debug("Failed to update cache for key=%s", key, exc_info=True)
         # Persist simplified record (data only). Validation headers are optional future work.
@@ -423,6 +415,7 @@ async def fetch_json(
             persist_store[key] = {
                 "data": data,
                 "saved_at": time.time(),
+                "ttl_seconds": max(1, int(ttl_seconds)),
             }
             if callable(persist_save):
                 # Save debounced by caller; we just request a save
@@ -466,6 +459,7 @@ async def fetch_text(
     inflight: dict[str, asyncio.Future] | None = None,
     persist_map: dict[str, Any] | None = None,
     persist_save: Callable[[], None] | None = None,
+    force_refresh: bool = False,
 ) -> str:
     """Fetch raw text with TTL cache and in-flight de-duplication."""
     base_key = _make_cache_key(url, params)
@@ -477,33 +471,17 @@ async def fetch_text(
     )
     persist_store: dict[str, Any] = persist_map if isinstance(persist_map, dict) else {}
 
+    if force_refresh:
+        cache_map.pop(key, None)
+        if persist_store.pop(key, None) is not None and callable(persist_save):
+            persist_save()
+
     try:
         exp, data = cache_map.get(key, (0.0, None))
         if exp and now < exp and isinstance(data, str):
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 is_jolpica = "api.jolpi.ca" in str(url) or "/ergast/" in str(url)
-                if is_jolpica:
-                    ua_sent = None
-                    try:
-                        if isinstance(headers, dict) and headers.get("User-Agent"):
-                            ua_sent = headers.get("User-Agent")
-                        else:
-                            ua_sent = (
-                                session.headers.get("User-Agent")
-                                if getattr(session, "headers", None) is not None
-                                else None
-                            )
-                    except Exception:
-                        ua_sent = None
-                    if key not in _JOLPICA_UA_TEXT_HIT_LOGGED:
-                        _JOLPICA_UA_TEXT_HIT_LOGGED.add(key)
-                        _LOGGER.debug(
-                            "Jolpica text cache HIT key=%s ttl_left=%.1fs ua_sent=%s",
-                            key,
-                            exp - now,
-                            ua_sent,
-                        )
-                else:
+                if not is_jolpica:
                     _LOGGER.debug(
                         "HTTP text cache HIT key=%s ttl_left=%.1fs", key, exp - now
                     )
@@ -521,42 +499,34 @@ async def fetch_text(
     fut = loop.create_future()
     inflight_map[key] = fut
     try:
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            ua_sent = None
-            try:
-                if isinstance(headers, dict) and headers.get("User-Agent"):
-                    ua_sent = headers.get("User-Agent")
-                else:
-                    ua_sent = (
-                        session.headers.get("User-Agent")
-                        if getattr(session, "headers", None) is not None
-                        else None
-                    )
-            except Exception:
-                ua_sent = None
-            if "api.jolpi.ca" in str(url) or "/ergast/" in str(url):
-                _LOGGER.debug(
-                    "Jolpica text request MISS -> url=%s ua_sent=%s key=%s",
-                    url,
-                    ua_sent,
-                    key,
-                )
-            else:
-                _LOGGER.debug("HTTP text cache MISS key=%s -> fetching", key)
+        if _LOGGER.isEnabledFor(logging.DEBUG) and not (
+            "api.jolpi.ca" in str(url) or "/ergast/" in str(url)
+        ):
+            _LOGGER.debug("HTTP text cache MISS key=%s -> fetching", key)
         if "api.jolpi.ca" in str(url) or "/ergast/" in str(url):
             _record_jolpica_miss(hass, key)
-        async with asyncio.timeout(30):
-            async with session.get(url, params=params, headers=headers) as resp:
-                resp.raise_for_status()
-                text = await resp.text()
+        parsed_url = urlparse(str(url))
+        if parsed_url.hostname == "api.jolpi.ca":
+            from .jolpica import JOLPICA_CLIENT_KEY
+
+            client = (hass.data.get(DOMAIN) or {}).get(JOLPICA_CLIENT_KEY)
+            if client is None:
+                raise RuntimeError("Shared Jolpica client is not initialized")
+            text = await client.async_get_text(url, params=params, timeout=30)
+        else:
+            async with asyncio.timeout(30):
+                async with session.get(url, params=params, headers=headers) as resp:
+                    resp.raise_for_status()
+                    text = await resp.text()
         try:
-            cache_map[key] = (now + max(1, int(ttl_seconds)), text)
+            cache_map[key] = (time.monotonic() + max(1, int(ttl_seconds)), text)
         except Exception:
             _LOGGER.debug("Failed to update text cache for key=%s", key, exc_info=True)
         try:
             persist_store[key] = {
                 "data": text,
                 "saved_at": time.time(),
+                "ttl_seconds": max(1, int(ttl_seconds)),
             }
             if callable(persist_save):
                 persist_save()
@@ -624,6 +594,16 @@ class PersistentCache:
             # Fallback to immediate save
             with suppress(Exception):
                 self._hass.loop.create_task(self._store.async_save(self._data))
+
+    async def async_close(self) -> None:
+        """Flush pending cache writes before config-entry unload completes."""
+        task = self._save_task
+        if task is not None and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        with suppress(Exception):
+            await self._store.async_save(self._data)
 
 
 _PDF_ANCHOR_RE = re.compile(

--- a/custom_components/f1_sensor/jolpica.py
+++ b/custom_components/f1_sensor/jolpica.py
@@ -1,0 +1,542 @@
+"""Shared, policy-compliant transport for the public Jolpica API."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from collections.abc import Mapping
+from contextlib import suppress
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+import json
+import logging
+import math
+import re
+import time
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+from aiohttp import ClientError, ClientResponseError
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+JOLPICA_CLIENT_KEY = "__jolpica_client__"
+JOLPICA_HOST = "api.jolpi.ca"
+JOLPICA_ORIGIN = f"https://{JOLPICA_HOST}"
+
+_SECOND_LIMIT = 3
+_HOUR_LIMIT = 450
+_SECOND_WINDOW = 1.0
+_HOUR_WINDOW = 3600.0
+_MAX_QUEUE_WAIT = 5.0
+_MAX_SERVER_RETRY_DELAY = 10.0
+_MAX_BACKOFF = 60.0
+_STORE_VERSION = 1
+_STORE_KEY = f"{DOMAIN}_jolpica_transport"
+_SAVE_DELAY = 1.0
+_USER_AGENT_PATTERN = re.compile(
+    r"^HomeAssistantF1Sensor/[A-Za-z0-9][A-Za-z0-9._+-]* "
+    r"HomeAssistant/[A-Za-z0-9][A-Za-z0-9._+-]*$"
+)
+
+
+class JolpicaError(Exception):
+    """Base class for Jolpica transport failures."""
+
+
+class JolpicaConfigurationError(JolpicaError):
+    """The client cannot safely make a Jolpica request."""
+
+
+class JolpicaInvalidRequestError(JolpicaError):
+    """A request violates the Jolpica transport policy."""
+
+
+class JolpicaTemporaryError(JolpicaError):
+    """A temporary problem prevented a request."""
+
+
+class JolpicaRateLimitError(JolpicaTemporaryError):
+    """A local or server-side rate limit prevented a request."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retry_after: float | None = None,
+        source: str,
+    ) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+        self.source = source
+
+
+class JolpicaRouteNotFoundError(JolpicaError):
+    """The requested Jolpica route does not exist."""
+
+    status = 404
+
+
+class JolpicaHTTPError(JolpicaError):
+    """Jolpica returned an HTTP error other than a rate limit."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+class JolpicaResponseError(JolpicaError):
+    """Jolpica returned a response that could not be decoded."""
+
+
+class JolpicaClient:
+    """Apply shared identity, traffic, retry, and lifecycle policy."""
+
+    def __init__(
+        self,
+        hass,
+        session,
+        user_agent: str,
+        *,
+        max_queue_wait: float = _MAX_QUEUE_WAIT,
+    ) -> None:
+        self._hass = hass
+        self._session = session
+        self._user_agent = str(user_agent or "").strip()
+        self._max_queue_wait = max(0.0, float(max_queue_wait))
+        self._store = Store(hass, _STORE_VERSION, _STORE_KEY)
+
+        self._second_requests: deque[float] = deque()
+        self._hour_requests: deque[float] = deque()
+        self._inflight: dict[str, asyncio.Task[str]] = {}
+        self._limiter_lock = asyncio.Lock()
+        self._inflight_lock = asyncio.Lock()
+
+        self._cooldown_until = 0.0
+        self._latest_429: float | None = None
+        self._backoff_step = 0
+        self._blocked_requests = 0
+        self._queue_length = 0
+        self._save_task: asyncio.Task[None] | None = None
+        self._initialized = False
+        self._closed = False
+        self._limit_problem_active = False
+        self._cooldown_problem_active = False
+
+    async def async_initialize(self) -> None:
+        """Load persisted hourly request budget and active cooldown."""
+        if self._initialized:
+            return
+        if not self._valid_user_agent:
+            raise JolpicaConfigurationError(
+                "A valid integration-specific User-Agent is required"
+            )
+
+        stored: Any = None
+        with suppress(Exception):
+            stored = await self._store.async_load()
+        if isinstance(stored, dict):
+            now = time.time()
+            timestamps = stored.get("request_timestamps")
+            if isinstance(timestamps, list):
+                for raw_timestamp in timestamps:
+                    try:
+                        timestamp = float(raw_timestamp)
+                    except (TypeError, ValueError):
+                        continue
+                    if now - _HOUR_WINDOW < timestamp <= now + 1:
+                        self._hour_requests.append(timestamp)
+
+            try:
+                cooldown_until = float(stored.get("cooldown_until", 0.0))
+            except (TypeError, ValueError):
+                cooldown_until = 0.0
+            if cooldown_until > now:
+                self._cooldown_until = cooldown_until
+
+            try:
+                backoff_step = int(stored.get("backoff_step", 0))
+            except (TypeError, ValueError):
+                backoff_step = 0
+            self._backoff_step = max(0, min(backoff_step, 6))
+
+            try:
+                latest_429 = float(stored.get("latest_429", 0.0))
+            except (TypeError, ValueError):
+                latest_429 = 0.0
+            self._latest_429 = latest_429 or None
+
+        self._initialized = True
+
+    async def async_get_text(
+        self,
+        url: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        timeout: float = 30.0,
+        retry_on_rate_limit: bool = True,
+    ) -> str:
+        """Return text from a policy-compliant, coalesced Jolpica GET."""
+        self._ensure_ready()
+        self._validate_request(url, params)
+        request_key = (
+            f"retry_429={bool(retry_on_rate_limit)}:{self._request_key(url, params)}"
+        )
+
+        async with self._inflight_lock:
+            task = self._inflight.get(request_key)
+            if task is None or task.done():
+                task = self._hass.loop.create_task(
+                    self._async_request_text(
+                        url,
+                        params=params,
+                        timeout=timeout,
+                        retry_on_rate_limit=retry_on_rate_limit,
+                    )
+                )
+                self._inflight[request_key] = task
+                task.add_done_callback(
+                    lambda completed, key=request_key: self._remove_inflight(
+                        key, completed
+                    )
+                )
+        return await asyncio.shield(task)
+
+    async def async_get_json(
+        self,
+        url: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        timeout: float = 30.0,
+        retry_on_rate_limit: bool = True,
+    ) -> Any:
+        """Return decoded JSON from a policy-compliant Jolpica GET."""
+        text = await self.async_get_text(
+            url,
+            params=params,
+            timeout=timeout,
+            retry_on_rate_limit=retry_on_rate_limit,
+        )
+        try:
+            return json.loads(text.lstrip("\ufeff"))
+        except (TypeError, ValueError) as err:
+            raise JolpicaResponseError("Jolpica returned invalid JSON") from err
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return safe runtime diagnostics without URLs or headers."""
+        now_mono = time.monotonic()
+        now_wall = time.time()
+        self._prune_requests(now_mono, now_wall)
+        cache_entries = 0
+        domain_data = self._hass.data.get(DOMAIN)
+        if isinstance(domain_data, dict):
+            for runtime in domain_data.values():
+                if not isinstance(runtime, dict):
+                    continue
+                cache = runtime.get("http_cache")
+                if isinstance(cache, dict):
+                    cache_entries += len(cache)
+        latest_429 = None
+        if self._latest_429 is not None:
+            latest_429 = datetime.fromtimestamp(self._latest_429, tz=UTC).isoformat()
+        return {
+            "user_agent_configured": self._valid_user_agent,
+            "second_limit": _SECOND_LIMIT,
+            "hour_limit": _HOUR_LIMIT,
+            "max_queue_wait_seconds": self._max_queue_wait,
+            "requests_last_second": len(self._second_requests),
+            "requests_last_hour": len(self._hour_requests),
+            "queue_length": self._queue_length,
+            "blocked_requests": self._blocked_requests,
+            "cooldown_remaining_seconds": max(
+                0.0, round(self._cooldown_until - now_wall, 3)
+            ),
+            "latest_429": latest_429,
+            "cache_entries": cache_entries,
+            "inflight_requests": len(self._inflight),
+        }
+
+    async def async_close(self) -> None:
+        """Cancel owned tasks and flush limiter state on normal shutdown."""
+        if self._closed:
+            return
+        self._closed = True
+
+        tasks = tuple(self._inflight.values())
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._inflight.clear()
+
+        if self._save_task is not None and not self._save_task.done():
+            self._save_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._save_task
+        with suppress(Exception):
+            await self._store.async_save(self._storage_payload())
+
+    @property
+    def _valid_user_agent(self) -> bool:
+        return bool(_USER_AGENT_PATTERN.fullmatch(self._user_agent))
+
+    def _ensure_ready(self) -> None:
+        if not self._initialized:
+            raise JolpicaConfigurationError(
+                "Jolpica client must be initialized before use"
+            )
+        if self._closed:
+            raise JolpicaConfigurationError("Jolpica client is closed")
+        if not self._valid_user_agent:
+            raise JolpicaConfigurationError(
+                "A valid integration-specific User-Agent is required"
+            )
+
+    @staticmethod
+    def _validate_request(url: str, params: Mapping[str, Any] | None) -> None:
+        parsed = urlsplit(str(url))
+        if (
+            parsed.scheme != "https"
+            or parsed.netloc != JOLPICA_HOST
+            or not parsed.path.startswith("/")
+        ):
+            raise JolpicaInvalidRequestError(
+                "Only the canonical Jolpica HTTPS origin is allowed"
+            )
+
+        query = parse_qs(parsed.query, keep_blank_values=True)
+        if params:
+            for key, value in params.items():
+                values = value if isinstance(value, (list, tuple)) else (value,)
+                query.setdefault(str(key), []).extend(str(item) for item in values)
+        for raw_limit in query.get("limit", []):
+            try:
+                limit = int(raw_limit)
+            except (TypeError, ValueError) as err:
+                raise JolpicaInvalidRequestError(
+                    "Jolpica limit must be an integer"
+                ) from err
+            if not 1 <= limit <= 100:
+                raise JolpicaInvalidRequestError(
+                    "Jolpica limit must be between 1 and 100"
+                )
+
+    @staticmethod
+    def _request_key(url: str, params: Mapping[str, Any] | None) -> str:
+        if not params:
+            return url
+        normalized: list[tuple[str, str]] = []
+        for key, value in params.items():
+            values = value if isinstance(value, (list, tuple)) else (value,)
+            normalized.extend((str(key), str(item)) for item in values)
+        return f"{url}?{urlencode(sorted(normalized))}"
+
+    async def _async_request_text(
+        self,
+        url: str,
+        *,
+        params: Mapping[str, Any] | None,
+        timeout: float,
+        retry_on_rate_limit: bool = True,
+    ) -> str:
+        timeout = float(timeout)
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise JolpicaInvalidRequestError("Request timeout must be positive")
+        deadline = time.monotonic() + timeout
+        retry_number = 0
+
+        while True:
+            await self._async_acquire_slot(deadline)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise JolpicaTemporaryError("Jolpica request budget expired")
+
+            try:
+                async with asyncio.timeout(remaining):
+                    async with self._session.get(
+                        url,
+                        params=params,
+                        headers={"User-Agent": self._user_agent},
+                        allow_redirects=False,
+                    ) as response:
+                        try:
+                            response.raise_for_status()
+                        except ClientResponseError as err:
+                            if response.status == 429:
+                                retry_after = self._record_server_limit(
+                                    response.headers.get("Retry-After")
+                                )
+                                if (
+                                    retry_on_rate_limit
+                                    and retry_number == 0
+                                    and retry_after <= _MAX_SERVER_RETRY_DELAY
+                                    and retry_after < deadline - time.monotonic()
+                                ):
+                                    retry_number += 1
+                                    if retry_after > 0:
+                                        await asyncio.sleep(retry_after)
+                                    continue
+                                raise JolpicaRateLimitError(
+                                    "Jolpica rate limit reached",
+                                    retry_after=retry_after,
+                                    source="server",
+                                ) from err
+                            if response.status == 404:
+                                raise JolpicaRouteNotFoundError(
+                                    "Jolpica route was not found"
+                                ) from err
+                            raise JolpicaHTTPError(
+                                response.status,
+                                f"Jolpica returned HTTP {response.status}",
+                            ) from err
+                        if not 200 <= response.status < 300:
+                            raise JolpicaHTTPError(
+                                response.status,
+                                f"Jolpica returned HTTP {response.status}",
+                            )
+                        text = await response.text()
+            except TimeoutError as err:
+                raise JolpicaTemporaryError("Jolpica request timed out") from err
+            except ClientError as err:
+                raise JolpicaTemporaryError("Jolpica network request failed") from err
+
+            self._record_success()
+            return text
+
+    async def _async_acquire_slot(self, deadline: float) -> None:
+        queue_deadline = time.monotonic() + self._max_queue_wait
+        self._queue_length += 1
+        try:
+            while True:
+                async with self._limiter_lock:
+                    now_mono = time.monotonic()
+                    now_wall = time.time()
+                    self._prune_requests(now_mono, now_wall)
+
+                    cooldown_delay = max(0.0, self._cooldown_until - now_wall)
+                    second_delay = 0.0
+                    if len(self._second_requests) >= _SECOND_LIMIT:
+                        second_delay = max(
+                            0.0,
+                            self._second_requests[0] + _SECOND_WINDOW - now_mono,
+                        )
+                    hour_delay = 0.0
+                    if len(self._hour_requests) >= _HOUR_LIMIT:
+                        hour_delay = max(
+                            0.0,
+                            self._hour_requests[0] + _HOUR_WINDOW - now_wall,
+                        )
+                    delay = max(cooldown_delay, second_delay, hour_delay)
+                    remaining = deadline - now_mono
+
+                    if delay <= 0:
+                        self._second_requests.append(now_mono)
+                        self._hour_requests.append(now_wall)
+                        self._schedule_save()
+                        if self._limit_problem_active:
+                            _LOGGER.info("Jolpica request limiter recovered")
+                            self._limit_problem_active = False
+                        return
+
+                    if delay > queue_deadline - now_mono or delay >= remaining:
+                        self._blocked_requests += 1
+                        if not self._limit_problem_active:
+                            _LOGGER.warning(
+                                "Jolpica request deferred by shared traffic limits"
+                            )
+                            self._limit_problem_active = True
+                        source = (
+                            "server"
+                            if cooldown_delay >= max(second_delay, hour_delay)
+                            else "local"
+                        )
+                        raise JolpicaRateLimitError(
+                            "Jolpica request cannot run within the local wait budget",
+                            retry_after=delay,
+                            source=source,
+                        )
+                await asyncio.sleep(delay)
+        finally:
+            self._queue_length -= 1
+
+    def _record_server_limit(self, raw_retry_after: str | None) -> float:
+        now = time.time()
+        retry_after = self._parse_retry_after(raw_retry_after, now=now)
+        if retry_after is None:
+            retry_after = min(2**self._backoff_step, _MAX_BACKOFF)
+            self._backoff_step = min(self._backoff_step + 1, 6)
+        self._cooldown_until = max(self._cooldown_until, now + retry_after)
+        self._latest_429 = now
+        self._schedule_save()
+        if not self._cooldown_problem_active:
+            _LOGGER.warning("Jolpica server cooldown activated")
+            self._cooldown_problem_active = True
+        return retry_after
+
+    def _record_success(self) -> None:
+        self._backoff_step = 0
+        if self._cooldown_until <= time.time():
+            self._cooldown_until = 0.0
+            if self._cooldown_problem_active:
+                _LOGGER.info("Jolpica server cooldown recovered")
+                self._cooldown_problem_active = False
+        self._schedule_save()
+
+    @staticmethod
+    def _parse_retry_after(raw_value: str | None, *, now: float) -> float | None:
+        if raw_value is None:
+            return None
+        value = str(raw_value).strip()
+        if not value:
+            return None
+        try:
+            delay = float(value)
+        except ValueError:
+            try:
+                parsed = parsedate_to_datetime(value)
+            except (TypeError, ValueError, OverflowError):
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            delay = parsed.timestamp() - now
+        if not math.isfinite(delay):
+            return None
+        return max(0.0, delay)
+
+    def _prune_requests(self, now_mono: float, now_wall: float) -> None:
+        while (
+            self._second_requests
+            and self._second_requests[0] <= now_mono - _SECOND_WINDOW
+        ):
+            self._second_requests.popleft()
+        while self._hour_requests and self._hour_requests[0] <= now_wall - _HOUR_WINDOW:
+            self._hour_requests.popleft()
+
+    def _remove_inflight(self, request_key: str, completed: asyncio.Task[str]) -> None:
+        if self._inflight.get(request_key) is completed:
+            self._inflight.pop(request_key, None)
+        with suppress(asyncio.CancelledError, Exception):
+            completed.exception()
+
+    def _schedule_save(self) -> None:
+        if self._closed or (self._save_task is not None and not self._save_task.done()):
+            return
+
+        async def _save_later() -> None:
+            await asyncio.sleep(_SAVE_DELAY)
+            with suppress(Exception):
+                await self._store.async_save(self._storage_payload())
+
+        self._save_task = self._hass.loop.create_task(_save_later())
+
+    def _storage_payload(self) -> dict[str, Any]:
+        return {
+            "request_timestamps": list(self._hour_requests),
+            "cooldown_until": self._cooldown_until,
+            "backoff_step": self._backoff_step,
+            "latest_429": self._latest_429,
+        }

--- a/custom_components/f1_sensor/jolpica_pagination.py
+++ b/custom_components/f1_sensor/jolpica_pagination.py
@@ -1,0 +1,479 @@
+"""Strict, atomic pagination helpers for Jolpica API payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Hashable
+from dataclasses import dataclass
+from typing import Any
+
+JOLPICA_PAGE_SIZE = 100
+JOLPICA_PAGE_CAP = 100
+
+
+class JolpicaPaginationError(RuntimeError):
+    """Raised when a paginated Jolpica response is incomplete or inconsistent."""
+
+
+class _JolpicaTotalChanged(JolpicaPaginationError):
+    """Raised when the authoritative total changes during one collection."""
+
+
+@dataclass(frozen=True, slots=True)
+class JolpicaPage:
+    """One validated data page."""
+
+    payload: dict[str, Any]
+    total: int
+    limit: int
+    offset: int
+    leaf_keys: tuple[Hashable, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class JolpicaPaginationResult:
+    """A complete, validated Jolpica pagination result."""
+
+    total: int
+    pages: tuple[JolpicaPage, ...]
+
+
+PageValidator = Callable[[dict[str, Any]], None]
+FetchPage = Callable[
+    [int, int, int, bool, PageValidator],
+    Awaitable[dict[str, Any]],
+]
+LeafKeys = Callable[[dict[str, Any]], list[Hashable]]
+
+
+def validate_single_page_jolpica(
+    payload: dict[str, Any],
+    leaf_keys: LeafKeys,
+) -> dict[str, Any]:
+    """Validate that one response contains its complete advertised result set."""
+    _, total, limit, offset = _metadata(payload, expected_offset=0)
+    keys = leaf_keys(payload)
+    if total > limit:
+        raise JolpicaPaginationError(
+            f"Jolpica single-page response advertises {total} leaves "
+            f"but its limit is {limit}"
+        )
+    if len(keys) != total or len(set(keys)) != total:
+        raise JolpicaPaginationError(
+            "Jolpica single-page response is incomplete: "
+            f"raw={len(keys)}, unique={len(set(keys))}, total={total}"
+        )
+    return payload
+
+
+def race_leaf_keys(payload: dict[str, Any]) -> list[Hashable]:
+    """Return race identities from a Jolpica RaceTable payload."""
+    races = payload.get("MRData", {}).get("RaceTable", {}).get("Races", [])
+    if not isinstance(races, list):
+        raise JolpicaPaginationError("Jolpica RaceTable.Races is not a list")
+    keys: list[Hashable] = []
+    for race in races:
+        if not isinstance(race, dict):
+            raise JolpicaPaginationError("Jolpica race entry is not an object")
+        season = str(race.get("season") or "").strip()
+        round_number = str(race.get("round") or "").strip()
+        if not season or not round_number:
+            raise JolpicaPaginationError("Jolpica race is missing its identity")
+        keys.append((season, round_number))
+    return keys
+
+
+def standings_leaf_keys(
+    payload: dict[str, Any],
+    collection: str,
+) -> list[Hashable]:
+    """Return driver or constructor identities from a standings payload."""
+    lists = (
+        payload.get("MRData", {}).get("StandingsTable", {}).get("StandingsLists", [])
+    )
+    if not isinstance(lists, list):
+        raise JolpicaPaginationError(
+            "Jolpica StandingsTable.StandingsLists is not a list"
+        )
+    identity_field = "Driver" if collection == "DriverStandings" else "Constructor"
+    identity_key = "driverId" if collection == "DriverStandings" else "constructorId"
+    keys: list[Hashable] = []
+    for standings_list in lists:
+        if not isinstance(standings_list, dict):
+            raise JolpicaPaginationError("Jolpica standings entry is not an object")
+        season = str(standings_list.get("season") or "").strip()
+        round_number = str(standings_list.get("round") or "").strip()
+        rows = standings_list.get(collection, [])
+        if not isinstance(rows, list):
+            raise JolpicaPaginationError(
+                f"Jolpica {collection} collection is not a list"
+            )
+        for row in rows:
+            identity = row.get(identity_field) if isinstance(row, dict) else None
+            identity_value = (
+                str(identity.get(identity_key) or "").strip()
+                if isinstance(identity, dict)
+                else ""
+            )
+            if not season or not round_number or not identity_value:
+                raise JolpicaPaginationError(
+                    f"Jolpica {collection} leaf is missing its identity"
+                )
+            keys.append((season, round_number, identity_value))
+    return keys
+
+
+def result_leaf_keys(
+    payload: dict[str, Any],
+    collection: str,
+) -> list[Hashable]:
+    """Return result-row identities from a Jolpica RaceTable payload."""
+    keys: list[Hashable] = []
+    races = (
+        payload.get("MRData", {}).get("RaceTable", {}).get("Races", [])
+        if isinstance(payload, dict)
+        else []
+    )
+    if not isinstance(races, list):
+        raise JolpicaPaginationError("Jolpica RaceTable.Races is not a list")
+    for race in races:
+        if not isinstance(race, dict):
+            raise JolpicaPaginationError("Jolpica race entry is not an object")
+        season = str(race.get("season") or "").strip()
+        round_number = str(race.get("round") or "").strip()
+        rows = race.get(collection, [])
+        if not isinstance(rows, list):
+            raise JolpicaPaginationError(
+                f"Jolpica {collection} collection is not a list"
+            )
+        for row in rows:
+            if not isinstance(row, dict):
+                raise JolpicaPaginationError(
+                    f"Jolpica {collection} entry is not an object"
+                )
+            driver = row.get("Driver")
+            driver_id = (
+                str(driver.get("driverId") or "").strip()
+                if isinstance(driver, dict)
+                else ""
+            )
+            if not season or not round_number or not driver_id:
+                raise JolpicaPaginationError(
+                    f"Jolpica {collection} leaf is missing its identity"
+                )
+            keys.append((season, round_number, driver_id))
+    return keys
+
+
+def lap_leaf_keys(payload: dict[str, Any]) -> list[Hashable]:
+    """Return lap-timing identities from a Jolpica RaceTable payload."""
+    keys: list[Hashable] = []
+    races = (
+        payload.get("MRData", {}).get("RaceTable", {}).get("Races", [])
+        if isinstance(payload, dict)
+        else []
+    )
+    if not isinstance(races, list):
+        raise JolpicaPaginationError("Jolpica RaceTable.Races is not a list")
+    for race in races:
+        if not isinstance(race, dict):
+            raise JolpicaPaginationError("Jolpica race entry is not an object")
+        laps = race.get("Laps", [])
+        if not isinstance(laps, list):
+            raise JolpicaPaginationError("Jolpica Laps collection is not a list")
+        for lap in laps:
+            if not isinstance(lap, dict):
+                raise JolpicaPaginationError("Jolpica lap entry is not an object")
+            lap_number = str(lap.get("number") or "").strip()
+            timings = lap.get("Timings", [])
+            if not isinstance(timings, list):
+                raise JolpicaPaginationError(
+                    "Jolpica lap Timings collection is not a list"
+                )
+            for timing in timings:
+                driver_id = (
+                    str(timing.get("driverId") or "").strip()
+                    if isinstance(timing, dict)
+                    else ""
+                )
+                if not lap_number or not driver_id:
+                    raise JolpicaPaginationError(
+                        "Jolpica lap timing is missing its identity"
+                    )
+                keys.append((lap_number, driver_id))
+    return keys
+
+
+def merge_result_pages(
+    result: JolpicaPaginationResult,
+    collection: str,
+) -> dict[str, Any]:
+    """Merge result rows split across API pages into deterministic races."""
+    races_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    race_table_metadata: dict[str, Any] = {}
+    for page in result.pages:
+        race_table = page.payload.get("MRData", {}).get("RaceTable", {})
+        if not isinstance(race_table, dict):
+            raise JolpicaPaginationError("Jolpica RaceTable is not an object")
+        if not race_table_metadata:
+            race_table_metadata = {
+                key: value for key, value in race_table.items() if key != "Races"
+            }
+        for race in race_table.get("Races", []):
+            key = (
+                str(race.get("season") or "").strip(),
+                str(race.get("round") or "").strip(),
+            )
+            existing = races_by_key.get(key)
+            if existing is None:
+                existing = dict(race)
+                existing[collection] = []
+                races_by_key[key] = existing
+            existing[collection].extend(race.get(collection, []))
+
+    def _number(value: Any) -> int:
+        try:
+            return int(str(value))
+        except (TypeError, ValueError):
+            return 2**31 - 1
+
+    races = list(races_by_key.values())
+    for race in races:
+        race[collection].sort(
+            key=lambda row: (
+                _number(row.get("position")),
+                str((row.get("Driver") or {}).get("driverId") or ""),
+            )
+        )
+    races.sort(
+        key=lambda race: (
+            _number(race.get("season")),
+            _number(race.get("round")),
+        )
+    )
+    return {
+        "MRData": {
+            "total": str(result.total),
+            "limit": str(min(JOLPICA_PAGE_SIZE, max(1, result.total))),
+            "offset": "0",
+            "RaceTable": {
+                **race_table_metadata,
+                "Races": races,
+            },
+        }
+    }
+
+
+def _metadata(
+    payload: Any,
+    *,
+    expected_offset: int,
+) -> tuple[dict[str, Any], int, int, int]:
+    """Return validated MRData pagination metadata."""
+    if not isinstance(payload, dict):
+        raise JolpicaPaginationError("Jolpica response is not an object")
+    mr_data = payload.get("MRData")
+    if not isinstance(mr_data, dict):
+        raise JolpicaPaginationError("Jolpica response is missing MRData")
+
+    values: dict[str, int] = {}
+    for field in ("total", "limit", "offset"):
+        raw = mr_data.get(field)
+        if isinstance(raw, bool):
+            raise JolpicaPaginationError(
+                f"Jolpica pagination field {field} is not numeric"
+            )
+        try:
+            value = int(str(raw))
+        except (TypeError, ValueError) as err:
+            raise JolpicaPaginationError(
+                f"Jolpica pagination field {field} is not numeric"
+            ) from err
+        if str(raw).strip() not in {str(value), f"+{value}"}:
+            raise JolpicaPaginationError(
+                f"Jolpica pagination field {field} is not an integer"
+            )
+        values[field] = value
+
+    total = values["total"]
+    limit = values["limit"]
+    offset = values["offset"]
+    if total < 0:
+        raise JolpicaPaginationError("Jolpica total cannot be negative")
+    if not 1 <= limit <= JOLPICA_PAGE_SIZE:
+        raise JolpicaPaginationError(
+            f"Jolpica page limit {limit} is outside the supported range"
+        )
+    if offset != expected_offset:
+        raise JolpicaPaginationError(
+            f"Jolpica returned offset {offset}, expected {expected_offset}"
+        )
+    if offset < 0:
+        raise JolpicaPaginationError("Jolpica offset cannot be negative")
+    return mr_data, total, limit, offset
+
+
+def _validate_page(
+    payload: dict[str, Any],
+    *,
+    expected_offset: int,
+    authoritative_total: int | None,
+    leaf_keys: LeafKeys,
+) -> JolpicaPage:
+    """Validate one probe or data page and return its leaf keys."""
+    _, total, limit, offset = _metadata(payload, expected_offset=expected_offset)
+    if authoritative_total is not None and total != authoritative_total:
+        raise _JolpicaTotalChanged(
+            f"Jolpica total changed from {authoritative_total} to {total}"
+        )
+
+    keys = leaf_keys(payload)
+    if not isinstance(keys, list):
+        raise JolpicaPaginationError("Jolpica leaf extractor returned invalid data")
+    expected_count = min(limit, max(0, total - offset))
+    if len(keys) != expected_count:
+        raise JolpicaPaginationError(
+            f"Jolpica page at offset {offset} contains {len(keys)} leaves, "
+            f"expected {expected_count}"
+        )
+    if len(set(keys)) != len(keys):
+        raise JolpicaPaginationError(
+            f"Jolpica page at offset {offset} contains duplicate leaves"
+        )
+    if expected_count == 0 and offset < total:
+        raise JolpicaPaginationError(
+            f"Jolpica returned an empty intermediate page at offset {offset}"
+        )
+    return JolpicaPage(payload, total, limit, offset, tuple(keys))
+
+
+async def _validated_fetch(
+    fetch_page: FetchPage,
+    *,
+    limit: int,
+    offset: int,
+    ttl_seconds: int,
+    authoritative_total: int | None,
+    leaf_keys: LeafKeys,
+    force_refresh: bool,
+) -> JolpicaPage:
+    """Fetch one page with validation applied before it can be cached."""
+
+    def _validator(payload: dict[str, Any]) -> None:
+        _validate_page(
+            payload,
+            expected_offset=offset,
+            authoritative_total=authoritative_total,
+            leaf_keys=leaf_keys,
+        )
+
+    payload = await fetch_page(
+        limit,
+        offset,
+        ttl_seconds,
+        force_refresh,
+        _validator,
+    )
+    return _validate_page(
+        payload,
+        expected_offset=offset,
+        authoritative_total=authoritative_total,
+        leaf_keys=leaf_keys,
+    )
+
+
+async def async_paginate_jolpica(
+    fetch_page: FetchPage,
+    leaf_keys: LeafKeys,
+    *,
+    ttl_stable: int,
+    ttl_recent: int,
+    ttl_latest: int,
+    ttl_probe: int | None = None,
+    page_cap: int = JOLPICA_PAGE_CAP,
+) -> JolpicaPaginationResult:
+    """Fetch all leaves atomically using a probe and strict page validation.
+
+    A total change causes one forced probe and one full restart. No page is
+    returned unless the raw and unique leaf counts match the authoritative total.
+    """
+    if page_cap < 1:
+        raise JolpicaPaginationError("Jolpica page cap must be positive")
+
+    last_total_error: _JolpicaTotalChanged | None = None
+    for collection_attempt in range(2):
+        force_probe = collection_attempt > 0
+        probe = await _validated_fetch(
+            fetch_page,
+            limit=1,
+            offset=0,
+            ttl_seconds=ttl_probe if ttl_probe is not None else ttl_latest,
+            authoritative_total=None,
+            leaf_keys=leaf_keys,
+            force_refresh=force_probe,
+        )
+        authoritative_total = probe.total
+        if authoritative_total == 0:
+            return JolpicaPaginationResult(total=0, pages=())
+
+        pages: list[JolpicaPage] = []
+        all_keys: list[Hashable] = []
+        offset = 0
+        seen_offsets: set[int] = set()
+
+        try:
+            while offset < authoritative_total:
+                if len(pages) >= page_cap:
+                    raise JolpicaPaginationError(
+                        f"Jolpica pagination exceeded the {page_cap}-page cap"
+                    )
+                if offset in seen_offsets:
+                    raise JolpicaPaginationError(
+                        f"Jolpica pagination repeated offset {offset}"
+                    )
+                seen_offsets.add(offset)
+
+                expected_last_offset = (
+                    (authoritative_total - 1) // JOLPICA_PAGE_SIZE
+                ) * JOLPICA_PAGE_SIZE
+                if offset >= expected_last_offset:
+                    ttl_seconds = ttl_latest
+                elif offset + (2 * JOLPICA_PAGE_SIZE) > authoritative_total:
+                    ttl_seconds = ttl_recent
+                else:
+                    ttl_seconds = ttl_stable
+
+                page = await _validated_fetch(
+                    fetch_page,
+                    limit=JOLPICA_PAGE_SIZE,
+                    offset=offset,
+                    ttl_seconds=ttl_seconds,
+                    authoritative_total=authoritative_total,
+                    leaf_keys=leaf_keys,
+                    force_refresh=force_probe,
+                )
+                pages.append(page)
+                all_keys.extend(page.leaf_keys)
+                next_offset = page.offset + page.limit
+                if next_offset <= offset:
+                    raise JolpicaPaginationError("Jolpica pagination did not advance")
+                offset = next_offset
+        except _JolpicaTotalChanged as err:
+            last_total_error = err
+            continue
+
+        raw_count = len(all_keys)
+        unique_count = len(set(all_keys))
+        if raw_count != authoritative_total or unique_count != authoritative_total:
+            raise JolpicaPaginationError(
+                "Jolpica pagination is incomplete: "
+                f"raw={raw_count}, unique={unique_count}, "
+                f"total={authoritative_total}"
+            )
+        return JolpicaPaginationResult(
+            total=authoritative_total,
+            pages=tuple(pages),
+        )
+
+    raise JolpicaPaginationError(
+        str(last_total_error or "Jolpica total changed repeatedly")
+    )

--- a/custom_components/f1_sensor/tests/test_button.py
+++ b/custom_components/f1_sensor/tests/test_button.py
@@ -22,23 +22,31 @@ from custom_components.f1_sensor.button import (
 from custom_components.f1_sensor.const import CONF_LIVE_TIMING_AUTH_HEADER, DOMAIN
 
 
-class _TimeoutSession:
-    def __init__(self) -> None:
-        self.headers = {"User-Agent": "session-ua"}
-        self.calls = 0
+class _TestJolpicaClient:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[str, dict[str, str], int, bool]] = []
 
-    def get(self, *_args, **_kwargs):
-        self.calls += 1
-        raise TimeoutError
+    async def async_get_json(
+        self,
+        url: str,
+        *,
+        params: dict[str, str],
+        timeout: int,
+        retry_on_rate_limit: bool,
+    ) -> dict:
+        self.calls.append((url, params, timeout, retry_on_rate_limit))
+        if self.error is not None:
+            raise self.error
+        return {"MRData": {}}
 
 
 @pytest.mark.asyncio
 async def test_jolpica_ua_button_timeout_reports_failure(hass, monkeypatch) -> None:
     entry_id = "entry-test"
-    session = _TimeoutSession()
+    client = _TestJolpicaClient(TimeoutError())
     hass.data.setdefault(DOMAIN, {})[entry_id] = {
-        "http_session": session,
-        "user_agent": "configured-ua",
+        "jolpica_client": client,
     }
 
     notifications = AsyncMock()
@@ -47,7 +55,7 @@ async def test_jolpica_ua_button_timeout_reports_failure(hass, monkeypatch) -> N
         notifications,
     )
     monkeypatch.setattr(
-        "custom_components.f1_sensor.button.time.time",
+        "custom_components.f1_sensor.button.time.monotonic",
         lambda: 10.0,
     )
 
@@ -60,12 +68,41 @@ async def test_jolpica_ua_button_timeout_reports_failure(hass, monkeypatch) -> N
 
     await button.async_press()
 
-    assert session.calls == 1
+    assert len(client.calls) == 1
+    _, params, timeout, retry_on_rate_limit = client.calls[0]
+    assert params == {"limit": "1", "offset": "0"}
+    assert timeout == 10
+    assert retry_on_rate_limit is False
     notifications.assert_awaited_once()
     message = notifications.await_args.args[1]
-    assert "Jolpica UA test FAILED" in message
-    assert "ua_configured='configured-ua'" in message
-    assert "ua_session='session-ua'" in message
+    assert "Jolpica API test FAILED" in message
+
+
+@pytest.mark.asyncio
+async def test_jolpica_ua_button_429_reports_failure(hass, monkeypatch) -> None:
+    entry_id = "entry-test"
+    client = _TestJolpicaClient(RuntimeError("HTTP 429 Too Many Requests"))
+    hass.data.setdefault(DOMAIN, {})[entry_id] = {
+        "jolpica_client": client,
+    }
+    notifications = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.button.persistent_notification.async_create",
+        notifications,
+    )
+
+    button = F1JolpicaUserAgentTestButton(
+        hass=hass,
+        unique_id=f"{entry_id}_jolpica_ua_test",
+        entry_id=entry_id,
+        device_name="F1",
+    )
+
+    await button.async_press()
+
+    notifications.assert_awaited_once()
+    assert "FAILED" in notifications.await_args.args[1]
+    assert "429" in notifications.await_args.args[1]
 
 
 @pytest.mark.asyncio
@@ -215,7 +252,7 @@ async def test_jolpica_ua_button_is_not_added_when_only_f1tv_auth_is_public(
     )
     entry.add_to_hass(hass)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        "http_session": _TimeoutSession()
+        "jolpica_client": _TestJolpicaClient()
     }
     added = []
 

--- a/custom_components/f1_sensor/tests/test_coordinator.py
+++ b/custom_components/f1_sensor/tests/test_coordinator.py
@@ -11,6 +11,7 @@ from custom_components.f1_sensor.__init__ import (
     F1DataCoordinator,
     F1LapPositionProgressionCoordinator,
     F1SeasonResultsCoordinator,
+    F1SprintResultsCoordinator,
     FiaDocumentsCoordinator,
     LiveSessionCoordinator,
 )
@@ -18,7 +19,10 @@ from custom_components.f1_sensor.const import (
     API_URL,
     FIA_SEASON_FALLBACK_URL,
     SEASON_RESULTS_URL,
+    SPRINT_RESULTS_URL,
 )
+from custom_components.f1_sensor.jolpica import JolpicaRouteNotFoundError
+from custom_components.f1_sensor.jolpica_pagination import JolpicaPaginationError
 
 
 class _TimeoutSession:
@@ -130,7 +134,14 @@ async def test_f1_data_coordinator_update(hass) -> None:
             persist_map={},
             persist_save=MagicMock(),
         )
-    payload = {"MRData": {"RaceTable": {"season": "2025", "Races": []}}}
+    payload = {
+        "MRData": {
+            "total": "0",
+            "limit": "100",
+            "offset": "0",
+            "RaceTable": {"season": "2025", "Races": []},
+        }
+    }
 
     mock_fetch = AsyncMock(return_value=payload)
     with pytest.MonkeyPatch().context() as monkeypatch:
@@ -219,20 +230,24 @@ async def test_season_results_coordinator_paginates_all_pages(hass) -> None:
         return {
             "season": "2025",
             "round": str(round_num),
-            "Results": [{"position": "1"}],
+            "Results": [
+                {
+                    "position": "1",
+                    "Driver": {"driverId": f"driver_{round_num}"},
+                }
+            ],
         }
 
     async def _fake_fetch_json(_hass, _session, url, **_kwargs):
         query = URL(url).query
+        requested_limit = int(query.get("limit") or "100")
         offset = int(query.get("offset") or "0")
-        response_limit = 2
+        response_limit = min(2, requested_limit)
         response_total = 4
-        if offset == 0:
-            races = [_race(1), _race(2)]
-        elif offset == 2:
-            races = [_race(3), _race(4)]
-        else:
-            races = []
+        races = [
+            _race(round_num)
+            for round_num in range(offset + 1, min(4, offset + response_limit) + 1)
+        ]
         return {
             "MRData": {
                 "total": str(response_total),
@@ -252,7 +267,158 @@ async def test_season_results_coordinator_paginates_all_pages(hass) -> None:
 
     races = data.get("MRData", {}).get("RaceTable", {}).get("Races", [])
     assert len(races) == 4
-    assert mock_fetch.await_count == 2
+    assert mock_fetch.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_season_results_timeout_keeps_previous_snapshot_without_fallback(
+    hass,
+) -> None:
+    coordinator = F1SeasonResultsCoordinator(
+        hass,
+        SEASON_RESULTS_URL,
+        "Test Season Results Coordinator",
+        session=MagicMock(),
+        user_agent="ua",
+        cache={},
+        inflight={},
+        persist_map={},
+        persist_save=MagicMock(),
+        season_source=_mock_data_coordinator(
+            {"MRData": {"RaceTable": {"season": "2025", "Races": []}}}
+        ),
+    )
+    previous = {"MRData": {"RaceTable": {"Races": [{"round": "1"}]}}}
+    coordinator.data = previous
+    mock_fetch = AsyncMock(side_effect=TimeoutError)
+
+    with (
+        patch("custom_components.f1_sensor.__init__.fetch_json", mock_fetch),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+
+    assert coordinator.data is previous
+    mock_fetch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_season_results_uses_current_fallback_only_for_route_not_found(
+    hass,
+) -> None:
+    coordinator = F1SeasonResultsCoordinator(
+        hass,
+        SEASON_RESULTS_URL,
+        "Test Season Results Coordinator",
+        session=MagicMock(),
+        user_agent="ua",
+        cache={},
+        inflight={},
+        persist_map={},
+        persist_save=MagicMock(),
+        season_source=_mock_data_coordinator(
+            {"MRData": {"RaceTable": {"season": "2025", "Races": []}}}
+        ),
+    )
+    urls: list[str] = []
+
+    async def _fake_fetch(_hass, _session, url, **_kwargs):
+        urls.append(url)
+        if "/ergast/f1/2025/" in url:
+            raise JolpicaRouteNotFoundError("missing season route")
+        query = URL(url).query
+        limit = int(query.get("limit") or "100")
+        return {
+            "MRData": {
+                "total": "1",
+                "limit": str(limit),
+                "offset": "0",
+                "RaceTable": {
+                    "Races": [
+                        {
+                            "season": "2025",
+                            "round": "1",
+                            "Results": [
+                                {
+                                    "position": "1",
+                                    "Driver": {"driverId": "driver_1"},
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        }
+
+    with patch(
+        "custom_components.f1_sensor.__init__.fetch_json",
+        AsyncMock(side_effect=_fake_fetch),
+    ):
+        data = await coordinator._async_update_data()
+
+    assert len(data["MRData"]["RaceTable"]["Races"]) == 1
+    assert len(urls) == 4
+    assert sum("/ergast/f1/2025/" in url for url in urls) == 2
+    assert sum("/ergast/f1/current/" in url for url in urls) == 2
+
+
+@pytest.mark.asyncio
+async def test_sprint_results_coordinator_keeps_all_120_rows(hass) -> None:
+    coordinator = F1SprintResultsCoordinator(
+        hass,
+        SPRINT_RESULTS_URL,
+        "Test Sprint Results Coordinator",
+        session=MagicMock(),
+        user_agent="ua",
+        cache={},
+        inflight={},
+        ttl_seconds=5,
+        persist_map={},
+        persist_save=MagicMock(),
+    )
+    drivers = [f"driver_{index}" for index in range(120)]
+
+    async def _fake_fetch_json(_hass, _session, url, **_kwargs):
+        query = URL(url).query
+        limit = int(query.get("limit") or "100")
+        offset = int(query.get("offset") or "0")
+        selected = drivers[offset : offset + limit]
+        return {
+            "MRData": {
+                "total": "120",
+                "limit": str(limit),
+                "offset": str(offset),
+                "RaceTable": {
+                    "season": "2025",
+                    "Races": [
+                        {
+                            "season": "2025",
+                            "round": "6",
+                            "SprintResults": [
+                                {
+                                    "position": str(offset + index + 1),
+                                    "Driver": {"driverId": driver_id},
+                                }
+                                for index, driver_id in enumerate(selected)
+                            ],
+                        }
+                    ],
+                },
+            }
+        }
+
+    mock_fetch = AsyncMock(side_effect=_fake_fetch_json)
+    with pytest.MonkeyPatch().context() as monkeypatch:
+        monkeypatch.setattr(
+            "custom_components.f1_sensor.__init__.fetch_json",
+            mock_fetch,
+        )
+        data = await coordinator._async_update_data()
+
+    races = data["MRData"]["RaceTable"]["Races"]
+    assert len(races) == 1
+    assert len(races[0]["SprintResults"]) == 120
+    assert mock_fetch.await_count == 3
 
 
 @pytest.mark.asyncio
@@ -277,32 +443,27 @@ async def test_lap_position_progression_coordinator_paginates_and_merges_laps(
 
     async def _fake_fetch_json(_hass, _session, url, **_kwargs):
         query = URL(url).query
+        requested_limit = int(query.get("limit") or "100")
         offset = int(query.get("offset") or "0")
-        if offset == 0:
-            laps = [
-                {
-                    "number": "1",
-                    "Timings": [
-                        {"driverId": "norris", "position": "1"},
-                        {"driverId": "verstappen", "position": "2"},
-                    ],
-                },
-                {
-                    "number": "2",
-                    "Timings": [{"driverId": "norris", "position": "2"}],
-                },
-            ]
-        else:
-            laps = [
-                {
-                    "number": "2",
-                    "Timings": [{"driverId": "verstappen", "position": "1"}],
-                }
-            ]
+        response_limit = min(3, requested_limit)
+        all_timings = [
+            ("1", {"driverId": "norris", "position": "1"}),
+            ("1", {"driverId": "verstappen", "position": "2"}),
+            ("2", {"driverId": "norris", "position": "2"}),
+            ("2", {"driverId": "verstappen", "position": "1"}),
+        ]
+        selected = all_timings[offset : offset + response_limit]
+        timings_by_lap = {}
+        for lap_number, timing in selected:
+            timings_by_lap.setdefault(lap_number, []).append(timing)
+        laps = [
+            {"number": lap_number, "Timings": timings}
+            for lap_number, timings in timings_by_lap.items()
+        ]
         return {
             "MRData": {
                 "total": "4",
-                "limit": "3",
+                "limit": str(response_limit),
                 "offset": str(offset),
                 "RaceTable": {
                     "season": "2026",
@@ -331,7 +492,7 @@ async def test_lap_position_progression_coordinator_paginates_and_merges_laps(
     session = data["session"]
     assert session["status"] == "available"
     assert session["labels"] == ["L1", "L2"]
-    assert mock_fetch.await_count == 2
+    assert mock_fetch.await_count == 3
 
     drivers = {driver["code"]: driver for driver in session["drivers"]}
     assert drivers["NOR"]["positions"] == [1, 2]
@@ -397,7 +558,7 @@ async def test_lap_position_progression_coordinator_marks_pending_when_laps_miss
         return_value={
             "MRData": {
                 "total": "0",
-                "limit": "100",
+                "limit": "1",
                 "offset": "0",
                 "RaceTable": {"Races": []},
             }
@@ -412,6 +573,69 @@ async def test_lap_position_progression_coordinator_marks_pending_when_laps_miss
 
     assert data["session"]["status"] == "pending"
     assert data["session"]["reason"]
+    assert mock_fetch.await_args.kwargs["ttl_seconds"] == coordinator._ttl_pending
+
+
+@pytest.mark.asyncio
+async def test_lap_position_failure_reuses_only_previous_complete_session(hass) -> None:
+    coordinator = F1LapPositionProgressionCoordinator(
+        hass,
+        _mock_data_coordinator(None),
+        _mock_data_coordinator(_lap_position_season_payload()),
+        _mock_data_coordinator(None),
+        "Test Lap Position Progression Coordinator",
+        session=MagicMock(),
+        user_agent="ua",
+        cache={},
+        inflight={},
+        persist_map={},
+        persist_save=MagicMock(),
+    )
+    previous = {
+        "key": "race:2026:1",
+        "status": "available",
+        "labels": ["L1"],
+        "drivers": [{"driver_id": "norris", "positions": [1]}],
+        "series": {"labels": ["L1"], "series": []},
+    }
+    coordinator._session_payload_cache["race:2026:1"] = previous
+
+    with patch(
+        "custom_components.f1_sensor.__init__.fetch_json",
+        AsyncMock(side_effect=JolpicaPaginationError("incomplete laps")),
+    ):
+        data = await coordinator.async_get_session("race:2026:1")
+
+    assert data["cached"] is True
+    assert data["session"] is previous
+    assert data["warning"] == "incomplete laps"
+
+
+@pytest.mark.asyncio
+async def test_lap_position_failure_without_complete_cache_returns_error(hass) -> None:
+    coordinator = F1LapPositionProgressionCoordinator(
+        hass,
+        _mock_data_coordinator(None),
+        _mock_data_coordinator(_lap_position_season_payload()),
+        _mock_data_coordinator(None),
+        "Test Lap Position Progression Coordinator",
+        session=MagicMock(),
+        user_agent="ua",
+        cache={},
+        inflight={},
+        persist_map={},
+        persist_save=MagicMock(),
+    )
+
+    with patch(
+        "custom_components.f1_sensor.__init__.fetch_json",
+        AsyncMock(side_effect=JolpicaPaginationError("incomplete laps")),
+    ):
+        data = await coordinator.async_get_session("race:2026:1")
+
+    assert data["status"] == "error"
+    assert data["session"]["status"] == "error"
+    assert data["session"]["labels"] == []
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_diagnostics.py
+++ b/custom_components/f1_sensor/tests/test_diagnostics.py
@@ -223,3 +223,56 @@ async def test_diagnostics_hides_auth_state_when_f1tv_auth_disabled(
     }
     assert CONF_LIVE_TIMING_AUTH_HEADER not in payload["entry"]["data"]
     assert "secret-token" not in str(payload)
+
+
+async def test_diagnostics_exposes_only_safe_jolpica_runtime_scalars(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="F1",
+        data={CONF_OPERATION_MODE: OPERATION_MODE_LIVE},
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.diagnostics.return_value = {
+        "user_agent_configured": True,
+        "second_limit": 3,
+        "hour_limit": 450,
+        "max_queue_wait_seconds": 5.0,
+        "requests_last_second": 2,
+        "requests_last_hour": 27,
+        "queue_length": 1,
+        "blocked_requests": 4,
+        "cooldown_remaining_seconds": 5.5,
+        "latest_429": "2026-07-28T10:00:00+00:00",
+        "cache_entries": 8,
+        "inflight_requests": 1,
+        "request_urls": ["https://api.jolpi.ca/ergast/f1/current.json"],
+        "headers": {"User-Agent": "must-not-be-exposed"},
+        "cache_keys": ["sensitive-request-key"],
+    }
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "operation_mode": OPERATION_MODE_LIVE,
+        "jolpica_client": client,
+        "http_cache": {"first": object(), "second": object()},
+    }
+
+    payload = await diagnostics_module.async_get_config_entry_diagnostics(hass, entry)
+
+    assert payload["runtime"]["jolpica"] == {
+        "user_agent_configured": True,
+        "second_limit": 3,
+        "hour_limit": 450,
+        "max_queue_wait_seconds": 5.0,
+        "requests_last_second": 2,
+        "requests_last_hour": 27,
+        "queue_length": 1,
+        "blocked_requests": 4,
+        "cooldown_remaining_seconds": 5.5,
+        "latest_429": "2026-07-28T10:00:00+00:00",
+        "cache_entries": 2,
+        "inflight_requests": 1,
+    }
+    assert "api.jolpi.ca" not in str(payload)
+    assert "must-not-be-exposed" not in str(payload)
+    assert "sensitive-request-key" not in str(payload)

--- a/custom_components/f1_sensor/tests/test_helpers.py
+++ b/custom_components/f1_sensor/tests/test_helpers.py
@@ -5,6 +5,7 @@ import base64
 from datetime import UTC, datetime
 import gc
 import json
+import time
 from types import TracebackType
 from unittest.mock import AsyncMock, MagicMock
 import zlib
@@ -12,6 +13,7 @@ import zlib
 import pytest
 
 from custom_components.f1_sensor.__init__ import FiaDocumentsCoordinator
+from custom_components.f1_sensor.const import DOMAIN
 from custom_components.f1_sensor.helpers import (
     CARDATA_MAX_DECOMPRESSED_BYTES,
     CARDATA_MAX_ENTRIES,
@@ -21,6 +23,7 @@ from custom_components.f1_sensor.helpers import (
     parse_cardata_line,
     parse_fia_documents,
 )
+from custom_components.f1_sensor.jolpica import JOLPICA_CLIENT_KEY
 
 
 class _TimeoutResponse:
@@ -35,6 +38,29 @@ class _TimeoutResponse:
     ) -> bool:
         del exc_type, exc, tb
         return False
+
+
+class _JsonResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        del exc_type, exc, tb
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def text(self) -> str:
+        return json.dumps(self._payload)
 
 
 def _future_race_payload() -> dict:
@@ -175,6 +201,95 @@ async def test_http_fetch_helpers_drain_unretrieved_future_exceptions(
         hass.loop.set_exception_handler(previous_handler)
 
     assert contexts == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_evicts_invalid_cached_page_before_one_refetch(hass) -> None:
+    url = "https://example.com/page"
+    invalid = {"valid": False}
+    valid = {"valid": True}
+    cache = {url: (time.monotonic() + 60, invalid)}
+    persisted = {url: {"data": invalid, "saved_at": time.time()}}
+    persist_save = MagicMock()
+    session = MagicMock()
+    session.get.return_value = _JsonResponse(valid)
+
+    def _validate(payload: dict) -> None:
+        if payload.get("valid") is not True:
+            raise ValueError("invalid page")
+
+    result = await fetch_json(
+        hass,
+        session,
+        url,
+        ttl_seconds=123,
+        cache=cache,
+        inflight={},
+        persist_map=persisted,
+        persist_save=persist_save,
+        validator=_validate,
+    )
+
+    assert result == valid
+    session.get.assert_called_once()
+    assert cache[url][1] == valid
+    assert persisted[url]["data"] == valid
+    assert persisted[url]["ttl_seconds"] == 123
+    assert persist_save.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_never_caches_invalid_fresh_page(hass) -> None:
+    url = "https://example.com/page"
+    cache = {}
+    persisted = {}
+    session = MagicMock()
+    session.get.return_value = _JsonResponse({"valid": False})
+
+    def _validate(payload: dict) -> None:
+        if payload.get("valid") is not True:
+            raise ValueError("invalid page")
+
+    with pytest.raises(ValueError, match="invalid page"):
+        await fetch_json(
+            hass,
+            session,
+            url,
+            cache=cache,
+            inflight={},
+            persist_map=persisted,
+            validator=_validate,
+        )
+
+    assert cache == {}
+    assert persisted == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_routes_jolpica_only_through_shared_client(hass) -> None:
+    client = MagicMock()
+    client.async_get_json = AsyncMock(return_value={"MRData": {}})
+    hass.data.setdefault(DOMAIN, {})[JOLPICA_CLIENT_KEY] = client
+    session = MagicMock()
+
+    result = await fetch_json(
+        hass,
+        session,
+        "https://api.jolpi.ca/ergast/f1/current.json",
+        params={"limit": "1", "offset": "0"},
+        headers={"User-Agent": "must-not-be-used"},
+        cache={},
+        inflight={},
+        persist_map={},
+    )
+
+    assert result == {"MRData": {}}
+    client.async_get_json.assert_awaited_once_with(
+        "https://api.jolpi.ca/ergast/f1/current.json",
+        params={"limit": "1", "offset": "0"},
+        timeout=30,
+    )
+    session.get.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_jolpica.py
+++ b/custom_components/f1_sensor/tests/test_jolpica.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
+import json
+import time
+from unittest.mock import AsyncMock, patch
+
+from aiohttp import ClientConnectionError, ClientResponseError
+import pytest
+
+from custom_components.f1_sensor.jolpica import (
+    JolpicaClient,
+    JolpicaConfigurationError,
+    JolpicaHTTPError,
+    JolpicaInvalidRequestError,
+    JolpicaRateLimitError,
+    JolpicaRouteNotFoundError,
+    JolpicaTemporaryError,
+)
+
+_URL = "https://api.jolpi.ca/ergast/f1/current.json"
+_USER_AGENT = "HomeAssistantF1Sensor/1.0.0 HomeAssistant/2026.7.0"
+
+
+class _Response:
+    def __init__(
+        self,
+        status: int = 200,
+        *,
+        payload: object | None = None,
+        headers: dict[str, str] | None = None,
+        gate: asyncio.Event | None = None,
+    ) -> None:
+        self.status = status
+        self.headers = headers or {}
+        self._payload = payload if payload is not None else {"MRData": {}}
+        self._gate = gate
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise ClientResponseError(
+                None,
+                (),
+                status=self.status,
+                message=f"HTTP {self.status}",
+                headers=self.headers,
+            )
+
+    async def text(self) -> str:
+        if self._gate is not None:
+            await self._gate.wait()
+        return json.dumps(self._payload)
+
+
+class _Session:
+    def __init__(
+        self,
+        responses: list[_Response] | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self.responses = list(responses or [_Response()])
+        self.error = error
+        self.calls: list[dict[str, object]] = []
+
+    def get(self, url, *, params=None, headers=None, allow_redirects=True):
+        self.calls.append(
+            {
+                "url": url,
+                "params": params,
+                "headers": headers,
+                "allow_redirects": allow_redirects,
+            }
+        )
+        if self.error is not None:
+            raise self.error
+        if not self.responses:
+            raise AssertionError("Unexpected request")
+        return self.responses.pop(0)
+
+
+async def _client(hass, session: _Session, **kwargs) -> JolpicaClient:
+    client = JolpicaClient(hass, session, _USER_AGENT, **kwargs)
+    with patch.object(client._store, "async_load", AsyncMock(return_value=None)):
+        await client.async_initialize()
+    return client
+
+
+async def test_requires_canonical_user_agent(hass) -> None:
+    client = JolpicaClient(hass, _Session(), "Python/3")
+    with (
+        patch.object(client._store, "async_load", AsyncMock(return_value=None)),
+        pytest.raises(JolpicaConfigurationError),
+    ):
+        await client.async_initialize()
+
+
+@pytest.mark.parametrize(
+    ("url", "params"),
+    [
+        ("http://api.jolpi.ca/ergast/f1/current.json", None),
+        ("https://www.api.jolpi.ca/ergast/f1/current.json", None),
+        ("https://api.jolpi.ca:443/ergast/f1/current.json", None),
+        (_URL, {"limit": 101}),
+        (_URL, {"limit": 0}),
+        (f"{_URL}?limit=200", None),
+    ],
+)
+async def test_rejects_noncanonical_or_excessive_requests(
+    hass, url: str, params: dict[str, int] | None
+) -> None:
+    session = _Session()
+    client = await _client(hass, session)
+
+    with pytest.raises(JolpicaInvalidRequestError):
+        await client.async_get_json(url, params=params)
+
+    assert session.calls == []
+
+
+async def test_identical_concurrent_requests_are_coalesced_and_shielded(hass) -> None:
+    gate = asyncio.Event()
+    session = _Session([_Response(gate=gate)])
+    client = await _client(hass, session)
+
+    first = asyncio.create_task(
+        client.async_get_json(_URL, params={"limit": 1, "offset": 0})
+    )
+    second = asyncio.create_task(
+        client.async_get_json(_URL, params={"offset": 0, "limit": 1})
+    )
+    await asyncio.sleep(0)
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    gate.set()
+    assert await second == {"MRData": {}}
+    assert len(session.calls) == 1
+    assert session.calls[0]["headers"] == {"User-Agent": _USER_AGENT}
+    assert session.calls[0]["allow_redirects"] is False
+
+
+async def test_five_concurrent_requests_respect_second_limit(hass) -> None:
+    session = _Session([_Response() for _ in range(5)])
+    client = await _client(hass, session)
+
+    with patch("custom_components.f1_sensor.jolpica._SECOND_WINDOW", 0.01):
+        await asyncio.gather(
+            *(
+                client.async_get_json(
+                    _URL,
+                    params={"limit": 1, "offset": offset},
+                )
+                for offset in range(5)
+            )
+        )
+
+    assert len(session.calls) == 5
+    assert all(call["headers"] == {"User-Agent": _USER_AGENT} for call in session.calls)
+    assert client.diagnostics()["requests_last_hour"] == 5
+
+
+async def test_451st_hourly_attempt_is_blocked_without_network(hass) -> None:
+    session = _Session()
+    client = await _client(hass, session, max_queue_wait=0.001)
+    client._hour_requests.extend([time.time()] * 450)
+
+    with pytest.raises(JolpicaRateLimitError) as raised:
+        await client.async_get_json(_URL, params={"limit": 1})
+
+    assert raised.value.source == "local"
+    assert session.calls == []
+    assert client.diagnostics()["blocked_requests"] == 1
+
+
+async def test_diagnostics_count_entry_cache_without_exposing_keys(hass) -> None:
+    client = await _client(hass, _Session())
+    hass.data.setdefault("f1_sensor", {})["entry"] = {
+        "http_cache": {"private-request-a": object(), "private-request-b": object()}
+    }
+
+    diagnostics = client.diagnostics()
+
+    assert diagnostics["cache_entries"] == 2
+    assert "private-request-a" not in str(diagnostics)
+
+
+async def test_numeric_retry_after_retries_once(hass) -> None:
+    session = _Session(
+        [
+            _Response(429, headers={"Retry-After": "0"}),
+            _Response(payload={"ok": True}),
+        ]
+    )
+    client = await _client(hass, session)
+
+    assert await client.async_get_json(_URL, params={"limit": 1}) == {"ok": True}
+    assert len(session.calls) == 2
+    assert client.diagnostics()["requests_last_hour"] == 2
+    assert client.diagnostics()["latest_429"] is not None
+
+
+async def test_second_429_is_not_retried(hass) -> None:
+    session = _Session(
+        [
+            _Response(429, headers={"Retry-After": "0"}),
+            _Response(429, headers={"Retry-After": "0"}),
+        ]
+    )
+    client = await _client(hass, session)
+
+    with pytest.raises(JolpicaRateLimitError) as raised:
+        await client.async_get_json(_URL, params={"limit": 1})
+
+    assert raised.value.source == "server"
+    assert len(session.calls) == 2
+
+
+async def test_rate_limit_retry_can_be_disabled_for_diagnostic_request(
+    hass,
+) -> None:
+    session = _Session(
+        [
+            _Response(429, headers={"Retry-After": "0"}),
+            _Response(payload={"would": "hide the rate limit"}),
+        ]
+    )
+    client = await _client(hass, session)
+
+    with pytest.raises(JolpicaRateLimitError):
+        await client.async_get_json(
+            _URL,
+            params={"limit": 1},
+            retry_on_rate_limit=False,
+        )
+
+    assert len(session.calls) == 1
+
+
+def test_retry_after_supports_http_date_and_missing_backoff() -> None:
+    now = datetime.now(tz=UTC).replace(microsecond=0)
+    future = now + timedelta(seconds=8)
+    delay = JolpicaClient._parse_retry_after(
+        format_datetime(future, usegmt=True), now=now.timestamp()
+    )
+    assert delay == 8
+    assert JolpicaClient._parse_retry_after(None, now=now.timestamp()) is None
+
+
+async def test_missing_retry_after_backoff_is_shared_and_capped(hass) -> None:
+    client = await _client(hass, _Session())
+
+    delays = []
+    for _ in range(8):
+        client._cooldown_until = 0
+        delays.append(client._record_server_limit(None))
+
+    assert delays == [1, 2, 4, 8, 16, 32, 60, 60]
+    with patch.object(client._store, "async_save", AsyncMock()):
+        await client.async_close()
+
+
+async def test_missing_retry_after_uses_backoff_without_retry_past_budget(
+    hass,
+) -> None:
+    session = _Session([_Response(429)])
+    client = await _client(hass, session)
+
+    with pytest.raises(JolpicaRateLimitError) as raised:
+        await client.async_get_json(_URL, params={"limit": 1}, timeout=0.01)
+
+    assert raised.value.retry_after == 1
+    assert len(session.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("status", "exception_type"),
+    [
+        (302, JolpicaHTTPError),
+        (404, JolpicaRouteNotFoundError),
+        (400, JolpicaHTTPError),
+        (500, JolpicaHTTPError),
+    ],
+)
+async def test_http_errors_are_not_retried(
+    hass, status: int, exception_type: type[Exception]
+) -> None:
+    session = _Session([_Response(status)])
+    client = await _client(hass, session)
+
+    with pytest.raises(exception_type):
+        await client.async_get_json(_URL, params={"limit": 1})
+
+    assert len(session.calls) == 1
+
+
+async def test_network_errors_are_not_retried(hass) -> None:
+    session = _Session(error=ClientConnectionError("offline"))
+    client = await _client(hass, session)
+
+    with pytest.raises(JolpicaTemporaryError):
+        await client.async_get_json(_URL, params={"limit": 1})
+
+    assert len(session.calls) == 1
+
+
+async def test_persisted_budget_and_cooldown_survive_reload(hass) -> None:
+    now = time.time()
+    stored = {
+        "request_timestamps": [now - 30, now - 10],
+        "cooldown_until": now + 30,
+        "backoff_step": 3,
+        "latest_429": now - 1,
+    }
+    client = JolpicaClient(hass, _Session(), _USER_AGENT)
+    with patch.object(client._store, "async_load", AsyncMock(return_value=stored)):
+        await client.async_initialize()
+
+    diagnostics = client.diagnostics()
+    assert diagnostics["requests_last_hour"] == 2
+    assert diagnostics["cooldown_remaining_seconds"] > 0
+    assert diagnostics["latest_429"] is not None
+
+    save = AsyncMock()
+    with patch.object(client._store, "async_save", save):
+        await client.async_close()
+    payload = save.await_args.args[0]
+    assert len(payload["request_timestamps"]) == 2
+    assert payload["cooldown_until"] == stored["cooldown_until"]
+
+
+async def test_close_cancels_inflight_request_and_flushes_once(hass) -> None:
+    gate = asyncio.Event()
+    client = await _client(hass, _Session([_Response(gate=gate)]))
+    request = asyncio.create_task(client.async_get_json(_URL, params={"limit": 1}))
+    await asyncio.sleep(0)
+
+    save = AsyncMock()
+    with patch.object(client._store, "async_save", save):
+        await client.async_close()
+
+    with pytest.raises(asyncio.CancelledError):
+        await request
+    save.assert_awaited_once()

--- a/custom_components/f1_sensor/tests/test_jolpica_pagination.py
+++ b/custom_components/f1_sensor/tests/test_jolpica_pagination.py
@@ -1,0 +1,446 @@
+"""Contract tests for strict Jolpica pagination."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+from typing import Any
+
+import pytest
+
+from custom_components.f1_sensor.jolpica_pagination import (
+    JolpicaPaginationError,
+    async_paginate_jolpica,
+    lap_leaf_keys,
+    merge_result_pages,
+    result_leaf_keys,
+)
+
+
+def _result_payload(
+    *,
+    total: int,
+    limit: int,
+    offset: int,
+    driver_ids: list[str],
+    collection: str = "Results",
+) -> dict[str, Any]:
+    return {
+        "MRData": {
+            "total": str(total),
+            "limit": str(limit),
+            "offset": str(offset),
+            "RaceTable": {
+                "season": "2025",
+                "Races": [
+                    {
+                        "season": "2025",
+                        "round": "6",
+                        "raceName": "Miami Grand Prix",
+                        collection: [
+                            {
+                                "position": str(index + offset + 1),
+                                "Driver": {"driverId": driver_id},
+                            }
+                            for index, driver_id in enumerate(driver_ids)
+                        ],
+                    }
+                ]
+                if driver_ids
+                else [],
+            },
+        }
+    }
+
+
+def _result_fetcher(
+    driver_ids: list[str],
+    *,
+    server_limit: int = 100,
+    collection: str = "Results",
+):
+    calls: list[tuple[int, int, int, bool]] = []
+
+    async def _fetch(
+        limit: int,
+        offset: int,
+        ttl: int,
+        force_refresh: bool,
+        validator,
+    ) -> dict[str, Any]:
+        calls.append((limit, offset, ttl, force_refresh))
+        response_limit = min(limit, server_limit)
+        rows = driver_ids[offset : offset + response_limit]
+        payload = _result_payload(
+            total=len(driver_ids),
+            limit=response_limit,
+            offset=offset,
+            driver_ids=rows,
+            collection=collection,
+        )
+        validator(payload)
+        return payload
+
+    return _fetch, calls
+
+
+@pytest.mark.asyncio
+async def test_results_over_100_merge_one_race_split_between_pages() -> None:
+    drivers = [f"driver_{index}" for index in range(120)]
+    fetch, calls = _result_fetcher(drivers)
+
+    paginated = await async_paginate_jolpica(
+        fetch,
+        lambda payload: result_leaf_keys(payload, "Results"),
+        ttl_stable=300,
+        ttl_recent=200,
+        ttl_latest=100,
+    )
+    payload = merge_result_pages(paginated, "Results")
+
+    races = payload["MRData"]["RaceTable"]["Races"]
+    assert paginated.total == 120
+    assert len(races) == 1
+    assert len(races[0]["Results"]) == 120
+    assert [(limit, offset) for limit, offset, _, _ in calls] == [
+        (1, 0),
+        (100, 0),
+        (100, 100),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_server_limit_below_100_advances_by_returned_limit() -> None:
+    drivers = [f"driver_{index}" for index in range(5)]
+    fetch, calls = _result_fetcher(drivers, server_limit=2)
+
+    result = await async_paginate_jolpica(
+        fetch,
+        lambda payload: result_leaf_keys(payload, "Results"),
+        ttl_stable=300,
+        ttl_recent=200,
+        ttl_latest=100,
+    )
+
+    assert result.total == 5
+    assert [(limit, offset) for limit, offset, _, _ in calls] == [
+        (1, 0),
+        (100, 0),
+        (100, 2),
+        (100, 4),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sprint_120_rows_are_complete() -> None:
+    drivers = [f"sprint_driver_{index}" for index in range(120)]
+    fetch, _ = _result_fetcher(drivers, collection="SprintResults")
+
+    paginated = await async_paginate_jolpica(
+        fetch,
+        lambda payload: result_leaf_keys(payload, "SprintResults"),
+        ttl_stable=300,
+        ttl_recent=200,
+        ttl_latest=100,
+    )
+    payload = merge_result_pages(paginated, "SprintResults")
+
+    assert len(payload["MRData"]["RaceTable"]["Races"][0]["SprintResults"]) == 120
+
+
+@pytest.mark.asyncio
+async def test_lap_split_between_pages_merges_unique_timings() -> None:
+    timings = [
+        ("1", "driver_a"),
+        ("1", "driver_b"),
+        ("2", "driver_a"),
+        ("2", "driver_b"),
+    ]
+
+    async def _fetch(
+        limit: int,
+        offset: int,
+        _ttl: int,
+        _force_refresh: bool,
+        validator,
+    ) -> dict[str, Any]:
+        response_limit = min(limit, 3)
+        selected = timings[offset : offset + response_limit]
+        laps: dict[str, list[dict[str, str]]] = {}
+        for lap_number, driver_id in selected:
+            laps.setdefault(lap_number, []).append(
+                {"driverId": driver_id, "position": "1"}
+            )
+        payload = {
+            "MRData": {
+                "total": "4",
+                "limit": str(response_limit),
+                "offset": str(offset),
+                "RaceTable": {
+                    "Races": [
+                        {
+                            "season": "2025",
+                            "round": "1",
+                            "Laps": [
+                                {"number": number, "Timings": values}
+                                for number, values in laps.items()
+                            ],
+                        }
+                    ]
+                },
+            }
+        }
+        validator(payload)
+        return payload
+
+    result = await async_paginate_jolpica(
+        _fetch,
+        lap_leaf_keys,
+        ttl_stable=300,
+        ttl_recent=200,
+        ttl_latest=100,
+    )
+
+    assert [key for page in result.pages for key in page.leaf_keys] == timings
+
+
+@pytest.mark.asyncio
+async def test_total_change_forces_one_full_restart() -> None:
+    calls = 0
+
+    async def _fetch(
+        limit: int,
+        offset: int,
+        _ttl: int,
+        force_refresh: bool,
+        validator,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        total = 3 if force_refresh or calls > 1 else 2
+        ids = [f"driver_{index}" for index in range(total)][offset : offset + limit]
+        payload = _result_payload(
+            total=total,
+            limit=limit,
+            offset=offset,
+            driver_ids=ids,
+        )
+        validator(payload)
+        return payload
+
+    result = await async_paginate_jolpica(
+        _fetch,
+        lambda payload: result_leaf_keys(payload, "Results"),
+        ttl_stable=300,
+        ttl_recent=200,
+        ttl_latest=100,
+    )
+
+    assert result.total == 3
+    assert calls == 4
+
+
+@pytest.mark.asyncio
+async def test_second_total_change_fails_closed() -> None:
+    calls = 0
+
+    async def _fetch(
+        limit: int,
+        offset: int,
+        _ttl: int,
+        _force_refresh: bool,
+        validator,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        total = (2, 3, 3, 4)[calls - 1]
+        ids = [f"driver_{index}" for index in range(total)][offset : offset + limit]
+        payload = _result_payload(
+            total=total,
+            limit=limit,
+            offset=offset,
+            driver_ids=ids,
+        )
+        validator(payload)
+        return payload
+
+    with pytest.raises(JolpicaPaginationError, match="total changed"):
+        await async_paginate_jolpica(
+            _fetch,
+            lambda payload: result_leaf_keys(payload, "Results"),
+            ttl_stable=300,
+            ttl_recent=200,
+            ttl_latest=100,
+        )
+
+    assert calls == 4
+
+
+@pytest.mark.asyncio
+async def test_empty_intermediate_page_fails_closed() -> None:
+    async def _fetch(
+        limit: int,
+        offset: int,
+        _ttl: int,
+        _force_refresh: bool,
+        validator,
+    ) -> dict[str, Any]:
+        ids = ["driver_0"] if limit == 1 else []
+        payload = _result_payload(
+            total=150,
+            limit=limit,
+            offset=offset,
+            driver_ids=ids,
+        )
+        validator(payload)
+        return payload
+
+    with pytest.raises(JolpicaPaginationError, match="contains 0 leaves"):
+        await async_paginate_jolpica(
+            _fetch,
+            lambda payload: result_leaf_keys(payload, "Results"),
+            ttl_stable=300,
+            ttl_recent=200,
+            ttl_latest=100,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("limit", "0"),
+        ("limit", "101"),
+        ("offset", "7"),
+        ("total", "invalid"),
+    ],
+)
+async def test_invalid_metadata_fails_closed_after_one_forced_refetch(
+    field: str,
+    value: str,
+) -> None:
+    calls: list[bool] = []
+
+    async def _fetch(
+        limit: int,
+        offset: int,
+        _ttl: int,
+        force_refresh: bool,
+        validator,
+    ) -> dict[str, Any]:
+        calls.append(force_refresh)
+        payload = _result_payload(
+            total=1,
+            limit=limit,
+            offset=offset,
+            driver_ids=["driver_0"],
+        )
+        payload["MRData"][field] = value
+        validator(payload)
+        return payload
+
+    with pytest.raises(JolpicaPaginationError):
+        await async_paginate_jolpica(
+            _fetch,
+            lambda payload: result_leaf_keys(payload, "Results"),
+            ttl_stable=300,
+            ttl_recent=200,
+            ttl_latest=100,
+        )
+
+    assert calls == [False]
+
+
+@pytest.mark.asyncio
+async def test_invalid_cached_page_is_refetched_once() -> None:
+    calls: list[tuple[int, bool]] = []
+
+    async def _fetch(
+        limit: int,
+        offset: int,
+        _ttl: int,
+        force_refresh: bool,
+        validator,
+    ) -> dict[str, Any]:
+        calls.append((offset, force_refresh))
+        ids = ["driver_0"] if limit == 1 else ["driver_0", "driver_1"]
+        if limit != 1 and not force_refresh:
+            stale = _result_payload(
+                total=2,
+                limit=limit,
+                offset=offset,
+                driver_ids=["driver_0"],
+            )
+            with pytest.raises(JolpicaPaginationError):
+                validator(stale)
+            calls.append((offset, True))
+        payload = _result_payload(
+            total=2,
+            limit=limit,
+            offset=offset,
+            driver_ids=ids,
+        )
+        validator(payload)
+        return payload
+
+    result = await async_paginate_jolpica(
+        _fetch,
+        lambda payload: result_leaf_keys(payload, "Results"),
+        ttl_stable=300,
+        ttl_recent=200,
+        ttl_latest=100,
+    )
+
+    assert result.total == 2
+    assert calls == [(0, False), (0, False), (0, True)]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_or_gap_never_returns_collected_partial_data() -> None:
+    keys: list[Hashable] = [
+        ("2025", "1", "driver_a"),
+        ("2025", "1", "driver_a"),
+    ]
+
+    async def _fetch(
+        limit: int,
+        offset: int,
+        _ttl: int,
+        _force_refresh: bool,
+        validator,
+    ) -> dict[str, Any]:
+        selected = keys[offset : offset + limit]
+        payload = _result_payload(
+            total=2,
+            limit=limit,
+            offset=offset,
+            driver_ids=[str(key[2]) for key in selected],
+        )
+        validator(payload)
+        return payload
+
+    with pytest.raises(JolpicaPaginationError, match="duplicate|incomplete"):
+        await async_paginate_jolpica(
+            _fetch,
+            lambda payload: result_leaf_keys(payload, "Results"),
+            ttl_stable=300,
+            ttl_recent=200,
+            ttl_latest=100,
+        )
+
+
+@pytest.mark.asyncio
+async def test_page_cap_fails_closed() -> None:
+    fetch, _ = _result_fetcher(
+        [f"driver_{index}" for index in range(3)],
+        server_limit=1,
+    )
+
+    with pytest.raises(JolpicaPaginationError, match="page cap"):
+        await async_paginate_jolpica(
+            fetch,
+            lambda payload: result_leaf_keys(payload, "Results"),
+            ttl_stable=300,
+            ttl_recent=200,
+            ttl_latest=100,
+            page_cap=2,
+        )

--- a/custom_components/f1_sensor/tests/test_sensors.py
+++ b/custom_components/f1_sensor/tests/test_sensors.py
@@ -1737,14 +1737,19 @@ async def test_season_results_coordinator_no_spoiler_without_cached_data_returns
     payload = {
         "MRData": {
             "total": "1",
-            "limit": "200",
+            "limit": "1",
             "offset": "0",
             "RaceTable": {
                 "Races": [
                     {
                         "season": "2026",
                         "round": "1",
-                        "Results": [{"position": "1"}],
+                        "Results": [
+                            {
+                                "position": "1",
+                                "Driver": {"driverId": "test_driver"},
+                            }
+                        ],
                     }
                 ]
             },
@@ -1760,7 +1765,7 @@ async def test_season_results_coordinator_no_spoiler_without_cached_data_returns
     data = await coordinator._async_update_data()
 
     assert data == {"MRData": {"RaceTable": {"Races": []}}}
-    assert mock_fetch.await_count == 1
+    assert mock_fetch.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/custom_components/f1_sensor/tests/test_setup.py
+++ b/custom_components/f1_sensor/tests/test_setup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 from contextlib import ExitStack
 from datetime import UTC, datetime, timedelta
@@ -23,6 +24,7 @@ from custom_components.f1_sensor import (
     RACE_CONTROL_LOG_MAX_ITEMS,
     RaceControlCoordinator,
     RaceControlLogStore,
+    _async_get_shared_jolpica_client,
     _is_activity_log_excluded_entity,
     _refresh_recorder_entity_filter,
     _wrap_activity_filter,
@@ -131,6 +133,26 @@ class DummyCoordinator:
             listener()
 
 
+class DummyJolpicaClient:
+    instances = 0
+    created: list[object] = []
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        type(self).instances += 1
+        type(self).created.append(self)
+        self.initialized = False
+        self.closed = False
+
+    async def async_initialize(self) -> None:
+        self.initialized = True
+
+    async def async_close(self) -> None:
+        self.closed = True
+
+    def diagnostics(self) -> dict:
+        return {}
+
+
 class FakeReplayController:
     def __init__(self, *args, **kwargs) -> None:
         self._initialized = False
@@ -170,6 +192,7 @@ def _coordinator_patches(
 ):
     """Return context managers that replace all coordinator classes with DummyCoordinator."""
     return (
+        patch("custom_components.f1_sensor.JolpicaClient", DummyJolpicaClient),
         patch("custom_components.f1_sensor.F1DataCoordinator", DummyCoordinator),
         patch(
             "custom_components.f1_sensor.F1SeasonResultsCoordinator",
@@ -217,6 +240,25 @@ def test_activity_log_exclude_entity_matcher() -> None:
     assert _is_activity_log_excluded_entity("sensor.f1_race_time_to_three_hour_limit")
     assert not _is_activity_log_excluded_entity("sensor.f1_next_race")
     assert not _is_activity_log_excluded_entity("binary_sensor.f1_track_time")
+
+
+@pytest.mark.asyncio
+async def test_shared_jolpica_client_initializes_once_for_concurrent_entries(
+    hass,
+) -> None:
+    DummyJolpicaClient.instances = 0
+    with patch(
+        "custom_components.f1_sensor.JolpicaClient",
+        DummyJolpicaClient,
+    ):
+        first, second = await asyncio.gather(
+            _async_get_shared_jolpica_client(hass, MagicMock(), "ua"),
+            _async_get_shared_jolpica_client(hass, MagicMock(), "ua"),
+        )
+
+    assert first is second
+    assert first.initialized is True
+    assert DummyJolpicaClient.instances == 1
 
 
 def test_activity_log_filter_wrapper() -> None:
@@ -534,6 +576,53 @@ async def test_async_setup_entry_minimal(hass, mock_config_entry) -> None:
     assert (
         entry_data["track_map_store"] is mock_config_entry.runtime_data.track_map_store
     )
+
+
+@pytest.mark.asyncio
+async def test_setup_unload_reload_flushes_and_recreates_shared_transport(
+    hass,
+    mock_config_entry,
+) -> None:
+    DummyJolpicaClient.instances = 0
+    DummyJolpicaClient.created = []
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.build_user_agent",
+                AsyncMock(return_value="ua"),
+            )
+        )
+        stack.enter_context(patch("custom_components.f1_sensor.LiveBus", FakeLiveBus))
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.LiveSessionCoordinator",
+                DummyCoordinator,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "custom_components.f1_sensor.ReplayController",
+                FakeReplayController,
+            )
+        )
+        for context_manager in _coordinator_patches():
+            stack.enter_context(context_manager)
+        hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=None)
+        hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+        assert await async_setup_entry(hass, mock_config_entry)
+        first_client = hass.data[DOMAIN][mock_config_entry.entry_id]["jolpica_client"]
+        assert await async_unload_entry(hass, mock_config_entry)
+        assert first_client.closed is True
+
+        assert await async_setup_entry(hass, mock_config_entry)
+        second_client = hass.data[DOMAIN][mock_config_entry.entry_id]["jolpica_client"]
+        assert second_client is not first_client
+        assert second_client.initialized is True
+        assert await async_unload_entry(hass, mock_config_entry)
+
+    assert second_client.closed is True
+    assert DummyJolpicaClient.instances == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…ity**

The F1 Sensor integration now follows Jolpica request limits and identification requirements while handling temporary rate limits safely. Season, sprint, and lap data are only updated after every page has been verified, preventing truncated or partial results from replacing previously complete data. Existing configuration and entity IDs remain unchanged.

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
