### PR TITLE
chore: patch vulnerable lockfile dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18274,9 +18274,10 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -19247,9 +19248,10 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.27.0",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
## Summary
- update the nested `ip-address` lock entry from 10.2.0 to 10.3.1
- update the nested `undici` lock entry from 6.27.0 to 6.28.0
- leave the two unpatchable `image-size` alerts unchanged

## Verification
- `npm ci --ignore-scripts`
- `npm run build`
- bundled card `node --check`
- `npm audit --package-lock-only` no longer reports `ip-address` or `undici`; `image-size` remains high with no patched version
- canonical pytest attempted locally, but collection is blocked by the local Python 3.11 environment resolving Home Assistant 2024.3.3 (missing `LOVELACE_DATA` / `DATA_COMPONENT`); GitHub CI uses Python 3.13

## Risk
Lockfile-only dependency patch; no application or documentation code changes.