### PR TITLE
chore: Automate verified security updates and branch synchronization

### DIFF
--- a/.github/scripts/auto-merge.cjs
+++ b/.github/scripts/auto-merge.cjs
@@ -1,0 +1,36 @@
+'use strict';
+
+async function enable({github, context}, pr) {
+  const rules = await github.paginate('GET /repos/{owner}/{repo}/rules/branches/{branch}',
+    {...context.repo, branch: pr.base.ref});
+  const protectedPR = rules.some(rule => rule.type === 'pull_request');
+  const required = rules.some(rule => rule.type === 'required_status_checks'
+    && rule.parameters.strict_required_status_checks_policy
+    && rule.parameters.required_status_checks.some(check =>
+      check.context === 'CI required' && check.integration_id === 15368));
+  if (!protectedPR || !required) throw new Error('Automatic merge requires strict, GitHub Actions-bound CI required and PR protection.');
+  const current = (await github.rest.pulls.get({...context.repo, pull_number: pr.number})).data;
+  if (current.state !== 'open' || current.draft || current.head.sha !== pr.head.sha
+      || current.base.sha !== pr.base.sha || current.base.ref !== pr.base.ref) {
+    throw new Error('PR changed before automatic merge could be enabled.');
+  }
+  if (current.auto_merge) return;
+  if (current.mergeable_state === 'clean') {
+    const result = (await github.rest.pulls.merge({...context.repo, pull_number:current.number,
+      sha:current.head.sha, merge_method:'merge'})).data;
+    if (!result.merged) throw new Error('GitHub did not merge the verified PR.');
+    return;
+  }
+  await github.graphql(`mutation($id:ID!, $head:GitObjectID!) {
+    enablePullRequestAutoMerge(input:{pullRequestId:$id, expectedHeadOid:$head, mergeMethod:MERGE}) {
+      pullRequest { number }
+    }
+  }`, {id: current.node_id, head: current.head.sha});
+}
+
+function eligible(base, metadata) {
+  if (base === 'main') return metadata.alert === 'OPEN' && /^GHSA-[a-z0-9-]+$/.test(metadata.ghsa || '');
+  return base === 'dev' && ['version-update:semver-patch', 'version-update:semver-minor'].includes(metadata.update);
+}
+
+module.exports = {enable, eligible};

--- a/.github/scripts/sync-branches.cjs
+++ b/.github/scripts/sync-branches.cjs
@@ -1,55 +1,75 @@
 'use strict';
+const {enable} = require('./auto-merge.cjs');
 
