### PR TITLE
docs: **Correct automation trigger documentation**

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -43,7 +43,7 @@ Triggers are organized per sub-device. Only triggers whose backing entity is ena
 | Formation start ready | Formation start procedure is ready |
 | Overtake mode enabled | Track-wide overtake mode is enabled (2026 regulation) |
 | Overtake mode disabled | Track-wide overtake mode is disabled (2026 regulation) |
-| Session live | Session status changes (any state transition) |
+| Session live | Session status changes to `live` |
 | Track status: CLEAR | Track status becomes CLEAR |
 | Track status: YELLOW | Track status becomes YELLOW |
 | Track status: Safety Car | Track status becomes SC |
@@ -61,6 +61,12 @@ Triggers are organized per sub-device. Only triggers whose backing entity is ena
 | New race control message | A new race control message is received |
 | New FIA document | A new FIA document is published |
 | Investigation changed | An investigation or penalty status changes |
+
+### Drivers device
+
+| Trigger | Fires when |
+| --- | --- |
+| New team radio message | A new Team Radio clip is published |
 
 ### System device
 


### PR DESCRIPTION
## Description

Corrects two mismatches between the automation documentation and the existing device-trigger implementation:

- `Session live` is documented as firing when session status changes to `live`, rather than on every transition.
- The existing New Team Radio message trigger is listed under the Drivers device.

## Related issue

No linked issue. The documentation mismatch was identified during a repository review.

## Type of change

- [ ] 🐛 Bug fix (corrects existing behavior without breaking anything)
- [ ] 🚀 New feature (adds functionality)
- [ ] ⚠️ Breaking change (existing automations, entities, or config will stop working or behave differently)
- [ ] 🏎️ Bundled live data card code
- [ ] 📋 Blueprint (new or updated blueprint)
- [x] 📚 Documentation only
- [ ] 🔧 Refactoring or internal cleanup

## How has this been tested?

- Docusaurus optimized production build completed successfully.
- Markdown diff and whitespace validation passed.
- Docusaurus configuration syntax check passed.

- [ ] Tested locally with a real Home Assistant instance
- [ ] Existing automations and dashboards still work as expected after the change

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and am targeting the correct branch
- [ ] Changes under `custom_components/f1_sensor/www/**` target `dev` as bundled card code, not the standalone documentation path — not applicable
- [ ] Code is formatted and passes lint check (`ruff format` and `ruff check`) — not applicable
- [ ] Tests have been added or updated and pass locally — not applicable
- [ ] Translations updated if new UI strings were added — not applicable
- [x] No merge conflicts with the target branch
