### PR TITLE
fix: Run releases after required checks pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,9 @@ jobs:
               output:{title:'Verified PR merge result',summary:`All applicable checks ran on this PR merge from its trusted target branch. Result: ${process.env.CI_RESULT}.`}});
   release:
     needs: required
+    # Optional ancestors can be skipped; the aggregate is the release gate.
     if: >-
-      needs.required.result == 'success' && vars.CI_ROLLOUT != 'true' &&
+      !cancelled() && needs.required.result == 'success' && vars.CI_ROLLOUT != 'true' &&
       !github.event.inputs.pull_request &&
       (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release)) &&
       (github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/main')
@@ -144,7 +145,7 @@ jobs:
   deploy:
     needs: [plan, required, documentation]
     if: >-
-      needs.required.result == 'success' && needs.documentation.result == 'success' &&
+      !cancelled() && needs.required.result == 'success' && needs.documentation.result == 'success' &&
       needs.plan.outputs.deploy == 'true' &&
       !github.event.inputs.pull_request &&
       github.ref == 'refs/heads/main' && github.event_name != 'pull_request'


### PR DESCRIPTION
Release drafts were skipped after successful CI because an optional upstream job was skipped. Evaluate the completed CI gate explicitly for release and documentation deployment while retaining all success and cancellation checks. Validated with actionlint and the offline automation suite; promotion and final beta CI will verify the actual GitHub execution.