### PR TITLE
chore: Restore reliable dependency updates and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,25 @@ registries:
     token: ${{ secrets.DEPENDABOT_GH_PACKAGES_TOKEN }}
 
 updates:
+  # Security updates use the default branch. Group them so independent fixes
+  # do not block one another behind the repository-wide dependency audit.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    registries:
+      - github-packages
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: "dev"

--- a/.github/scripts/auto-merge.cjs
+++ b/.github/scripts/auto-merge.cjs
@@ -71,6 +71,69 @@ function eligible(base, metadata) {
   return base === 'dev' && ['version-update:semver-patch', 'version-update:semver-minor'].includes(metadata.update);
 }
 
+// Only stable numeric versions in the advisory's patched major are eligible.
+// Ambiguous versions and cross-major security upgrades need manual review.
+function compareVersion(value, fixed) {
+  const parse = version => /^\d+\.\d+\.\d+$/.test(version || '') ? version.split('.').map(Number) : null;
+  const a = parse(value), b = parse(fixed);
+  if (!a || !b || a[0] !== b[0]) return null;
+  for (let i=0; i<3; i++) if (a[i] !== b[i]) return Math.sign(a[i]-b[i]);
+  return 0;
+}
+
+async function securityAdvisories({github, context}, pr, dependencies) {
+  // fetch-metadata reads only the first 100 historical alerts and assumes
+  // vulnerableRequirements starts with '= '. Neither holds for this repo.
+  const alerts = await github.paginate('GET /repos/{owner}/{repo}/dependabot/alerts',
+    {...context.repo, state:'open', per_page:100});
+  const files = await github.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/files',
+    {...context.repo, pull_number:pr.number, per_page:100});
+  const changed = new Set(files.map(file => file.filename));
+  const contents = new Map();
+  async function read(path, ref) {
+    const key = `${ref}:${path}`;
+    if (!contents.has(key)) {
+      const {data} = await github.rest.repos.getContent({...context.repo, path, ref});
+      if (data.encoding !== 'base64' || typeof data.content !== 'string') throw new Error('Cannot verify dependency manifest.');
+      contents.set(key, Buffer.from(data.content, 'base64').toString('utf8'));
+    }
+    return contents.get(key);
+  }
+  const matches = new Set();
+  for (const alert of alerts) {
+    const {package:pkg, manifest_path:path} = alert.dependency;
+    const fixed = alert.security_vulnerability.first_patched_version?.identifier;
+    if (alert.state !== 'open' || !fixed || !changed.has(path)) continue;
+    const metadata = dependencies.find(dependency => {
+      const directory = (dependency.directory || '/').replace(/^\/+|\/+$/g, '');
+      const manifestDirectory = path.includes('/') ? path.slice(0,path.lastIndexOf('/')) : '';
+      const ecosystem = {npm_and_yarn:'npm',pip:'pip'}[dependency.packageEcosystem];
+      return dependency.dependencyName === pkg.name && ecosystem === pkg.ecosystem && directory === manifestDirectory;
+    });
+    if (!metadata) continue;
+    let before, after;
+    if (pkg.ecosystem === 'npm' && path.endsWith('package-lock.json')) {
+      const versions = content => Object.entries(JSON.parse(content).packages || {})
+        .filter(([location]) => location === `node_modules/${pkg.name}` || location.endsWith(`/node_modules/${pkg.name}`))
+        .map(([,entry]) => entry.version);
+      before = versions(await read(path,pr.base.sha));
+      after = versions(await read(path,pr.head.sha));
+    } else if (pkg.ecosystem === 'pip' && path.endsWith('.txt')) {
+      const versions = content => content.split(/\r?\n/).map(line => line.trim().match(/^([a-zA-Z0-9_.-]+)==(\d+\.\d+\.\d+)\s*(?:#.*)?$/))
+        .filter(match => match && match[1].toLowerCase().replace(/[-_.]+/g,'-') === pkg.name.toLowerCase().replace(/[-_.]+/g,'-'))
+        .map(match => match[2]);
+      before = versions(await read(path,pr.base.sha));
+      after = versions(await read(path,pr.head.sha));
+    } else continue;
+    if (before.some(version => compareVersion(version,fixed) === -1) && after.length &&
+        after.every(version => [0,1].includes(compareVersion(version,fixed))) &&
+        /^GHSA-[a-z0-9-]+$/.test(alert.security_advisory.ghsa_id)) {
+      matches.add(alert.security_advisory.ghsa_id);
+    }
+  }
+  return [...matches];
+}
+
 async function queueDependabot(environment, verifiedPR) {
   const {github, context} = environment;
   // Reopened dependency events can retain an old base SHA. Refresh the base,
@@ -83,4 +146,4 @@ async function queueDependabot(environment, verifiedPR) {
   await refresh(environment, current);
 }
 
-module.exports = {enable, eligible, verifyDependabot, refresh, queueDependabot};
+module.exports = {enable, eligible, securityAdvisories, verifyDependabot, refresh, queueDependabot};

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,5 +20,6 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - run: npm ci --no-audit --no-fund
+      - name: Use the project npm version
+        run: npm install --global npm@10.9.8 --no-audit --no-fund
       - run: npm run test:audit

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -94,7 +94,7 @@ jobs:
   required:
     name: Verify selected checks
     needs: [plan, lint, backend, frontend, documentation, validation, package, audit, blueprints, automation]
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
   required:
     name: ${{ github.event.inputs.pull_request && 'Dispatched CI result' || github.event_name == 'pull_request' && 'CI required' || 'Manual verification result' }}
     needs: checks
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Direct release retries to the release pipeline

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -25,23 +25,24 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: await require('./.github/scripts/auto-merge.cjs').verifyDependabot({github, context}, context.payload.pull_request);
-      - uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         id: metadata
         with:
           github-token: ${{ github.token }}
-          alert-lookup: ${{ github.event.pull_request.base.ref == 'main' && 'true' || '' }}
       - name: Queue verified security updates and development patch/minor updates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          ALERT: ${{ steps.metadata.outputs.alert-state }}
-          GHSA: ${{ steps.metadata.outputs.ghsa-id }}
+          DEPENDENCIES: ${{ steps.metadata.outputs.updated-dependencies-json }}
           UPDATE: ${{ steps.metadata.outputs.update-type }}
         with:
           script: |
             const automation = require('./.github/scripts/auto-merge.cjs');
             const pr = context.payload.pull_request;
-            if (automation.eligible(pr.base.ref, {alert:process.env.ALERT, ghsa:process.env.GHSA, update:process.env.UPDATE})) {
+            const advisories = pr.base.ref === 'main'
+              ? await automation.securityAdvisories({github, context}, pr, JSON.parse(process.env.DEPENDENCIES)) : [];
+            if (automation.eligible(pr.base.ref, {alert:advisories.length ? 'OPEN' : '', ghsa:advisories[0], update:process.env.UPDATE})) {
               await automation.queueDependabot({github, context}, pr);
+              await core.summary.addRaw(`PR #${pr.number}: automatic merge requested, subject to required CI. Verified advisories: ${advisories.join(', ') || 'development patch/minor update'}.`).write();
             } else {
-              core.info('This update is outside the automatic merge policy.');
+              await core.summary.addRaw(`PR #${pr.number}: automatic merge was not enabled. No eligible security fix or development patch/minor update could be verified; maintainer review is required.`).write();
             }

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,10 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - run: npm ci --no-audit --no-fund
+      - name: Use the project npm version
+        run: npm install --global npm@10.9.8 --no-audit --no-fund
+      - name: Install locked dependencies
+        run: npm ci --no-audit --no-fund
       - run: npx playwright install --with-deps chromium
       - run: npm run test:docs
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
@@ -28,7 +31,7 @@ jobs:
         with:
           path: build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: failure()
+        if: failure() && hashFiles('playwright-report/docs/**', 'test-results/docs/**') != ''
         with:
           name: documentation-evidence
           path: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm ci --no-audit --no-fund
       - run: npx playwright install --with-deps chromium
       - run: npm run test:docs
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         if: inputs.publish && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         with:
           path: build

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -16,12 +16,15 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-      - run: npm ci --no-audit --no-fund
+      - name: Use the project npm version
+        run: npm install --global npm@10.9.8 --no-audit --no-fund
+      - name: Install locked dependencies
+        run: npm ci --no-audit --no-fund
       - run: npm run test:frontend:unit
       - run: npx playwright install --with-deps chromium
       - run: npm run test:frontend
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: failure()
+        if: failure() && hashFiles('playwright-report/**', 'test-results/playwright/**') != ''
         with:
           name: frontend-evidence
           path: |

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,11 +12,11 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.inputs.pull_request && format('refs/pull/{0}/merge', github.event.inputs.pull_request) || github.sha }}
-      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+      - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           version: "0.15.4"
           args: "check custom_components scripts ci_tests ci_smoke"
-      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+      - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           version: "0.15.4"
           args: "format --check custom_components scripts ci_tests ci_smoke"

--- a/ci_tests/auto-merge.test.cjs
+++ b/ci_tests/auto-merge.test.cjs
@@ -81,3 +81,50 @@ test('reopened dependency events refresh the base without trusting a changed dep
   await assert.rejects(queueDependabot(env,pr));
   assert.equal(queued,1);
 });
+
+test('security lookup paginates open alerts and verifies the exact changed lockfile',async()=>{
+  const {securityAdvisories}=require('../.github/scripts/auto-merge.cjs');
+  const alert={state:'open',dependency:{package:{ecosystem:'npm',name:'svgo'},manifest_path:'package-lock.json'},
+    security_advisory:{ghsa_id:'GHSA-w27v-7q3p-w38r'},security_vulnerability:{first_patched_version:{identifier:'3.3.5'}}};
+  let alerts=[alert], version='3.3.5', changed=true;
+  const calls=[];
+  const env={context:{repo:{owner:'Nicxe',repo:'f1_sensor'}},github:{
+    paginate:async(route,params)=>{calls.push({route,params});return route.includes('dependabot')?alerts:changed?[{filename:'package-lock.json'}]:[];},
+    rest:{repos:{getContent:async({ref})=>({data:{encoding:'base64',content:Buffer.from(JSON.stringify({packages:{'node_modules/svgo':{version:ref==='base'?'3.3.4':version}}})).toString('base64')}})}}}};
+  const metadata=[{dependencyName:'svgo',packageEcosystem:'npm_and_yarn',directory:'/'}];
+  assert.deepEqual(await securityAdvisories(env,pr,metadata),['GHSA-w27v-7q3p-w38r']);
+  assert.equal(calls[0].params.state,'open');assert.equal(calls[0].params.per_page,100);
+  version='3.3.4';assert.deepEqual(await securityAdvisories(env,pr,metadata),[]);
+  version='4.0.0';assert.deepEqual(await securityAdvisories(env,pr,metadata),[]);
+  version='3.3.5';changed=false;assert.deepEqual(await securityAdvisories(env,pr,metadata),[]);
+  changed=true;alerts=[{...alert,state:'dismissed'}];assert.deepEqual(await securityAdvisories(env,pr,metadata),[]);
+  alerts=[{...alert,dependency:{...alert.dependency,manifest_path:'other/package-lock.json'}}];
+  assert.deepEqual(await securityAdvisories(env,pr,metadata),[]);
+  alerts=[{...alert,security_vulnerability:{first_patched_version:null}}];
+  assert.deepEqual(await securityAdvisories(env,pr,metadata),[]);
+});
+
+test('grouped security updates use lockfile versions and API failures stop automation',async()=>{
+  const {securityAdvisories}=require('../.github/scripts/auto-merge.cjs');
+  const alert={state:'open',dependency:{package:{ecosystem:'npm',name:'colord'},manifest_path:'package-lock.json'},
+    security_advisory:{ghsa_id:'GHSA-2wm5-q62r-hmrv'},security_vulnerability:{first_patched_version:{identifier:'2.9.4'}}};
+  const env={context:{repo:{}},github:{paginate:async(route)=>route.includes('dependabot')?[alert]:[{filename:'package-lock.json'}],
+    rest:{repos:{getContent:async({ref})=>({data:{encoding:'base64',content:Buffer.from(JSON.stringify({packages:{'node_modules/colord':{version:ref==='base'?'2.9.3':'2.10.0'}}})).toString('base64')}})}}}};
+  assert.deepEqual(await securityAdvisories(env,pr,[{dependencyName:'svgo',directory:'/',packageEcosystem:'npm_and_yarn'},
+    {dependencyName:'colord',directory:'/',packageEcosystem:'npm_and_yarn',prevVersion:'',newVersion:''}]),['GHSA-2wm5-q62r-hmrv']);
+  env.github.paginate=async()=>{throw new Error('API unavailable');};
+  await assert.rejects(securityAdvisories(env,pr,[]),/API unavailable/);
+});
+
+test('pinned Python security fixes are checked against both commit snapshots',async()=>{
+  const {securityAdvisories}=require('../.github/scripts/auto-merge.cjs');
+  const alert={state:'open',dependency:{package:{ecosystem:'pip',name:'pycares'},manifest_path:'requirements/ha-minimum.txt'},
+    security_advisory:{ghsa_id:'GHSA-5qpg-rh4j-qp35'},security_vulnerability:{first_patched_version:{identifier:'4.9.0'}}};
+  let after='pycares==4.9.0\n';
+  const env={context:{repo:{}},github:{paginate:async(route)=>route.includes('dependabot')?[alert]:[{filename:'requirements/ha-minimum.txt'}],
+    rest:{repos:{getContent:async({ref})=>({data:{encoding:'base64',content:Buffer.from(ref==='base'?'pycares==4.8.0\n':after).toString('base64')}})}}}};
+  const metadata=[{dependencyName:'pycares',directory:'/requirements',packageEcosystem:'pip'}];
+  assert.deepEqual(await securityAdvisories(env,pr,metadata),['GHSA-5qpg-rh4j-qp35']);
+  after='pycares==4.8.0\n';assert.deepEqual(await securityAdvisories(env,pr,metadata),[]);
+  after='pycares>=4.9.0\n';assert.deepEqual(await securityAdvisories(env,pr,metadata),[]);
+});

--- a/ci_tests/test_ci_policy.py
+++ b/ci_tests/test_ci_policy.py
@@ -25,6 +25,29 @@ def pull(base, head, fork=False):
 
 
 class PolicyTests(unittest.TestCase):
+    def test_owner_maintenance_can_repair_main_without_promoting_runtime_code(self):
+        event = pull("main", "maintenance/dependency-ci-recovery")
+        event["pull_request"]["user"]["login"] = "Nicxe"
+        files = [
+            "package.json",
+            ".github/scripts/auto-merge.cjs",
+            "scripts/ci_policy.py",
+            "ci_tests/test_ci_policy.py",
+        ]
+        self.assertEqual(branch_error(event, files), "")
+        for changed in [
+            [],
+            files + ["custom_components/f1_sensor/sensor.py"],
+            ["docs/help.md"],
+            ["scripts/other.py"],
+        ]:
+            self.assertTrue(branch_error(event, changed))
+        event["pull_request"]["user"]["login"] = "contributor"
+        self.assertTrue(branch_error(event, files))
+        event["pull_request"]["user"]["login"] = "Nicxe"
+        event["pull_request"]["head"]["repo"]["full_name"] = "fork/repo"
+        self.assertTrue(branch_error(event, files))
+
     def test_dependabot_default_branch_dependency_exception_is_narrow(self):
         event = pull("main", "dependabot/pip/requirements/pycares-4.9.0")
         event["pull_request"]["user"]["login"] = "dependabot[bot]"

--- a/ci_tests/verification.test.cjs
+++ b/ci_tests/verification.test.cjs
@@ -41,3 +41,17 @@ test('cancelled verification cannot publish failure while completed failures sti
     assert.equal(Boolean(vm.runInNewContext(expression, context)), false);
   }
 });
