### PR TITLE
chore: harden release dependency overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node": ">=20.0"
   },
   "overrides": {
-    "tar": "^7.5.10",
+    "tar": "^7.5.22",
     "cross-spawn": "^7.0.6",
     "brace-expansion": "^2.1.3",
     "minimatch": "^3.1.4",
@@ -69,7 +69,7 @@
     "@semantic-release/github": {
       "undici": "^7.29.0"
     },
-    "npm": ">=11.18.0",
+    "npm": "12.0.2",
     "websocket-driver": "^0.7.5",
     "cheerio": {
       "undici": "^7.29.0"


### PR DESCRIPTION
## Sammanfattning

- höjer `tar`-overriden till den korrigerade versionen 7.5.22
- använder npm 12.0.2 i release-kedjan så transitiva säkerhetsfixar kan tas in
- lämnar `image-size` 2.0.2 orörd eftersom någon korrigerad upstreamversion ännu inte finns

## Verifiering

- `npm ci`
- `npm run build`
- JavaScript-syntaxkontroll
- GitHub Actions: pytest, Validate, card assets och conflict check gröna

## Kvarstående risk

Dependabot-varningarna för `image-size` kan inte lösas säkert förrän upstream publicerar en korrigerad version. Ingen osäker nedgradering av Docusaurus/search-plugin görs.
