### PR TITLE
feat: **Automatically bind bundled cards to F1 entities**

### DIFF
--- a/custom_components/f1_sensor/__init__.py
+++ b/custom_components/f1_sensor/__init__.py
@@ -93,6 +93,10 @@ from .entity import (
     register_entry_name_settings,
     unregister_entry_name_settings,
 )
+from .entity_map_websocket import (
+    ENTITY_MAP_WS_MARKER,
+    async_register_entity_map_websocket,
+)
 from .feature_plan import FeaturePlan, build_feature_plan
 from .formation_start import FormationStartTracker
 from .frontend import async_ensure_live_data_card_frontend
@@ -244,6 +248,7 @@ _DOMAIN_ROOT_INTERNAL_KEYS = frozenset(
         HISTORY_WS_MARKER,
         ANALYSIS_WS_MARKER,
         TRACK_MAP_WS_MARKER,
+        ENTITY_MAP_WS_MARKER,
     }
 )
 _FINISHING_PLUS_LAPS_RE = re.compile(r"^\+\d+\s+Laps?$", re.IGNORECASE)
@@ -2089,6 +2094,7 @@ async def _async_setup_entry(
         async_register_history_websocket(hass)
         async_register_analysis_websocket(hass)
         async_register_track_map_websocket(hass)
+        async_register_entity_map_websocket(hass)
         no_spoiler_mgr: NoSpoilerModeManager | None = hass.data.get(DOMAIN, {}).get(
             _NO_SPOILER_MANAGER_KEY
         )
@@ -2758,6 +2764,7 @@ async def _async_setup_entry(
     async_register_history_websocket(hass)
     async_register_analysis_websocket(hass)
     async_register_track_map_websocket(hass)
+    async_register_entity_map_websocket(hass)
 
     hass_data = hass.data.setdefault(DOMAIN, {}).get(entry.entry_id)
     if isinstance(hass_data, dict):

--- a/custom_components/f1_sensor/entity_map_websocket.py
+++ b/custom_components/f1_sensor/entity_map_websocket.py
@@ -1,0 +1,54 @@
+"""WebSocket discovery API for bundled dashboard cards."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import voluptuous as vol
+
+from .const import DOMAIN
+
+ENTITY_MAP_WS_MARKER = "__entity_map_ws_registered__"
+ENTITY_MAP_WS_TYPE = f"{DOMAIN}/entities"
+
+
+def async_register_entity_map_websocket(hass: HomeAssistant) -> None:
+    """Register the card entity-discovery command exactly once."""
+    root = hass.data.setdefault(DOMAIN, {})
+    if root.get(ENTITY_MAP_WS_MARKER):
+        return
+    websocket_api.async_register_command(hass, _ws_get_entity_map)
+    root[ENTITY_MAP_WS_MARKER] = True
+
+
+@websocket_api.websocket_command({vol.Required("type"): ENTITY_MAP_WS_TYPE})
+@websocket_api.async_response
+async def _ws_get_entity_map(
+    hass: HomeAssistant,
+    connection: Any,
+    msg: dict[str, Any],
+) -> None:
+    """Return entity IDs grouped by their F1 Sensor config entry."""
+    registry = er.async_get(hass)
+    result: list[dict[str, Any]] = []
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        prefix = f"{entry.entry_id}_"
+        entities: dict[str, str] = {}
+        for registry_entry in er.async_entries_for_config_entry(
+            registry, entry.entry_id
+        ):
+            unique_id = registry_entry.unique_id
+            if not unique_id.startswith(prefix):
+                continue
+            entities[unique_id.removeprefix(prefix)] = registry_entry.entity_id
+        result.append(
+            {
+                "entry_id": entry.entry_id,
+                "title": entry.title,
+                "entities": dict(sorted(entities.items())),
+            }
+        )
+    connection.send_result(msg["id"], result)

--- a/custom_components/f1_sensor/frontend.py
+++ b/custom_components/f1_sensor/frontend.py
@@ -36,6 +36,7 @@ LIVE_DATA_CARD_ASSET_FILENAMES = (
     "platform/base-card.js",
     "platform/card-registry.js",
     "platform/dashboard-context.js",
+    "platform/entity-resolver.js",
     "platform/i18n.js",
     "hard_tyre.png",
     "intermediate_tyre.png",

--- a/custom_components/f1_sensor/tests/test_entity_map_websocket.py
+++ b/custom_components/f1_sensor/tests/test_entity_map_websocket.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.f1_sensor.const import DOMAIN
+from custom_components.f1_sensor.entity_map_websocket import (
+    ENTITY_MAP_WS_MARKER,
+    _ws_get_entity_map,
+    async_register_entity_map_websocket,
+)
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.results: list[tuple[int, Any]] = []
+
+    def send_result(self, msg_id: int, result: Any) -> None:
+        self.results.append((msg_id, result))
+
+
+async def test_entity_map_groups_registry_entities_by_config_entry(hass) -> None:
+    first = MockConfigEntry(domain=DOMAIN, title="Living room F1", entry_id="first")
+    second = MockConfigEntry(domain=DOMAIN, title="Office F1", entry_id="second")
+    first.add_to_hass(hass)
+    second.add_to_hass(hass)
+    registry = er.async_get(hass)
+    first_driver = registry.async_get_or_create(
+        "sensor", DOMAIN, "first_driver_list", config_entry=first
+    )
+    second_driver = registry.async_get_or_create(
+        "sensor", DOMAIN, "second_driver_list", config_entry=second
+    )
+    registry.async_get_or_create("sensor", DOMAIN, "unrelated", config_entry=first)
+    connection = _Connection()
+
+    _ws_get_entity_map(hass, connection, {"id": 7, "type": "f1_sensor/entities"})
+    await hass.async_block_till_done()
+
+    assert connection.results == [
+        (
+            7,
+            [
+                {
+                    "entry_id": "first",
+                    "title": "Living room F1",
+                    "entities": {"driver_list": first_driver.entity_id},
+                },
+                {
+                    "entry_id": "second",
+                    "title": "Office F1",
+                    "entities": {"driver_list": second_driver.entity_id},
+                },
+            ],
+        )
+    ]
+
+
+def test_entity_map_websocket_registration_is_idempotent(hass, monkeypatch) -> None:
+    registered = []
+    monkeypatch.setattr(
+        "custom_components.f1_sensor.entity_map_websocket.websocket_api.async_register_command",
+        lambda _hass, handler: registered.append(handler),
+    )
+
+    async_register_entity_map_websocket(hass)
+    async_register_entity_map_websocket(hass)
+
+    assert registered == [_ws_get_entity_map]
+    assert hass.data[DOMAIN][ENTITY_MAP_WS_MARKER] is True

--- a/custom_components/f1_sensor/tests/test_entity_resolver.py
+++ b/custom_components/f1_sensor/tests/test_entity_resolver.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+RESOLVER_PATH = (
+    ROOT
+    / "custom_components"
+    / "f1_sensor"
+    / "www"
+    / "f1-sensor-live-data-card"
+    / "platform"
+    / "entity-resolver.js"
+)
+
+NODE_SCRIPT = r"""
+import { pathToFileURL } from 'node:url';
+
+const payload = JSON.parse(process.env.F1_RESOLVER_PAYLOAD || '{}');
+const { resolveF1CardEntities } = await import(pathToFileURL(process.env.F1_RESOLVER_PATH));
+let calls = 0;
+const hass = {
+  connection: {},
+  callWS: async (message) => {
+    calls += 1;
+    if (message.type !== 'f1_sensor/entities') throw new Error('Unexpected command');
+    return payload.entries;
+  },
+};
+const first = await resolveF1CardEntities(hass, payload.config, payload.bindings);
+const second = await resolveF1CardEntities(hass, first, payload.bindings);
+process.stdout.write(JSON.stringify({ first, second, calls }));
+"""
+
+
+def _resolve(payload: dict) -> dict:
+    env = {
+        **os.environ,
+        "F1_RESOLVER_PATH": str(RESOLVER_PATH),
+        "F1_RESOLVER_PAYLOAD": json.dumps(payload),
+    }
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", NODE_SCRIPT],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_single_entry_resolves_empty_and_default_entities() -> None:
+    result = _resolve(
+        {
+            "entries": [
+                {
+                    "entry_id": "entry-two",
+                    "title": "F1",
+                    "entities": {
+                        "driver_list": "sensor.f1_driver_list_2",
+                        "current_tyres": "sensor.f1_current_tyres_2",
+                    },
+                }
+            ],
+            "config": {
+                "entry_id": "auto",
+                "drivers_entity": "",
+                "tyres_entity": "sensor.f1_current_tyres",
+            },
+            "bindings": {
+                "drivers_entity": "driver_list",
+                "tyres_entity": "current_tyres",
+            },
+        }
+    )
+
+    assert result["first"] == {
+        "f1_entry_id": "entry-two",
+        "entry_id": "entry-two",
+        "drivers_entity": "sensor.f1_driver_list_2",
+        "tyres_entity": "sensor.f1_current_tyres_2",
+    }
+    assert result["second"] == result["first"]
+    assert result["calls"] == 1
+
+
+def test_weekend_hub_resolves_automatic_config_entry() -> None:
+    result = _resolve(
+        {
+            "entries": [
+                {
+                    "entry_id": "weekend-entry",
+                    "title": "Weekend Hub",
+                    "entities": {},
+                }
+            ],
+            "config": {"entry_id": "auto", "default_view": "overview"},
+            "bindings": {},
+        }
+    )
+
+    assert result["first"] == {
+        "f1_entry_id": "weekend-entry",
+        "entry_id": "weekend-entry",
+        "default_view": "overview",
+    }
+    assert result["second"] == result["first"]
+
+
+def test_multiple_entries_infer_from_an_explicit_entity_and_preserve_overrides() -> (
+    None
+):
+    result = _resolve(
+        {
+            "entries": [
+                {
+                    "entry_id": "first",
+                    "entities": {
+                        "driver_list": "sensor.f1_driver_list",
+                        "current_tyres": "sensor.f1_current_tyres",
+                    },
+                },
+                {
+                    "entry_id": "second",
+                    "entities": {
+                        "driver_list": "sensor.office_drivers",
+                        "current_tyres": "sensor.f1_current_tyres_2",
+                    },
+                },
+            ],
+            "config": {
+                "drivers_entity": "sensor.office_drivers",
+                "tyres_entity": "sensor.f1_current_tyres",
+            },
+            "bindings": {
+                "drivers_entity": "driver_list",
+                "tyres_entity": "current_tyres",
+            },
+        }
+    )
+
+    assert result["first"]["f1_entry_id"] == "second"
+    assert result["first"]["drivers_entity"] == "sensor.office_drivers"
+    assert result["first"]["tyres_entity"] == "sensor.f1_current_tyres_2"
+
+
+def test_multiple_entries_remain_unchanged_when_selection_is_ambiguous() -> None:
+    config = {"drivers_entity": "", "tyres_entity": ""}
+    result = _resolve(
+        {
+            "entries": [
+                {"entry_id": "first", "entities": {"driver_list": "sensor.one"}},
+                {"entry_id": "second", "entities": {"driver_list": "sensor.two"}},
+            ],
+            "config": config,
+            "bindings": {
+                "drivers_entity": "driver_list",
+                "tyres_entity": "current_tyres",
+            },
+        }
+    )
+
+    assert result["first"] == config

--- a/custom_components/f1_sensor/tests/test_phase_4_weekend_hub_card.py
+++ b/custom_components/f1_sensor/tests/test_phase_4_weekend_hub_card.py
@@ -200,6 +200,7 @@ def test_weekend_hub_registers_full_phase4_experience() -> None:
     assert "customElements.define('f1-weekend-hub-card', F1WeekendHubCard)" in source
     assert "'f1-weekend-hub-card'" in registry
     assert "platform/dashboard-context.js" in source
+    assert "installF1EntityAutoBinding(F1WeekendHubCard, {})" in source
     assert "setInterval(" not in source[source.index("class F1WeekendHubCard") :]
     for method in (
         "_renderOverview",

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -12,6 +12,7 @@ import {
   installF1DashboardContext,
   updateF1DashboardContext,
 } from './platform/dashboard-context.js';
+import { installF1EntityAutoBinding } from './platform/entity-resolver.js';
 import {
   f1Translate,
   installF1FrontendLocalization,
@@ -35193,6 +35194,143 @@ class F1SessionArchiveCardCompatibility extends F1LastRaceResultsCard {
     });
   }
 }
+
+installF1EntityAutoBinding(F1TyreStatisticsCard, {
+  drivers_entity: 'driver_list',
+  entity: 'tyre_statistics',
+});
+installF1EntityAutoBinding(F1PitStopOverviewCard, {
+  drivers_entity: 'driver_list',
+  tyres_entity: 'current_tyres',
+  pitstops_entity: 'pitstops',
+  positions_entity: 'driver_positions',
+});
+installF1EntityAutoBinding(F1DriverLapTimesCard, {
+  drivers_entity: 'driver_list',
+  positions_entity: 'driver_positions',
+});
+installF1EntityAutoBinding(F1ChampionshipPredictionDriversCard, {
+  current_entity: 'driver_standings',
+  entity: 'championship_prediction_drivers',
+  drivers_entity: 'driver_list',
+  session_entity: 'current_session',
+  session_status_entity: 'session_status',
+  no_spoiler_entity: 'no_spoiler_mode',
+});
+installF1EntityAutoBinding(F1ChampionshipPredictionTeamsCard, {
+  current_entity: 'constructor_standings',
+  entity: 'championship_prediction_teams',
+  session_entity: 'current_session',
+  session_status_entity: 'session_status',
+  no_spoiler_entity: 'no_spoiler_mode',
+});
+installF1EntityAutoBinding(F1SeasonProgressionCard, {
+  entity: (config) => config?.mode === 'constructors'
+    ? 'constructor_points_progression'
+    : 'driver_points_progression',
+  calendar_entity: 'current_season',
+  driver_list_entity: 'driver_list',
+});
+installF1EntityAutoBinding(F1LapPositionProgressionCard, {
+  entity: 'lap_position_progression',
+  drivers_entity: 'driver_list',
+  no_spoiler_entity: 'no_spoiler_mode',
+});
+installF1EntityAutoBinding(F1LastRaceResultsCard, {
+  entity: 'last_race_results',
+  season_results_entity: 'season_results',
+  sprint_results_entity: 'sprint_results',
+  drivers_entity: 'driver_list',
+  no_spoiler_entity: 'no_spoiler_mode',
+});
+installF1EntityAutoBinding(F1InvestigationsCard, {
+  investigations_entity: 'investigations',
+  drivers_entity: 'driver_list',
+  positions_entity: 'driver_positions',
+});
+installF1EntityAutoBinding(F1TrackLimitsCard, {
+  track_limits_entity: 'track_limits',
+  drivers_entity: 'driver_list',
+  positions_entity: 'driver_positions',
+});
+installF1EntityAutoBinding(F1LiveSessionCard, {
+  session_entity: 'current_session',
+  session_status_entity: 'session_status',
+  formation_start_entity: 'formation_start',
+  lap_count_entity: 'race_lap_count',
+  track_status_entity: 'track_status',
+  weather_entity: 'track_weather',
+  next_race_entity: 'next_race',
+  session_time_remaining_entity: 'session_time_remaining',
+  session_time_elapsed_entity: 'session_time_elapsed',
+  overtake_mode_entity: 'overtake_mode',
+  straight_mode_entity: 'straight_mode',
+});
+installF1EntityAutoBinding(F1ReplayControlCard, {
+  status_entity: 'replay_status',
+  year_entity: 'replay_year_select',
+  session_entity: 'replay_session_select',
+  start_reference_entity: 'replay_start_reference',
+  load_button_entity: 'replay_load',
+  play_button_entity: 'replay_play',
+  pause_button_entity: 'replay_pause',
+  back_button_entity: 'replay_back_30',
+  forward_button_entity: 'replay_forward_30',
+  stop_button_entity: 'replay_stop',
+  refresh_button_entity: 'replay_refresh',
+  player_entity: 'replay_player',
+});
+installF1EntityAutoBinding(F1NextRaceCard, {
+  next_race_entity: 'next_race',
+  weather_entity: 'weather',
+  track_weather_entity: 'track_weather',
+  current_session_entity: 'current_session',
+  session_status_entity: 'session_status',
+});
+installF1EntityAutoBinding(F1WeatherCard, {
+  weather_entity: 'weather',
+  track_weather_entity: 'track_weather',
+  next_race_entity: 'next_race',
+  session_status_entity: 'session_status',
+});
+installF1EntityAutoBinding(F1SeasonCalendarCard, {
+  current_season_entity: 'current_season',
+});
+installF1EntityAutoBinding(F1RaceControlCard, { entity: 'race_control' });
+installF1EntityAutoBinding(F1FiaDocumentsCard, {
+  entity: 'fia_documents',
+  last_race_entity: 'last_race_results',
+});
+installF1EntityAutoBinding(F1QualifyingTimingCard, {
+  positions_entity: 'driver_positions',
+  tyres_entity: 'current_tyres',
+  drivers_entity: 'driver_list',
+  session_entity: 'current_session',
+  session_status_entity: 'session_status',
+});
+installF1EntityAutoBinding(F1PracticeTimingCard, {
+  positions_entity: 'driver_positions',
+  session_entity: 'current_session',
+  session_status_entity: 'session_status',
+  drivers_entity: 'driver_list',
+  tyres_entity: 'current_tyres',
+});
+installF1EntityAutoBinding(F1RaceLapCard, {
+  positions_entity: 'driver_positions',
+  lap_count_entity: 'race_lap_count',
+  session_entity: 'current_session',
+  session_status_entity: 'session_status',
+  drivers_entity: 'driver_list',
+  tyres_entity: 'current_tyres',
+  pitstops_entity: 'pitstops',
+});
+installF1EntityAutoBinding(F1StartingGridCard, { entity: 'starting_grid' });
+installF1EntityAutoBinding(F1TrackMapCard, {
+  lap_count_entity: 'race_lap_count',
+  driver_positions_entity: 'driver_positions',
+  track_status_entity: 'track_status',
+});
+installF1EntityAutoBinding(F1WeekendHubCard, {});
 
 installSectionsAutoHeight(F1WeekendHubCard, {
   columns: 12,

--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/platform/entity-resolver.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/platform/entity-resolver.js
@@ -1,0 +1,116 @@
+const entityMapRequests = new WeakMap();
+
+const requestKey = (hass) => hass?.connection || hass;
+
+const loadEntries = async (hass) => {
+  if (!hass?.callWS) return [];
+  const key = requestKey(hass);
+  if (!entityMapRequests.has(key)) {
+    entityMapRequests.set(
+      key,
+      hass.callWS({ type: 'f1_sensor/entities' }).catch((error) => {
+        entityMapRequests.delete(key);
+        throw error;
+      }),
+    );
+  }
+  const entries = await entityMapRequests.get(key);
+  return Array.isArray(entries) ? entries : [];
+};
+
+const suffixesFor = (suffixValue, config) => {
+  const configuredSuffix = typeof suffixValue === 'function'
+    ? suffixValue(config)
+    : suffixValue;
+  return Array.isArray(configuredSuffix) ? configuredSuffix : [configuredSuffix];
+};
+
+const configuredEntityIds = (config, bindings, includeDefaults) => Object.entries(bindings)
+  .map(([field, suffixValue]) => ({
+    value: config?.[field],
+    suffixes: suffixesFor(suffixValue, config),
+  }))
+  .filter(({ value, suffixes }) => (
+    typeof value === 'string'
+    && value.includes('.')
+    && value !== 'auto'
+    && (includeDefaults || !conventionalDefault(value, suffixes))
+  ))
+  .map(({ value }) => value);
+
+const selectEntry = (entries, config, bindings) => {
+  if (config?.f1_entry_id) {
+    return entries.find((entry) => entry.entry_id === config.f1_entry_id) || null;
+  }
+  for (const includeDefaults of [false, true]) {
+    const configured = new Set(configuredEntityIds(config, bindings, includeDefaults));
+    const matching = entries.filter((entry) => (
+      Object.values(entry.entities || {}).some((entityId) => configured.has(entityId))
+    ));
+    if (matching.length === 1) return matching[0];
+  }
+  return entries.length === 1 ? entries[0] : null;
+};
+
+const conventionalDefault = (entityId, suffixes) => {
+  if (typeof entityId !== 'string') return false;
+  return suffixes.some((suffix) => entityId.endsWith(`.f1_${suffix}`));
+};
+
+const targetEntity = (entry, suffixes) => {
+  for (const suffix of suffixes) {
+    if (entry.entities?.[suffix]) return entry.entities[suffix];
+  }
+  return null;
+};
+
+export const resolveF1CardEntities = async (hass, config = {}, bindings = {}) => {
+  const entries = await loadEntries(hass);
+  const entry = selectEntry(entries, config, bindings);
+  if (!entry) return config;
+
+  let changed = config.f1_entry_id !== entry.entry_id;
+  const resolved = { ...config, f1_entry_id: entry.entry_id };
+  for (const entryField of ['entry_id', 'history_entry_id']) {
+    if (entryField in config && (!config[entryField] || config[entryField] === 'auto')) {
+      resolved[entryField] = entry.entry_id;
+      changed = true;
+    }
+  }
+  for (const [field, suffixValue] of Object.entries(bindings)) {
+    const suffixes = suffixesFor(suffixValue, config);
+    const target = targetEntity(entry, suffixes);
+    if (!target) continue;
+    const current = config[field];
+    const mayReplace = !current || current === 'auto' || conventionalDefault(current, suffixes);
+    if (mayReplace && current !== target) {
+      resolved[field] = target;
+      changed = true;
+    }
+  }
+  return changed ? resolved : config;
+};
+
+export const installF1EntityAutoBinding = (CardClass, bindings) => {
+  if (!CardClass || CardClass.prototype.__f1EntityAutoBindingInstalled) return;
+  const proto = CardClass.prototype;
+  const originalWillUpdate = proto.willUpdate;
+  proto.willUpdate = function willUpdate(changedProperties) {
+    if (this.hass && this.config && !this.__f1EntityBindingPending) {
+      this.__f1EntityBindingPending = true;
+      resolveF1CardEntities(this.hass, this.config, bindings)
+        .then((resolved) => {
+          if (resolved !== this.config) {
+            this.config = resolved;
+            this.requestUpdate();
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          this.__f1EntityBindingPending = false;
+        });
+    }
+    return originalWillUpdate?.call(this, changedProperties);
+  };
+  proto.__f1EntityAutoBindingInstalled = true;
+};

--- a/docs/cards/overview.md
+++ b/docs/cards/overview.md
@@ -125,7 +125,9 @@ font_style: balanced
 ```
 
 :::info[Entity IDs]
-The defaults use the standard F1 Sensor entity IDs, such as `sensor.f1_driver_positions`. Older installations may have existing registry IDs from earlier releases. Select the correct entities in the visual editor if your IDs differ.
+Bundled cards discover the entity IDs created by F1 Sensor, including renamed IDs and the `_2` suffixes Home Assistant assigns when needed. With one F1 Sensor configuration entry, empty and standard default data sources are connected automatically.
+
+With multiple F1 Sensor entries, selecting one entity in the visual editor identifies the entry and the card connects its other standard data sources to that same entry. Explicit custom entity selections are preserved. If a new card is ambiguous because no source has been selected, choose any one of its F1 entities in **Data Sources**.
 :::
 
 ---


### PR DESCRIPTION
## Description

Bundled F1 cards now discover entity IDs from Home Assistant's entity registry instead of assuming the first integration entry owns the standard IDs.

- Automatically binds empty and standard default data sources for a single F1 Sensor entry.
- Infers the matching config entry from an explicitly selected entity when multiple entries exist.
- Supports renamed entities and Home Assistant suffixes such as `_2`.
- Preserves explicit custom entity selections and avoids guessing when multiple entries remain ambiguous.
- Adds a cached, config-entry-scoped WebSocket discovery endpoint and documents the behavior.
- Resolves the new Weekend Hub's `entry_id: auto` against the selected F1 Sensor config entry.

## Related issue

No linked issue. This improvement was identified while reviewing multi-entry and bundled-card behavior.

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [x] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [x] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [ ] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

- Rebased onto the current `dev` branch.
- Full minimum-version integration suite: `961 passed`.
- Current Phase 5 frontend/browser matrix: `13 passed`, including accessibility, localization, visual layouts, lifecycle, and render-budget checks.
- Ruff lint and format checks passed.
- Translation parity, source-review policy, dependency-audit policy, deterministic release, and documentation production build checks passed.
- Resolver tests cover a single entry, renamed/suffixed IDs, multi-entry inference, explicit overrides, caching, ambiguous selection, and Weekend Hub config-entry resolution.
- JavaScript syntax checks passed for the card bundle and resolver.

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [x] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — if applicable
- [x] Code is formatted and passes lint check (`ruff format` and `ruff check`) — if applicable
- [x] Tests have been added or updated and pass locally — if applicable
- [ ] Translations updated if new UI strings were added — not applicable
- [x] No merge conflicts with the target branch