+
+test('superseded native runs skip both gates, while real failures still reach the gates', () => {
+  for (const filename of ['ci.yml','ci-checks.yml']) {
+    const text=fs.readFileSync(path.join(__dirname,'../.github/workflows',filename),'utf8');
+    const condition=text.split('  required:')[1].match(/^    if: (.+)$/m)[1];
+    const expression=condition.replace(/^\$\{\{\s*|\s*\}\}$/g,'');
+    for (const result of ['success','failure']) {
+      const context={always:()=>true,cancelled:()=>false,needs:{checks:{result}}};
+      assert.equal(Boolean(vm.runInNewContext(expression,context)),true);
+      context.cancelled=()=>true;
+      assert.equal(Boolean(vm.runInNewContext(expression,context)),false);
+    }
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,9 +88,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9339,9 +9339,9 @@
       "license": "MIT"
     },
     "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.10.0.tgz",
+      "integrity": "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==",
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -13343,9 +13343,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.4",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
-      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
+      "version": "17.13.7",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.7.tgz",
+      "integrity": "sha512-MF80Dm5Y2veNy8QWVx9Bj3ui4mo7+VPSPsR1M+oaHXV0Gx6zGX9a2F+OZG3Blby9tOlzU9Rs5FUimlEhbKtfnQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -13362,9 +13362,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -23748,9 +23748,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
-      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.5.tgz",
+      "integrity": "sha512-8SQMzdrvWaD8deUmrnYB+ASyxBVgWUOilg+A75nE/76WdLpj6LopCwiAVvkzkcqy/9b7t2Mg7faFLjg0ZRcZ3w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "qs": "^6.15.2",
     "uuid": "^11.1.1",
     "@babel/core": "7.29.6",
-    "joi": "17.13.4",
-    "js-yaml": "4.3.1",
+    "joi": "^17.13.6",
+    "js-yaml": "^4.3.2",
     "@semantic-release/github": {
       "undici": "^7.29.0"
     },
@@ -93,6 +93,11 @@
     "webpack-dev-server": {
       "http-proxy-middleware": "3.0.7",
       "ws": "^8.20.1"
-    }
+    },
+    "@actions/http-client": {
+      "undici": "^6.28.1"
+    },
+    "colord": "^2.10.0",
+    "svgo": "^3.3.5"
   }
 }

