### PR TITLE
docs: **Document version 5.4 weather and reliability updates**

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -20,18 +20,16 @@ Start with the [installation guide](/getting-started/installation), then use [co
 
 Most users should install the stable release. See [Release Channels](/getting-started/release-channels) before using beta or `dev` builds.
 
-## Version 5.2
+## Version 5.4
 
-Version 5.2 improves the bundled dashboard cards, incident notifications, and live timing sync:
+Version 5.4 expands race weather support and improves data reliability:
 
-- [Live Data Cards](/cards/cards-overview) add configurable font styles for wide, balanced, and system typography
-- Practice and Race timing cards can show optional S1, S2, and S3 sector columns with timing highlights
-- The Race Control card can hide track limits messages without deleting saved Race Control history
-- [Track Map](/features/track-map) now follows [Live Delay](/features/live-delay) during live sessions and handles unavailable position data more clearly
-- [Incident Notifications](/blueprints/incident-notifications) add optional presence, media player, do-not-disturb, and custom activation conditions
-- Weather sensors and cards now match Home Assistant temperature and wind unit preferences more consistently
+- The new [F1 Race Weather card](/cards/cards-overview#f1-race-weather-card) compares current circuit conditions with the forecast for race start
+- A native [next-race weather entity](/entities/static-data#next-race-weather) provides hourly, daily, and twice-daily forecasts for the circuit
+- New installations receive the documented entity IDs without an extra device-name prefix; existing entity IDs and customizations stay unchanged
+- Season, sprint, and lap results update only after complete data has been received, preventing partial classifications from replacing complete results
 
-Version 5.2 also includes correctness fixes for sector timing alignment, lap position progression finish positions, and post-race position lines in the bundled cards.
+The existing `sensor.f1_weather` remains available for dashboards and automations that already use it.
 
 ## Features
 

--- a/docs/cards/overview.md
+++ b/docs/cards/overview.md
@@ -25,6 +25,7 @@ Public live timing works without F1TV Auth. Cards that show live Track Map, Pit 
 | --- | --- | --- |
 | [F1 Live Session](#f1-live-session-card) | `custom:f1-live-session-card` | Session status, track condition, weather, and lap counter |
 | [F1 Next Race](#f1-next-race-card) | `custom:f1-next-race-card` | Next race countdown, schedule, circuit map, weather, and track time |
+| [F1 Race Weather](#f1-race-weather-card) | `custom:f1-weather-card` | Current circuit conditions and the forecast for race start |
 | [F1 Season Calendar](#f1-season-calendar-card) | `custom:f1-season-calendar-card` | Season schedule with past and upcoming races |
 | [F1 Race Control](#f1-race-control-card) | `custom:f1-race-control-card` | Race Control messages, flags, and optional message filters |
 | [F1 FIA Documents](#f1-fia-documents-card) | `custom:f1-fia-documents-card` | FIA documents and decision PDFs for the current weekend |
@@ -200,6 +201,39 @@ Shows the next race, countdown, weekend schedule, circuit map, track time, weath
 | `show_weather` | `true` | Show weather information |
 | `show_history` | `true` | Show race history when available |
 | `prefer_live_weather` | `true` | Prefer `sensor.f1_track_weather` during live sessions |
+
+---
+
+### F1 Race Weather Card
+
+`custom:f1-weather-card`
+
+Compares the current conditions at the next race circuit with the forecast for race start. During an active weekend, the card can replace the current forecast with live track measurements while keeping the race-start forecast visible.
+
+**Required entity:** `sensor.f1_weather`
+
+**Optional entities:** `sensor.f1_track_weather`, `sensor.f1_next_race`, `sensor.f1_session_status`
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `weather_entity` | `sensor.f1_weather` | Provides current conditions and the race-start forecast |
+| `track_weather_entity` | `sensor.f1_track_weather` | Provides live air temperature, track temperature, rainfall, humidity, pressure, and wind |
+| `next_race_entity` | `sensor.f1_next_race` | Adds the race name, circuit location, and race-start time |
+| `session_status_entity` | `sensor.f1_session_status` | Determines when live track conditions replace the current forecast |
+| `prefer_live_weather` | `true` | Prefer live track conditions during `pre`, `live`, `suspended`, and `break` session states |
+| `show_header` | `true` | Show the race, circuit location, and race-start time |
+| `theme_mode` | `dark` | Card theme |
+
+```yaml
+type: custom:f1-weather-card
+weather_entity: sensor.f1_weather
+track_weather_entity: sensor.f1_track_weather
+next_race_entity: sensor.f1_next_race
+session_status_entity: sensor.f1_session_status
+prefer_live_weather: true
+show_header: true
+theme_mode: auto
+```
 
 ---
 

--- a/docs/entities/static_data.md
+++ b/docs/entities/static_data.md
@@ -19,6 +19,7 @@ Display names can be translated in Home Assistant, and older installations may a
 | [sensor.f1_current_season](#current-season)                                       | Full race schedule                                | 
 | [sensor.f1_driver_standings](#driver-standings)                                   | Current driver championship standings             | 
 | [sensor.f1_constructor_standings](#constructor-standings)                         | Current constructor standings                     | 
+| [weather.f1_weather](#next-race-weather)                                          | Native current conditions and forecasts for the next race circuit |
 | [sensor.f1_weather](#weather-summary)                                             | Weather forecast at next race circuit             | 
 | [sensor.f1_last_race_results](#last-race-results)                                 | Most recent race results                          | 
 | [sensor.f1_season_results](#season-results)                                       | All season race results                           | 
@@ -328,8 +329,54 @@ Each entry in `Constructors` contains:
 | constructor_standings | list | Ergast “ConstructorStandings” array (positions, points, wins, constructor info) |
 
 
-## Weather (Summary)
-`sensor.f1_weather` - Compact weather for the circuit location: current and projected at race start.
+## Next Race Weather
+
+`weather.f1_weather` provides current conditions and native forecasts for the circuit hosting the next race. Its display name includes the circuit and city when both are available, and it updates when the next race destination changes.
+
+**State**
+
+- Home Assistant weather condition, such as `sunny`, `cloudy`, `rainy`, or `lightning-rainy`.
+
+**Example**
+
+```text
+partlycloudy
+```
+
+**Forecasts**
+
+The entity supports Home Assistant's hourly, daily, and twice-daily forecast types. Forecast values use your Home Assistant unit preferences when displayed in the UI.
+
+**Attributes**
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| temperature | number | Current air temperature |
+| humidity | number | Current relative humidity (%) |
+| cloud_coverage | number | Current cloud cover (%) |
+| wind_speed | number | Current wind speed |
+| wind_gust_speed | number | Current wind gust speed |
+| wind_bearing | number | Current wind direction in degrees |
+| visibility | number | Current visibility |
+| race_start | string | Race start timestamp |
+| race_forecast_available | boolean | Whether a forecast for race start is available |
+| season | string | Season year for the next race |
+| round | string | Round number for the next race |
+| race_name | string | Grand Prix name |
+| circuit_id | string | Circuit identifier |
+| circuit_name | string | Circuit name |
+| circuit_locality | string | City/area |
+| circuit_country | string | Country |
+
+:::info[Existing weather sensor]
+The existing `sensor.f1_weather` remains available for backward compatibility and for bundled cards that compare current conditions with the race-start forecast.
+:::
+
+---
+
+## Weather Summary
+
+`sensor.f1_weather` provides compact weather data for the circuit location, both now and at race start.
 
 **State**
 - Number: current air temperature in Home Assistant's selected temperature unit, or `unknown`.


### PR DESCRIPTION
Update the documentation for the new Race Weather card and native next-race weather entity. Explain the stable entity IDs for new installations and the improved reliability of season, sprint, and lap results.

<!--
  Target the correct branch:
  - Docs or blueprint changes (standalone, no code) → `content` branch
  - Code changes (integration, sensors, bundled card code, fixes, features, tests) → `dev` branch
  - PRs targeting `main` or `beta` are closed automatically.
  If you are unsure whether your change fits the project direction, open an issue first.
-->

## Description

<!-- What does this PR change, and why? Be specific about what behavior changes, what was broken, or what is new. -->

## Related issue

<!-- Link to the issue this PR fixes or relates to. If there is no issue, explain why the change is needed. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

<!-- Describe how you tested the change. Be specific about your setup and what you verified. -->

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [ ] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — if applicable
- [ ] No merge conflicts with the target branch

<!-- Blueprint only -->
If this adds or changes a blueprint:

- [ ] The blueprint has been imported and tested in Home Assistant
- [ ] Triggers and conditions work as expected in a live environment

<!-- Breaking changes only -->
If this is a breaking change:

- [ ] I have clearly described what will break and what users need to do to adapt
