### PR TITLE
fix: Keep documentation checks green while indexing is active

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -31,5 +31,5 @@ jobs:
             echo "Request failed ($http_code): $body"
             exit 1
           done
-          echo "Context7 still busy after 3 attempts, giving up."
-          exit 1
+          echo "Context7 is already processing an indexing job; no new refresh is needed."
+          exit 0


### PR DESCRIPTION
Treats Context7's `user-has-active-task` response as a successful outcome after the existing retry window. Real API errors still fail the workflow, while an already-running index no longer creates a misleading red check.