### PR TITLE
fix: Finalize beta live timing reliability

### DIFF
--- a/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
+++ b/custom_components/f1_sensor/www/f1-sensor-live-data-card/f1-sensor-live-data-card.js
@@ -27115,11 +27115,14 @@ class F1QualifyingTimingCard extends LitElement {
   }
 
   _resolveBestQualifyingLap(row) {
-    const candidates = [
-      ['q3_lap', 'q3_lap_position'],
-      ['q2_lap', 'q2_lap_position'],
-      ['q1_lap', 'q1_lap_position'],
-    ];
+    const part = this._normalizeQualifyingPart(row?.qualifying_part);
+    const candidates = part !== null
+      ? [[`q${part}_lap`, `q${part}_lap_position`]]
+      : [
+        ['q3_lap', 'q3_lap_position'],
+        ['q2_lap', 'q2_lap_position'],
+        ['q1_lap', 'q1_lap_position'],
+      ];
 
     for (const [timeKey, positionKey] of candidates) {
       const time = row?.[timeKey];
@@ -27296,6 +27299,7 @@ class F1QualifyingTimingCard extends LitElement {
         sector_state: pos.sector_state ?? pos.sectors?.state ?? null,
         last_lap: lastLap,
         current_segment_best_lap: currentSegmentBestLap,
+        qualifying_part: resolvedQPart,
         sort_position: sortPosition,
         q1_lap: pos.q1_time ?? null,
         q1_lap_position: pos.q1_position ?? null,

--- a/frontend-tests/qualifying-part.spec.js
+++ b/frontend-tests/qualifying-part.spec.js
@@ -1,0 +1,54 @@
+const {test, expect} = require('@playwright/test');
+const observed = require('./unit/qualifying-part-events.json');
+
+for (const [width, layout] of [[360,'narrow'], [700,'medium'], [1450,'wide']]) {
+  test(`qualifying ${layout} labels each time with its actual Q part`, async ({page}) => {
+    await page.setViewportSize({width, height:1000});
+    await page.goto('/frontend-tests/fixture.html');
+    await page.waitForFunction(() => typeof window.makeHass === 'function');
+    await page.evaluate(async () => { await customElements.whenDefined('f1-qualifying-timing-card'); });
+    await page.evaluate(async (observed) => {
+      const host = document.createElement('f1-qualifying-timing-card');
+      const base = window.makeHass();
+      host.setConfig({type:'custom:f1-qualifying-timing-card', positions_entity:'sensor.positions', session_entity:'sensor.session', session_status_entity:'sensor.status', show_team_logo:false, show_delta:false});
+      window.updateQualifyingPartFixture = async (part, time=null) => {
+        const drivers = observed.drivers.map(driver => ({...driver,
+          q2_time:part === 1 ? null : driver.q2_time,
+          q2_position:part === 1 ? null : driver.q2_position,
+          ...(driver.racing_number === '16' && part >= 2 ? {q2_time:part === 2 ? time : '1:23.500', q2_position:time || part === 3 ? 4 : null} : {}),
+          ...(driver.racing_number === '16' && part === 3 ? {q3_time:time, q3_position:time ? 2 : null} : {}),
+        }));
+        host.hass = {...base, states:{...base.states,
+          'sensor.positions':{state:'3',attributes:{current_qualifying_part:part, drivers}},
+          'sensor.session':{state:'Qualifying',attributes:{name:'Qualifying',type:'Qualifying',session_part:part,meeting_key:1293}},
+          'sensor.status':{state:'live',attributes:{}},
+        }};
+        await host.updateComplete;
+      };
+      document.querySelector('#mount').append(host);
+      await window.updateQualifyingPartFixture(1);
+    }, observed);
+    const host = page.locator('f1-qualifying-timing-card');
+    await expect(host.locator('.qt-card')).toHaveAttribute('data-layout', layout);
+    const leclerc = host.locator('.qt-row:not(.header)').filter({hasText:'LEC'});
+    const tsunoda = host.locator('.qt-row:not(.header)').filter({hasText:'TSU'});
+    const lap = (row, part) => row.locator('.qt-lap').nth(layout === 'wide' ? part : 1);
+    await expect(lap(leclerc,1)).toHaveText('1:22.902');
+    await page.evaluate(() => window.updateQualifyingPartFixture(2));
+    await expect(host.locator('.qt-q-badge')).toHaveText('Q2');
+    await expect(lap(leclerc,2)).toHaveText('--:--.---');
+    await expect(lap(tsunoda,2)).toHaveText('--:--.---');
+    if (layout === 'wide') await expect(lap(leclerc,1)).toHaveText('1:22.902');
+    await page.evaluate(() => window.updateQualifyingPartFixture(2,'1:23.500'));
+    await expect(lap(leclerc,2)).toHaveText('1:23.500');
+    await page.evaluate(() => window.updateQualifyingPartFixture(3));
+    await expect(host.locator('.qt-q-badge')).toHaveText('Q3');
+    await expect(lap(leclerc,3)).toHaveText('--:--.---');
+    await page.evaluate(() => window.updateQualifyingPartFixture(3,'1:24.500'));
+    await expect(lap(leclerc,3)).toHaveText('1:24.500');
+    if (layout === 'wide') {
+      await expect(lap(leclerc,1)).toHaveText('1:22.902');
+      await expect(lap(leclerc,2)).toHaveText('1:23.500');
+    }
+  });
+}

--- a/frontend-tests/unit/qualifying-part-events.json
+++ b/frontend-tests/unit/qualifying-part-events.json
@@ -1,0 +1,63 @@
+{
+  "observation": "HA 2026.9.0, Italian Grand Prix Qualifying 11357, 2026-09-05 16:29:08 Europe/Stockholm; selected existing fields only",
+  "current_qualifying_part": 2,
+  "drivers": [
+    {
+      "racing_number": "3",
+      "tla": "VER",
+      "current_position": "1",
+      "laps": {
+        "3": "1:53.815",
+        "5": "20:29.380",
+        "6": "1:22.573"
+      },
+      "q1_time": "1:22.631",
+      "q1_position": 2,
+      "q1_knocked_out": false,
+      "q2_time": "1:22.573",
+      "q2_position": 1,
+      "q2_knocked_out": false,
+      "q3_time": null,
+      "q3_position": null,
+      "q3_knocked_out": false
+    },
+    {
+      "racing_number": "16",
+      "tla": "LEC",
+      "current_position": "11",
+      "laps": {
+        "3": "1:56.520",
+        "5": "2:10.770",
+        "6": "1:42.985"
+      },
+      "q1_time": "1:22.902",
+      "q1_position": 9,
+      "q1_knocked_out": false,
+      "q2_time": null,
+      "q2_position": null,
+      "q2_knocked_out": false,
+      "q3_time": null,
+      "q3_position": null,
+      "q3_knocked_out": false
+    },
+    {
+      "racing_number": "22",
+      "tla": "TSU",
+      "current_position": "17",
+      "laps": {
+        "3": "1:43.673",
+        "5": "6:06.868",
+        "6": "1:52.174"
+      },
+      "q1_time": "1:23.755",
+      "q1_position": 17,
+      "q1_knocked_out": true,
+      "q2_time": null,
+      "q2_position": null,
+      "q2_knocked_out": false,
+      "q3_time": null,
+      "q3_position": null,
+      "q3_knocked_out": false
+    }
+  ]
+}

--- a/frontend-tests/unit/qualifying-part.test.mjs
+++ b/frontend-tests/unit/qualifying-part.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import {card} from './card-module.mjs';
+
+const observed = JSON.parse(readFileSync(new URL('./qualifying-part-events.json', import.meta.url)));
+
+for (const mode of ['narrow', 'medium']) {
+  test(`qualifying ${mode} Q2 column never borrows a Q1 time`, () => {
+    const host = card('f1-qualifying-timing-card');
+    const rows = host._buildRows(observed.drivers, [], [], 2);
+    const col = host._columns(mode, 2, false).find(col => col.key === 'best_session');
+    assert.equal(col.label, 'Q2');
+    for (const number of ['16', '22']) {
+      const row = rows.find(row => row.rn === number);
+      assert.equal(row.q2_lap, null);
+      assert.match(host._renderCell(row, col), /--:--\.---/);
+      assert.ok(!host._renderCell(row, col).includes(row.q1_lap));
+    }
+    const timed = rows.find(row => row.rn === '3');
+    assert.match(host._renderCell(timed, col), /1:22\.573/);
+  });
+
+  test(`qualifying ${mode} Q3 stays empty until its own slower lap arrives`, () => {
+    const host = card('f1-qualifying-timing-card');
+    const driver = {...observed.drivers.find(driver => driver.racing_number === '16'), q2_time:'1:23.500', q2_position:4};
+    const col = host._columns(mode, 3, false).find(col => col.key === 'best_session');
+    assert.equal(col.label, 'Q3');
+    let row = host._buildRows([driver], [], [], 3)[0];
+    assert.match(host._renderCell(row, col), /--:--\.---/);
+    row = host._buildRows([{...driver, q3_time:'1:24.500', q3_position:2}], [], [], 3)[0];
+    assert.match(host._renderCell(row, col), /1:24\.500/);
+    assert.ok(!host._renderCell(row, col).includes('1:23.500'));
+  });
+}
+
+test('wide qualifying keeps separately labelled earlier parts', () => {
+  const host = card('f1-qualifying-timing-card');
+  const row = host._buildRows(observed.drivers, [], [], 2).find(row => row.rn === '16');
+  const cols = host._columns('wide', 2, false);
+  assert.match(host._renderCell(row, cols.find(col => col.key === 'q1_lap')), /1:22\.902/);
+  assert.match(host._renderCell(row, cols.find(col => col.key === 'q2_lap')), /--:--\.---/);
+});
+
+test('unknown qualifying part retains the existing BEST fallback', () => {
+  const host = card('f1-qualifying-timing-card');
+  const row = {q1_lap:'1:22.902', q1_lap_position:9, q2_lap:null, q3_lap:null};
+  const col = host._columns('narrow', null, false).find(col => col.key === 'best_session');
+  assert.equal(col.label, 'BEST');
+  assert.match(host._renderCell(row, col), /1:22\.902/);
+});


### PR DESCRIPTION
Qualifying cards now show a time only from the displayed Q1, Q2 or Q3 segment. When the current segment has no time, narrow and medium layouts show the existing placeholder. Wide layouts retain the separate qualifying history.

Validation: reproduced the observed Q2/Q3 error before the fix; six focused unit tests and three browser cases pass in Chromium and WebKit. Full local quality checks pass (51 frontend unit tests, 30 browser tests, 1,448 runtime Python tests), with Ruff and coverage checks green. The authenticated qualifying live session validated the unchanged backend; the final display correction is covered by the focused regressions. The maintainer has confirmed visual validation.

This completes the beta candidate. Main promotion is outside the revised scope; PR #653 is closed without merging.