--- a/scripts/ci_policy.py
+++ b/scripts/ci_policy.py
@@ -78,6 +78,29 @@ def branch_error(event: dict, files: list[str]) -> str:
     )
     if sync and base in ("dev", "beta", "content"):
         return ""
+    # The repository owner can repair dependency/CI infrastructure on main
+    # without promoting unreleased integration changes from dev. Required CI
+    # and PR protection still apply; this does not grant automatic merging.
+    maintenance_files = bool(files) and all(
+        p
+        in (
+            "package.json",
+            "package-lock.json",
+            ".github/dependabot.yml",
+            "quality/npm-audit-allowlist.json",
+            "scripts/ci_policy.py",
+        )
+        or p.startswith((".github/workflows/", ".github/scripts/", "ci_tests/"))
+        for p in files
+    )
+    if (
+        same_repo
+        and base == "main"
+        and head.startswith("maintenance/")
+        and pr["user"]["login"] == pr["base"]["repo"]["full_name"].split("/")[0]
+        and maintenance_files
+    ):
+        return ""
     # Dependency PRs may target the default branch for security fixes. The
     # trusted auto-merge workflow separately verifies signed Dependabot commits
     # and a matching open security alert before enabling automatic merging.


### PR DESCRIPTION
Dependabot security PRs currently fail before frontend and documentation tests start because their regenerated lockfiles omit the nested undici dependency. Security updates are also skipped by auto-merge because metadata lookup only examines the first 100 historical alerts and assumes a version format that GitHub no longer returns.

This repairs the dependency baseline, updates vulnerable documentation dependencies, and groups future npm security updates on main. Security eligibility now paginates open alerts and verifies corrected versions in the exact base/head manifests. Signed-commit verification, strict GitHub Actions-bound CI, and unchanged-head checks remain required. Updated Node 24 metadata/lint actions, the current Pages artifact uploader, and explicit job summaries remove deprecated behavior and clarify when automatic merging is not enabled.

Documentation and frontend use the project npm version; security auditing no longer depends on a successful installation; missing test reports do not generate secondary artifact warnings. Cancelled runs skip their summary gates instead of publishing false failures. Owner-authored maintenance PRs may target main only for dependency/CI files, so this repair does not promote unreleased integration changes from dev.

Validation: reproduced the original npm ci failure; clean npm 10.9.8 install on Node 22.23.2; lockfile regeneration with npm 11 and npm 12 followed by npm 10 verification; audit policy; 51 frontend unit tests; automation regression suite; documentation build and all 15 browser checks; Ruff and actionlint. Read-only checks against PRs 684 and 685 identify their actual open advisories with the new resolver. GitHub verification is required before merging.
