### PR TITLE
chore: Validate F1 Sensor dependency patches during releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - "hacs.json"
       - "package-lock.json"
       - "package.json"
+      - "patches/**"
       - "release.config.cjs"
 
 permissions:


### PR DESCRIPTION
Adds dependency patch files to the Release workflow path filter. These files run during installation and can break releases, so changes to them need the same release validation as lockfile and package configuration changes.

The workflow-only change has been reviewed for syntax and does not affect F1 Sensor runtime behavior. Merging it will trigger Release on the current corrected dependency state and provide an end-to-end verification.