### PR TITLE
docs: Explain dashboard test coverage for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,4 +106,6 @@ npm run test:frontend
 npm run test:docs
 ```
 
+The Node unit suite loads complete delivered card modules and simulates the browser/Lit boundary. Playwright renders the real components in Chromium. Run both after changing dashboard behavior; passing unit tests alone does not verify layout or accessibility.
+
 Python line coverage must remain at least 95 percent across shipped code; branch coverage is reported separately. Tests should protect user behavior, lifecycle and external boundaries rather than specific source formatting. The weekly maintenance workflow checks latest stable HA compatibility on `dev`, WebKit smoke flows, timing budgets, npm audit and review dates. Review-date checks document overdue manual review; they do not verify a remote service's security.


### PR DESCRIPTION
Explain why dashboard contributors run both direct-module Node tests and real-browser checks. This documentation-only PR also verifies that selective CI reports `CI required` after documentation and automation checks without running unrelated HA or npm audit jobs.

No integration code changes. The maintainer can merge after the applicable checks; no additional reviewer is required.
