### PR TITLE
chore: Isolate automatic branch verification

### DIFF
--- a/.github/scripts/sync-branches.cjs
+++ b/.github/scripts/sync-branches.cjs
@@ -22,6 +22,13 @@ async function syncOne(environment, source, sha, target) {
     // GitHub returns 409 for conflicts, leaving both protected branches intact.
     await github.rest.repos.merge({...repo, base:branch, head:base,
       commit_message:`chore: Preserve ${target} changes while synchronizing ${source}`});
+  } else if (snapshot.sha === sha) {
+    // Even when the source already contains the target, give each PR its own
+    // head. GitHub associates required checks with commits, not PR numbers.
+    const commit = (await github.rest.git.createCommit({...repo,
+      message:`chore: Verify ${source} synchronization into ${target}`,
+      tree:snapshot.commit.tree.sha, parents:[sha, base]})).data;
+    await github.rest.git.updateRef({...repo, ref:`heads/${branch}`, sha:commit.sha, force:false});
   }
   const pulls = await github.paginate(github.rest.pulls.list,
     {...repo, state:'open', base:target, head:`${repo.owner}:${branch}`, per_page:100});

--- a/ci_tests/sync.test.cjs
+++ b/ci_tests/sync.test.cjs
@@ -11,8 +11,9 @@ function environment(status='diverged') {
     ] : [],
     graphql:async(_,data)=>writes.push(['queue',data]),
     rest:{
-      git:{getRef:async()=>({data:{object:{sha:base}}}),createRef:async data=>writes.push(['snapshot',data])},
-      repos:{compareCommits:async()=>({data:{status}}),getCommit:async()=>({data:{sha:source}}),merge:async data=>writes.push(['merge',data])},
+      git:{getRef:async()=>({data:{object:{sha:base}}}),createRef:async data=>writes.push(['snapshot',data]),
+        createCommit:async data=>{writes.push(['commit',data]);return {data:{sha:merged}};},updateRef:async data=>writes.push(['update',data])},
+      repos:{compareCommits:async()=>({data:{status}}),getCommit:async()=>({data:{sha:source,commit:{tree:{sha:'source-tree'}}}}),merge:async data=>writes.push(['merge',data])},
       pulls:{list(){},create:async data=>{writes.push(['pr',data]);return {data:pr};},get:async()=>({data:pr}),update:async data=>writes.push(['close',data])},
       checks:{listForRef(){},create:async data=>writes.push(['pending',data])},
       actions:{createWorkflowDispatch:async data=>writes.push(['ci',data])},
@@ -36,6 +37,22 @@ test('target snapshot is merged before CI and automatic merge is queued last', a
   assert.equal(env.writes[1][1].head,base);
   assert.equal(env.writes[3][1].external_id,`f1-pr:42:${base}:${merged}`);
   assert.equal(env.writes[4][1].inputs.pull_request,'42');
+});
+test('fast-forwardable targets receive separate commits so their required checks cannot collide',async()=>{
+  const messages=[];
+  for(const target of ['dev','beta','content']) {
+    const env=environment('ahead');env.pr.base.ref=target;
+    await syncOne(env,'main',source,target);
+    const commit=env.writes.find(x=>x[0]==='commit')[1];
+    messages.push(commit.message);
+    assert.equal(commit.tree,'source-tree');
+    assert.deepEqual(commit.parents,[source,base]);
+    const update=env.writes.find(x=>x[0]==='update')[1];
+    assert.equal(update.force,false);
+    assert.notEqual(update.sha,source);
+    assert.ok(env.writes.findIndex(x=>x[0]==='update') < env.writes.findIndex(x=>x[0]==='ci'));
+  }
+  assert.equal(new Set(messages).size,3);
 });
 test('conflicts, unexpected snapshots and failed dispatch never enable automatic merging',async()=>{
   for(const failure of ['conflict','snapshot','dispatch']) {


### PR DESCRIPTION
Give every synchronization PR a unique commit even when main already contains the target history. GitHub attaches required checks to commits; sharing a head allowed one branch verification to satisfy another while its report was still running.

The new commits preserve the exact source tree and both histories. Tests cover all three targets and ensure no forced ref update. All 38 Python and 33 Node automation tests pass locally.