### PR TITLE
chore: Avoid labeler failures on release promotion PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,9 +15,12 @@ concurrency:
 jobs:
   labeler:
     name: Apply labels
+    if: >-
+      github.event.pull_request.base.ref == 'dev' ||
+      github.event.pull_request.base.ref == 'content'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
## Summary

- skip the file labeler for internal promotion PRs targeting beta or main
- pin the labeler action to the tested v7 commit

## Root cause

The pull_request_target workflow is loaded from the default branch. Keeping the fix only on dev means promotion PRs still execute the older main-branch workflow and can fail while GitHub generates a large cross-history diff.

## Validation

- ./scripts/run_ruff.sh
- ./scripts/run_ruff_ci.sh
- ./scripts/run_tests.sh (938 passed)