-async function syncOne({github, context, core, legacyContent=false}, source, sha, target) {
+async function syncOne(environment, source, sha, target) {
+  const {github, context, core} = environment;
   const repo = context.repo;
-  const comparison = (await github.rest.repos.compareCommits({...repo, base:target, head:sha})).data;
-  if (['identical','behind'].includes(comparison.status)) return 'contained';
-  if (comparison.status === 'ahead' && !(legacyContent && target === 'content')) {
-    let updated = false;
-    try {
-      await github.rest.git.updateRef({...repo, ref:`heads/${target}`, sha, force:false});
-      updated = true;
-    } catch (error) {
-      if (![403,422].includes(error.status)) throw error;
-      core.info(`Protected ${target}; using a pull request.`);
-    }
-    if (updated) {
-      await github.rest.actions.createWorkflowDispatch({...repo, workflow_id:'ci.yml', ref:target, inputs:{release:false}});
-      return 'fast-forward';
-    }
-  }
-  const branch = `sync/${source}-to-${target}/${sha.slice(0,12)}`;
+  const base = (await github.rest.git.getRef({...repo, ref:`heads/${target}`})).data.object.sha;
+  const comparison = (await github.rest.repos.compareCommits({...repo, base, head:sha})).data;
+  if (['identical', 'behind'].includes(comparison.status)) return 'contained';
+  // A new target head gets a new snapshot; strict branch rules never require
+  // rewriting a snapshot or choosing a conflict resolution automatically.
+  const prefix = `sync/${source}-to-${target}/`;
+  const branch = `${prefix}${sha.slice(0,12)}-${base.slice(0,12)}`;
   try { await github.rest.git.createRef({...repo, ref:`refs/heads/${branch}`, sha}); }
-  catch (error) {
-    if (error.status !== 422) throw error;
-    const existing = (await github.rest.git.getRef({...repo, ref:`heads/${branch}`})).data;
-    if (existing.object.sha !== sha) throw new Error('Synchronization snapshot changed; refusing to overwrite it.');
+  catch (error) { if (error.status !== 422) throw error; }
+  const snapshot = (await github.rest.repos.getCommit({...repo, ref:branch})).data;
+  if (snapshot.sha !== sha && (snapshot.parents?.length !== 2
+      || snapshot.parents[0].sha !== sha || snapshot.parents[1].sha !== base)) {
+    throw new Error('Synchronization snapshot changed; refusing to overwrite it.');
   }
-  const pulls = await github.paginate(github.rest.pulls.list, {...repo, state:'open', base:target, head:`${repo.owner}:${branch}`, per_page:100});
+  if (snapshot.sha === sha && comparison.status === 'diverged') {
+    // GitHub returns 409 for conflicts, leaving both protected branches intact.
+    await github.rest.repos.merge({...repo, base:branch, head:base,
+      commit_message:`chore: Preserve ${target} changes while synchronizing ${source}`});
+  }
+  const pulls = await github.paginate(github.rest.pulls.list,
+    {...repo, state:'open', base:target, head:`${repo.owner}:${branch}`, per_page:100});
   const pr = pulls[0] || (await github.rest.pulls.create({...repo, base:target, head:branch,
     title:`chore: Synchronize ${source} into ${target}`,
-    body:`Preserve the published ${source} history in ${target} without replacing commits. This synchronization uses an immutable source snapshot and must pass CI before merging. Conflicts require a normal merge resolution; no side is selected automatically.`})).data;
-  // GITHUB_TOKEN pushes do not reliably start CI. Run the merge ref explicitly,
-  // attaching the required check to this immutable PR head.
-  const legacy = legacyContent && target === 'content';
-  await github.rest.actions.createWorkflowDispatch({...repo, workflow_id:legacy?'sync-legacy.yml':'ci.yml', ref:legacy?'main':target, inputs:legacy?{pull_request:String(pr.number)}:{release:false, pull_request:String(pr.number)}});
+    body:`Preserve the ${source} and ${target} histories. This snapshot includes the exact target head before verification. Automatic merging requires CI; conflicts require normal manual resolution.`})).data;
+  if (pr.user.login !== 'github-actions[bot]') throw new Error('Unexpected synchronization PR author.');
+  if (pr.auto_merge) return 'queued';
+  const head = pr.head.sha;
+  if (pr.base.sha !== base) throw new Error('Target changed; a fresh synchronization snapshot is required.');
+  // Fence off unrelated green checks on the same commit before enabling merge.
+  const externalId = `f1-pr:${pr.number}:${base}:${head}`;
+  const checks = await github.paginate(github.rest.checks.listForRef,
+    {...repo, ref:head, check_name:'CI required', per_page:100});
+  const existing = checks.find(check => check.external_id === externalId && check.app?.id === 15368);
+  const pending = {...repo, name:'CI required', status:'in_progress',
+    output:{title:'Verifying synchronization',summary:'Checking the exact source and target snapshot before automatic merging.'}};
+  if (existing) await github.rest.checks.update({...pending, check_run_id:existing.id});
+  else await github.rest.checks.create({...pending, head_sha:head, external_id:externalId});
+  await github.rest.actions.createWorkflowDispatch({...repo, workflow_id:'ci.yml', ref:target,
+    inputs:{release:false, pull_request:String(pr.number)}});
+  await enable(environment, pr);
+  // Retire only our older pending snapshots, after the replacement is queued.
+  const obsolete = await github.paginate(github.rest.pulls.list, {...repo, state:'open', base:target, per_page:100});
+  for (const old of obsolete) {
+    if (old.number !== pr.number && old.user.login === 'github-actions[bot]'
+        && old.head.repo?.full_name === pr.head.repo.full_name && old.head.ref.startsWith(prefix)) {
+      await github.rest.pulls.update({...repo, pull_number:old.number, state:'closed'});
+    }
+  }
+  core.info(`Queued synchronization PR #${pr.number}.`);
   return 'pull-request';
 }
 
 async function synchronize(environment) {
   const {github, context} = environment;
   const release = context.payload.release;
-  let source, sha, targets;
+  let source = 'main';
+  let targets = ['beta', 'content', 'dev'];
+  let sha;
   if (release) {
     if (release.draft) return;
     source = release.prerelease ? 'beta' : 'main';
     if (release.target_commitish !== source) throw new Error('Unexpected release target; synchronization stopped.');
     sha = (await github.rest.repos.getCommit({...context.repo, ref:release.tag_name})).data.sha;
-    targets = release.prerelease ? ['dev'] : ['beta','content','dev'];
+    if (release.prerelease) targets = ['dev'];
   } else {
-    source = 'main';
-    sha = context.payload.after;
-    targets = ['content','dev'];
+    sha = (await github.rest.git.getRef({...context.repo, ref:'heads/main'})).data.object.sha;
   }
   const failures = [];
   for (const target of targets) {

--- a/.github/workflows/automation-tests.yml
+++ b/.github/workflows/automation-tests.yml
@@ -20,5 +20,7 @@ jobs:
           curl --fail --location --retry 2 --max-time 60 https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz -o /tmp/actionlint.tar.gz
           echo '8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  /tmp/actionlint.tar.gz' | sha256sum --check
           tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
-      - run: /tmp/actionlint
+      # GitHub added this read-only permission on 2026-09-03; actionlint 1.7.12
+      # predates it. Keep all other permission and workflow validation enabled.
+      - run: /tmp/actionlint -ignore '^unknown permission scope "vulnerability-alerts"\.'
       - run: npm run test:automation

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,36 +1,42 @@
 name: Dependabot auto-merge
 on:
   pull_request_target:
-    branches: [dev]
+    branches: [dev, main]
     types: [opened, reopened, synchronize]
 permissions:
   contents: write
   pull-requests: write
+  vulnerability-alerts: read
 concurrency:
   group: dependabot-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   automerge:
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.base.ref == 'dev'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Verify required checks are enforced before enabling auto-merge
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          script: |
-            const rules = await github.paginate('GET /repos/{owner}/{repo}/rules/branches/{branch}', {...context.repo, branch:'dev'});
-            if (!rules.some(r => r.type === 'pull_request') || !rules.some(r => r.type === 'required_status_checks' && r.parameters.required_status_checks.some(c => c.context === 'CI required'))) {
-              throw new Error('Auto-merge requires the active dev PR rule and CI required check.');
-            }
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
       - uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         id: metadata
         with:
           github-token: ${{ github.token }}
-      - name: Queue patch/minor merge after required checks
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          alert-lookup: ${{ github.event.pull_request.base.ref == 'main' && 'true' || '' }}
+      - name: Queue verified security updates and development patch/minor updates
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_HEAD: ${{ github.event.pull_request.head.sha }}
-        run: gh pr merge --auto --squash --match-head-commit "$PR_HEAD" "$PR_URL"
+          ALERT: ${{ steps.metadata.outputs.alert-state }}
+          GHSA: ${{ steps.metadata.outputs.ghsa-id }}
+          UPDATE: ${{ steps.metadata.outputs.update-type }}
+        with:
+          script: |
+            const automation = require('./.github/scripts/auto-merge.cjs');
+            const pr = context.payload.pull_request;
+            if (automation.eligible(pr.base.ref, {alert:process.env.ALERT, ghsa:process.env.GHSA, update:process.env.UPDATE})) {
+              await automation.enable({github, context}, pr);
+            } else {
+              core.info('This update is outside the automatic merge policy.');
+            }

--- a/.github/workflows/sync-after-release.yml
+++ b/.github/workflows/sync-after-release.yml
@@ -4,11 +4,17 @@ on:
     types: [published]
   push:
     branches: [main]
-    paths: ['docs/**', 'blueprints/**']
+  workflow_run:
+    workflows: ['PR verification']
+    types: [completed]
+  schedule:
+    - cron: '17,47 * * * *'
+  workflow_dispatch:
 permissions:
   contents: write
   pull-requests: write
   actions: write
+  checks: write
 concurrency:
   group: synchronize-published-history
   cancel-in-progress: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,3 +117,9 @@ Development checks run on pushes to `dev` and `content`. When an existing PR ver
 PRs can reuse successful checks from a development push completed within the last two hours only when the complete Git tree is identical. This includes all sources, test profiles, workflows and dependency locks. The source must be a successful push in this repository on `dev` or `content`, and all jobs in each reused profile must have succeeded. CI revalidates the source run and its attempt before passing the gate. The run summary links the evidence. Registry audits and external HACS/hassfest validation always run when applicable. Release verification never reuses results and still tests the final commit before creating a draft. GitHub may continue to display earlier push checks attached to the PR head.
 
 The repository allows Actions to create synchronization PRs. This GitHub setting also technically permits review approval; these workflows never submit approval reviews, and branch rules require zero approvals.
+
+## Security updates and branch synchronization
+
+Dependabot security updates target `main`. Dependency-only PRs from Dependabot may run full CI there; automatic merging additionally requires verified Dependabot commits and a matching open security advisory. Ordinary patch/minor Dependabot updates continue to target `dev`. Both paths use merge commits and require strict, GitHub Actions-bound `CI required` protection.
+
+After changes reach `main`, automation synchronizes its history to `beta`, `content` and `dev`. Each synchronization PR preserves the exact target snapshot and merges automatically only after CI. A changed target produces a new snapshot; conflicts and failed tests remain visible for manual resolution. Synchronization runs on main pushes, after PR verification, and every 30 minutes to recover events suppressed by bot tokens. Published beta releases also synchronize to `dev`. Release publication remains manual.

--- a/ci_tests/auto-merge.test.cjs
+++ b/ci_tests/auto-merge.test.cjs
@@ -1,0 +1,42 @@
+const {test} = require('node:test');
+const assert = require('node:assert/strict');
+const {enable, eligible} = require('../.github/scripts/auto-merge.cjs');
+const rules = [
+  {type:'pull_request'},
+  {type:'required_status_checks', parameters:{strict_required_status_checks_policy:true,
+    required_status_checks:[{context:'CI required', integration_id:15368}]}},
+];
+const pr = {number:1, node_id:'PR_1', state:'open', draft:false, head:{sha:'head'}, base:{ref:'main', sha:'base'}};
+
+test('main requires an open security advisory; ordinary dev updates retain patch/minor policy', () => {
+  assert.equal(eligible('main', {alert:'OPEN', ghsa:'GHSA-5qpg-rh4j-qp35'}), true);
+  for (const alert of ['', 'FIXED', 'DISMISSED']) assert.equal(eligible('main', {alert,ghsa:'GHSA-1234'}),false);
+  assert.equal(eligible('main', {alert:'OPEN',ghsa:''}),false);
+  assert.equal(eligible('dev', {update:'version-update:semver-minor'}),true);
+  assert.equal(eligible('dev', {update:'version-update:semver-major'}),false);
+  assert.equal(eligible('beta', {alert:'OPEN',ghsa:'GHSA-1234'}),false);
+});
+
+test('automatic merging requires strict app-bound checks and an unchanged PR', async () => {
+  const calls=[];
+  const env={context:{repo:{owner:'Nicxe',repo:'f1_sensor'}},github:{
+    paginate:async()=>rules,
+    rest:{pulls:{get:async()=>({data:pr})}},
+    graphql:async(query,variables)=>calls.push({query,variables}),
+  }};
+  await enable(env,pr);
+  assert.equal(calls[0].variables.head,'head');
+  assert.match(calls[0].query,/mergeMethod:MERGE/);
+  for(const changed of [[],rules.slice(1),[rules[0]],
+    [rules[0],{...rules[1],parameters:{...rules[1].parameters,strict_required_status_checks_policy:false}}],
+    [rules[0],{...rules[1],parameters:{...rules[1].parameters,required_status_checks:[{context:'CI required',integration_id:1}]}}]]) {
+    env.github.paginate=async()=>changed;
+    await assert.rejects(enable(env,pr));
+  }
+  env.github.paginate=async()=>rules;
+  for(const changed of [{draft:true},{state:'closed'},{head:{sha:'new'}},{base:{ref:'main',sha:'new'}}]) {
+    env.github.rest.pulls.get=async()=>({data:{...pr,...changed}});
+    await assert.rejects(enable(env,pr));
+  }
+  assert.equal(calls.length,1);
+});

--- a/ci_tests/sync.test.cjs
+++ b/ci_tests/sync.test.cjs
@@ -1,43 +1,65 @@
 const {test} = require('node:test');
 const assert = require('node:assert/strict');
-const {syncOne} = require('../.github/scripts/sync-branches.cjs');
-
-function environment(status, protectedBranch=false) {
+const {syncOne, synchronize} = require('../.github/scripts/sync-branches.cjs');
+const source='a'.repeat(40), base='b'.repeat(40), merged='c'.repeat(40);
+function environment(status='diverged') {
   const writes=[];
-  return {writes, context:{repo:{owner:'Nicxe',repo:'f1_sensor'}}, core:{info(){}}, github:{
-    paginate:async()=>[],
+  const pr={number:42,node_id:'PR_42',state:'open',user:{login:'github-actions[bot]'},head:{sha:merged,repo:{full_name:'Nicxe/f1_sensor'}},base:{ref:'dev',sha:base}};
+  const env={writes,pr,context:{repo:{owner:'Nicxe',repo:'f1_sensor'},payload:{}},core:{info(){}},github:{
+    paginate:async(route)=>typeof route==='string' ? [
+      {type:'pull_request'}, {type:'required_status_checks',parameters:{strict_required_status_checks_policy:true,required_status_checks:[{context:'CI required',integration_id:15368}]}}
+    ] : [],
+    graphql:async(_,data)=>writes.push(['queue',data]),
     rest:{
-      repos:{compareCommits:async()=>({data:{status}})},
-      git:{updateRef:async x=>{writes.push(['update',x]); if(protectedBranch) throw {status:422};}, createRef:async x=>writes.push(['snapshot',x])},
-      pulls:{list(){},create:async x=>{writes.push(['pr',x]);return {data:{number:42}};}},
-      actions:{createWorkflowDispatch:async x=>writes.push(['ci',x])},
+      git:{getRef:async()=>({data:{object:{sha:base}}}),createRef:async data=>writes.push(['snapshot',data])},
+      repos:{compareCommits:async()=>({data:{status}}),getCommit:async()=>({data:{sha:source}}),merge:async data=>writes.push(['merge',data])},
+      pulls:{list(){},create:async data=>{writes.push(['pr',data]);return {data:pr};},get:async()=>({data:pr}),update:async data=>writes.push(['close',data])},
+      checks:{listForRef(){},create:async data=>writes.push(['pending',data])},
+      actions:{createWorkflowDispatch:async data=>writes.push(['ci',data])},
     },
   }};
+  return env;
 }
 
-test('already contained history is untouched', async()=>{
-  for (const status of ['identical','behind']) {
+test('contained history does not start verification or mutate refs', async()=>{
+  for(const status of ['identical','behind']) {
     const env=environment(status);
-    assert.equal(await syncOne(env,'beta','a'.repeat(40),'dev'),'contained');
+    assert.equal(await syncOne(env,'main',source,'dev'),'contained');
     assert.deepEqual(env.writes,[]);
   }
 });
-test('fast-forward explicitly verifies the new head and never forces',async()=>{
-  const env=environment('ahead');
-  assert.equal(await syncOne(env,'beta','a'.repeat(40),'dev'),'fast-forward');
-  assert.equal(env.writes[0][1].force,false);
-  assert.equal(env.writes[1][0],'ci');
+test('target snapshot is merged before CI and automatic merge is queued last', async()=>{
+  const env=environment();
+  assert.equal(await syncOne(env,'main',source,'dev'),'pull-request');
+  assert.deepEqual(env.writes.map(x=>x[0]),['snapshot','merge','pr','pending','ci','queue']);
+  assert.match(env.writes[0][1].ref,new RegExp(`${source.slice(0,12)}-${base.slice(0,12)}$`));
+  assert.equal(env.writes[1][1].head,base);
+  assert.equal(env.writes[3][1].external_id,`f1-pr:42:${base}:${merged}`);
+  assert.equal(env.writes[4][1].inputs.pull_request,'42');
 });
-test('divergence or branch protection preserves both histories in a PR',async()=>{
-  for(const env of [environment('diverged'),environment('ahead',true)]) {
-    assert.equal(await syncOne(env,'main','b'.repeat(40),'beta'),'pull-request');
-    assert.equal(env.writes.find(([kind])=>kind==='snapshot')[1].sha,'b'.repeat(40));
-    assert.equal(env.writes.at(-1)[1].inputs.pull_request,'42');
-    assert.equal(env.writes.some(([,v])=>v.force===true),false);
+test('conflicts, unexpected snapshots and failed dispatch never enable automatic merging',async()=>{
+  for(const failure of ['conflict','snapshot','dispatch']) {
+    const env=environment();
+    if(failure==='conflict') env.github.rest.repos.merge=async()=>{throw {status:409};};
+    if(failure==='snapshot') env.github.rest.repos.getCommit=async()=>({data:{sha:'unrelated',parents:[]}});
+    if(failure==='dispatch') env.github.rest.actions.createWorkflowDispatch=async()=>{throw {status:403};};
+    await assert.rejects(syncOne(env,'main',source,'dev'));
+    assert.ok(!env.writes.some(x=>x[0]==='queue'));
   }
 });
-
-test('real Git divergence keeps later development commits and published ancestry',async()=>{
+test('already queued PR is left running without duplicate dispatch',async()=>{
+  const env=environment();env.pr.auto_merge={};
+  env.github.paginate=async route=>route===env.github.rest.pulls.list?[env.pr]:[];
+  assert.equal(await syncOne(env,'main',source,'dev'),'queued');
+  assert.ok(!env.writes.some(x=>x[0]==='ci'));
+});
+test('reconciliation checks all three branches against latest main',async()=>{
+  const env=environment('identical'),refs=[];
+  env.github.rest.git.getRef=async ({ref})=>{refs.push(ref);return {data:{object:{sha:source}}};};
+  await synchronize(env);
+  assert.deepEqual(refs,['heads/main','heads/beta','heads/content','heads/dev']);
+});
+test('real Git snapshot retains development and published source ancestry',async()=>{
   const {mkdtempSync,writeFileSync,rmSync}=require('node:fs');
   const {tmpdir}=require('node:os');const {join}=require('node:path');
   const {execFileSync}=require('node:child_process');
@@ -45,20 +67,20 @@ test('real Git divergence keeps later development commits and published ancestry
   const git=(...args)=>execFileSync('git',args,{cwd:dir,encoding:'utf8',stdio:['pipe','pipe','pipe']}).trim();
   try {
     git('init','-b','dev');git('config','user.name','CI test');git('config','user.email','ci@example.invalid');
-    writeFileSync(join(dir,'base'),'base');git('add','.');git('commit','-m','base');git('branch','beta');
-    writeFileSync(join(dir,'development'),'later work');git('add','.');git('commit','-m','later development');const dev=git('rev-parse','HEAD');
-    git('checkout','beta');writeFileSync(join(dir,'release'),'release evidence');git('add','.');git('commit','-m','published beta');const published=git('rev-parse','HEAD');
-    const env=environment('diverged');
+    writeFileSync(join(dir,'base'),'base');git('add','.');git('commit','-m','base');git('branch','main');
+    writeFileSync(join(dir,'development'),'later work');git('add','.');git('commit','-m','development');const target=git('rev-parse','HEAD');
+    git('checkout','main');writeFileSync(join(dir,'release'),'published');git('add','.');git('commit','-m','published');const published=git('rev-parse','HEAD');
+    const env=environment();
+    env.github.rest.git.getRef=async()=>({data:{object:{sha:target}}});
     env.github.rest.git.createRef=async({ref,sha})=>git('update-ref',ref,sha);
-    env.github.rest.pulls.create=async({head,base})=>{assert.equal(git('rev-parse',base),dev);assert.equal(git('rev-parse',head),published);return {data:{number:42}};};
-    await syncOne(env,'beta',published,'dev');assert.equal(git('rev-parse','dev'),dev);
-    git('checkout','dev');git('merge','--no-ff',published,'-m','merge released history');
-    git('merge-base','--is-ancestor',dev,'HEAD');git('merge-base','--is-ancestor',published,'HEAD');
+    env.github.rest.repos.getCommit=async({ref})=>({data:{sha:git('rev-parse',ref)}});
+    env.github.rest.repos.merge=async({base,head})=>{git('checkout',base);git('merge','--no-ff',head,'-m','preserve target');};
+    env.github.rest.pulls.create=async({head})=>{
+      git('merge-base','--is-ancestor',target,head);git('merge-base','--is-ancestor',published,head);
+      env.pr.head.sha=git('rev-parse',head);env.pr.base.sha=target;
+      return {data:env.pr};
+    };
+    await syncOne(env,'main',published,'dev');
+    assert.equal(git('rev-parse','dev'),target);
   } finally {rmSync(dir,{recursive:true,force:true});}
-});
-
-test('failure to dispatch verification is not misreported as a protection conflict',async()=>{
-  const env=environment('ahead');env.github.rest.actions.createWorkflowDispatch=async()=>{throw {status:403};};
-  await assert.rejects(syncOne(env,'beta','a'.repeat(40),'dev'));
-  assert.ok(!env.writes.some(([kind])=>kind==='pr'));
 });

--- a/ci_tests/test_ci_policy.py
+++ b/ci_tests/test_ci_policy.py
@@ -25,6 +25,32 @@ def pull(base, head, fork=False):
 
 
 class PolicyTests(unittest.TestCase):
+    def test_dependabot_default_branch_dependency_exception_is_narrow(self):
+        event = pull("main", "dependabot/pip/requirements/pycares-4.9.0")
+        event["pull_request"]["user"]["login"] = "dependabot[bot]"
+        files = ["requirements/ha-minimum.txt"]
+        self.assertEqual(branch_error(event, files), "")
+        self.assertTrue(
+            all(
+                enabled
+                for job, enabled in select_jobs(
+                    files, event, "pull_request", ""
+                ).items()
+                if job != "blueprints"
+            )
+        )
+        for changed in [
+            [],
+            ["scripts/ci_policy.py"],
+            ["custom_components/f1_sensor/sensor.py"],
+        ]:
+            self.assertTrue(branch_error(event, changed))
+        event["pull_request"]["user"]["login"] = "contributor"
+        self.assertTrue(branch_error(event, files))
+        event["pull_request"]["user"]["login"] = "dependabot[bot]"
+        event["pull_request"]["head"]["repo"]["full_name"] = "fork/repo"
+        self.assertTrue(branch_error(event, files))
+
     def test_site_deploy_depends_on_content_even_when_release_tests_run(self):
         self.assertFalse(
             should_deploy(["custom_components/f1_sensor/auth.py"], "push", "main")

--- a/scripts/ci_policy.py
+++ b/scripts/ci_policy.py
@@ -78,6 +78,23 @@ def branch_error(event: dict, files: list[str]) -> str:
     )
     if sync and base in ("dev", "beta", "content"):
         return ""
+    # Dependency PRs may target the default branch for security fixes. The
+    # trusted auto-merge workflow separately verifies signed Dependabot commits
+    # and a matching open security alert before enabling automatic merging.
+    dependency_files = bool(files) and all(
+        p in ("package.json", "package-lock.json")
+        or (p.startswith("requirements/") and p.endswith(".txt"))
+        or (p.startswith(".github/workflows/") and p.endswith((".yml", ".yaml")))
+        for p in files
+    )
+    if (
+        same_repo
+        and base == "main"
+        and head.startswith("dependabot/")
+        and pr["user"]["login"] == "dependabot[bot]"
+        and dependency_files
+    ):
+        return ""
     if base == "dev":
         return (
             "Use content for standalone docs/blueprints." if content_only(files) else ""


### PR DESCRIPTION
Dependabot security updates currently target main but fail branch routing, and published-history synchronization leaves PRs waiting for manual merges.

Allow dependency-only Dependabot PRs to run full CI on main. Enable automatic merging only for verified Dependabot commits associated with an open advisory; retain patch/minor automation on dev. Require strict GitHub Actions-bound CI and merge commits.

Synchronize main to beta, content and dev using immutable source/target snapshots. Queue verification and merge, preserve divergent history, stop on conflicts, and recover missed bot events every 30 minutes. Published beta releases still synchronize to dev. Release publication remains manual.

Validation: 38 Python and 30 Node automation tests pass, including real Git history preservation, cancellation, snapshot tampering and branch-protection checks. Ruff and actionlint pass; actionlint has a narrow exception for GitHub’s newly added vulnerability-alerts permission.